### PR TITLE
Port tlmtest to Go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,11 +2,14 @@ version: "2"
 linters:
   default: all
   disable:
+    - "cyclop"  # One day
+    - "dupl"  # One day
     - "dupword"  # One day
     - "errcheck"  # I appreciate the intent, but I'm not checking errors on fmt.Printf etc.
     - "forbidigo"  # fmt.Print* are fine for now
     - "funlen"  # We have inherited lots of long lines
     - "gochecknoglobals"  # One day there will be no globals but I do not expect it will be today
+    - "gocyclo"  # One day
     - "godot"  # Implicit full stops are ok
     - "godox"  # There will be TODOs
     - "lll"  # We have inherited lots of long lines

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -68,48 +68,12 @@
 #define MAX(x,y) ((x)>(y) ? (x) : (y))
 
 
-#define T_NUM_ANALOG 5				/* Number of analog channels. */
-#define T_NUM_DIGITAL 8				/* Number of digital channels. */
-
-#define T_STR_LEN 32				/* Max len for labels and units. */
-
-
 #define MAGIC1  0x5a1111a5			/* For checking storage allocation problems. */
 #define MAGIC2  0x5a2222a5
 
 #define C_A 0					/* Scaling coefficient positions. */
 #define C_B 1
 #define C_C 2
-
-
-/*
- * Metadata for telemetry data.
- */
-
-struct t_metadata_s {
-	int magic1;
-
-	struct t_metadata_s * pnext;		/* Next in linked list. */
-
-	char station[AX25_MAX_ADDR_LEN];	/* Station name with optional SSID. */
-
-	char project[40];			/* Description for data. */
-						/* "Project Name" or "project title" in the spec. */
-
-	char name[T_NUM_ANALOG+T_NUM_DIGITAL][T_STR_LEN];
-						/* Names for channels.  e.g. Battery, Temperature */
-
-	char unit[T_NUM_ANALOG+T_NUM_DIGITAL][T_STR_LEN];
-						/* Units for channels.  e.g. Volts, Deg.C */
-
-	float coeff[T_NUM_ANALOG][3];		/* a, b, c coefficients for scaling. */
-
-	int coeff_ndp[T_NUM_ANALOG][3];		/* Number of decimal places for above. */
-
-	int sense[T_NUM_DIGITAL];		/* Polarity for digital channels. */
-
-	int magic2;
-};
 
 
 static 	struct t_metadata_s * md_list_head = NULL;
@@ -130,7 +94,7 @@ static void t_data_process (struct t_metadata_s *pm, int seq, float araw[T_NUM_A
  *
  *--------------------------------------------------------------------*/
 
-static struct t_metadata_s * t_get_metadata (char *station)
+struct t_metadata_s * t_get_metadata (char *station)
 {
 	struct t_metadata_s *p;
 	int n;

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -13,3 +13,38 @@ void telemetry_unit_label_message (char *station, char *msg);
 void telemetry_coefficents_message (char *station, char *msg, int quiet);
 
 void telemetry_bit_sense_message (char *station, char *msg, int quiet);
+
+
+/*
+ * Metadata for telemetry data.
+ */
+
+#define T_NUM_ANALOG 5				/* Number of analog channels. */
+#define T_NUM_DIGITAL 8				/* Number of digital channels. */
+
+#define T_STR_LEN 32				/* Max len for labels and units. */
+
+struct t_metadata_s {
+	int magic1;
+
+	struct t_metadata_s * pnext;		/* Next in linked list. */
+
+	char station[AX25_MAX_ADDR_LEN];	/* Station name with optional SSID. */
+
+	char project[40];			/* Description for data. */
+						/* "Project Name" or "project title" in the spec. */
+
+	char name[T_NUM_ANALOG+T_NUM_DIGITAL][T_STR_LEN];
+						/* Names for channels.  e.g. Battery, Temperature */
+
+	char unit[T_NUM_ANALOG+T_NUM_DIGITAL][T_STR_LEN];
+						/* Units for channels.  e.g. Volts, Deg.C */
+
+	float coeff[T_NUM_ANALOG][3];		/* a, b, c coefficients for scaling. */
+
+	int coeff_ndp[T_NUM_ANALOG][3];		/* Number of decimal places for above. */
+
+	int sense[T_NUM_DIGITAL];		/* Polarity for digital channels. */
+
+	int magic2;
+};

--- a/src/telemetry_test.go
+++ b/src/telemetry_test.go
@@ -1,0 +1,7 @@
+package direwolf
+
+import "testing"
+
+func Test_telemetry(t *testing.T) {
+	telemetry_test_main(t)
+}

--- a/src/telemetry_test_shim.go
+++ b/src/telemetry_test_shim.go
@@ -1,0 +1,316 @@
+package direwolf
+
+// #include "direwolf.h"
+// #include <stdio.h>
+// #include <unistd.h>
+// #include <stdlib.h>
+// #include <assert.h>
+// #include <string.h>
+// #include <math.h>
+// #include <ctype.h>
+// #include "ax25_pad.h"			// for packet_t, AX25_MAX_ADDR_LEN
+// #include "decode_aprs.h"		// for decode_aprs_t, G_UNKNOWN
+// #include "textcolor.h"
+// #include "telemetry.h"
+// struct t_metadata_s * t_get_metadata (char *station);
+import "C"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func telemetry_data_original(station string, info string, quiet C.int, output *C.char, outputsize C.size_t, comment *C.char, commentsize C.size_t) {
+	C.telemetry_data_original(C.CString(station), C.CString(info), quiet, output, outputsize, comment, commentsize)
+}
+
+func telemetry_data_base91(station string, cdata string, output *C.char, outputsize C.size_t) {
+	C.telemetry_data_base91(C.CString(station), C.CString(cdata), output, outputsize)
+}
+
+func telemetry_name_message(station string, msg string) {
+	C.telemetry_name_message(C.CString(station), C.CString(msg))
+}
+
+func telemetry_unit_label_message(station string, msg string) {
+	C.telemetry_unit_label_message(C.CString(station), C.CString(msg))
+}
+
+func telemetry_coefficents_message(station string, msg string, quiet C.int) {
+	C.telemetry_coefficents_message(C.CString(station), C.CString(msg), quiet)
+}
+
+func telemetry_bit_sense_message(station string, msg string, quiet C.int) {
+	C.telemetry_bit_sense_message(C.CString(station), C.CString(msg), quiet)
+}
+
+func telemetry_test_main(t *testing.T) {
+	t.Helper()
+
+	var resultAlloc [120]C.char
+	var result = &resultAlloc[0]
+	var commentAlloc [40]C.char
+	var comment = &commentAlloc[0]
+	var sizeofResult = C.size_t(len(resultAlloc))
+	var sizeofComment = C.size_t(len(commentAlloc))
+
+	dw_printf("Unit test for telemetry decoding functions...\n")
+
+	dw_printf("part 1\n")
+
+	// From protocol spec.
+
+	telemetry_data_original("WB2OSZ", "T#005,199,000,255,073,123,01101001", 0, result, sizeofResult, comment, sizeofComment)
+
+	assert.Equal(t, "Seq=5, A1=199, A2=0, A3=255, A4=73, A5=123, D1=0, D2=1, D3=1, D4=0, D5=1, D6=0, D7=0, D8=1", C.GoString(result), "test 101")
+	assert.Empty(t, C.GoString(comment), "test 101")
+
+	// Try adding a comment.
+
+	telemetry_data_original("WB2OSZ", "T#005,199,000,255,073,123,01101001Comment,with,commas", 0, result, sizeofResult, comment, sizeofComment)
+
+	assert.Equal(t, "Seq=5, A1=199, A2=0, A3=255, A4=73, A5=123, D1=0, D2=1, D3=1, D4=0, D5=1, D6=0, D7=0, D8=1", C.GoString(result), "test 102")
+	assert.Equal(t, "Comment,with,commas", C.GoString(comment), "test 102")
+
+	// Error handling - Try shortening or omitting parts.
+
+	telemetry_data_original("WB2OSZ", "T005,199,000,255,073,123,0110", 0, result, sizeofResult, comment, sizeofComment)
+
+	assert.Empty(t, C.GoString(result), "test 103")
+	assert.Empty(t, C.GoString(comment), "test 103")
+
+	telemetry_data_original("WB2OSZ", "T#005,199,000,255,073,123,0110", 0, result, sizeofResult, comment, sizeofComment)
+
+	assert.Equal(t, "Seq=5, A1=199, A2=0, A3=255, A4=73, A5=123, D1=0, D2=1, D3=1, D4=0", C.GoString(result), "test 104")
+	assert.Empty(t, C.GoString(comment), "test 104")
+
+	telemetry_data_original("WB2OSZ", "T#005,199,000,255,073,123", 0, result, sizeofResult, comment, sizeofComment)
+
+	assert.Equal(t, "Seq=5, A1=199, A2=0, A3=255, A4=73, A5=123", C.GoString(result), "test 105")
+	assert.Empty(t, C.GoString(comment), "test 105")
+
+	telemetry_data_original("WB2OSZ", "T#005,199,000,255,,123,01101001", 0, result, sizeofResult, comment, sizeofComment)
+
+	assert.Equal(t, "Seq=5, A1=199, A2=0, A3=255, A5=123, D1=0, D2=1, D3=1, D4=0, D5=1, D6=0, D7=0, D8=1", C.GoString(result), "test 106")
+	assert.Empty(t, C.GoString(comment), "test 106")
+
+	telemetry_data_original("WB2OSZ", "T#005,199,000,255,073,123,01101009", 0, result, sizeofResult, comment, sizeofComment)
+
+	assert.Equal(t, "Seq=5, A1=199, A2=0, A3=255, A4=73, A5=123, D1=0, D2=1, D3=1, D4=0, D5=1, D6=0, D7=0", C.GoString(result), "test 107")
+	assert.Empty(t, C.GoString(comment), "test 107")
+
+	// Local observation.
+
+	telemetry_data_original("WB2OSZ", "T#491,4.9,0.3,25.0,0.0,1.0,00000000", 0, result, sizeofResult, comment, sizeofComment)
+
+	assert.Equal(t, "Seq=491, A1=4.9, A2=0.3, A3=25.0, A4=0.0, A5=1.0, D1=0, D2=0, D3=0, D4=0, D5=0, D6=0, D7=0, D8=0", C.GoString(result), "test 108")
+	assert.Empty(t, C.GoString(comment), "test 108")
+
+	dw_printf("part 2\n")
+
+	// From protocol spec.
+
+	telemetry_data_base91("WB2OSZ", "ss11", result, sizeofResult)
+
+	assert.Equal(t, "Seq=7544, A1=1472", C.GoString(result), "test 201")
+
+	telemetry_data_base91("WB2OSZ", "ss11223344{{!\"", result, sizeofResult)
+
+	assert.Equal(t, "Seq=7544, A1=1472, A2=1564, A3=1656, A4=1748, A5=8280, D1=1, D2=0, D3=0, D4=0, D5=0, D6=0, D7=0, D8=0", C.GoString(result), "test 202")
+
+	// Error cases.  Should not happen in practice because function
+	// should be called only with valid data that matches the pattern.
+
+	telemetry_data_base91("WB2OSZ", "ss11223344{{!\"x", result, sizeofResult)
+
+	assert.Empty(t, C.GoString(result), "test 203")
+
+	telemetry_data_base91("WB2OSZ", "ss1", result, sizeofResult)
+
+	assert.Empty(t, C.GoString(result), "test 204")
+
+	telemetry_data_base91("WB2OSZ", "ss11223344{{!", result, sizeofResult)
+
+	assert.Empty(t, C.GoString(result), "test 205")
+
+	telemetry_data_base91("WB2OSZ", "s |1", result, sizeofResult)
+
+	assert.Equal(t, "Seq=?", C.GoString(result), "test 206")
+
+	dw_printf("part 3\n")
+
+	telemetry_name_message("N0QBF-11", "Battery,Btemp,ATemp,Pres,Alt,Camra,Chut,Sun,10m,ATV")
+
+	var pm = C.t_get_metadata(C.CString("N0QBF-11"))
+
+	assert.Equal(t, "Battery", C.GoString(&pm.name[0][0]), "test 301")
+	assert.Equal(t, "Btemp", C.GoString(&pm.name[1][0]), "test 301")
+	assert.Equal(t, "ATemp", C.GoString(&pm.name[2][0]), "test 301")
+	assert.Equal(t, "Pres", C.GoString(&pm.name[3][0]), "test 301")
+	assert.Equal(t, "Alt", C.GoString(&pm.name[4][0]), "test 301")
+	assert.Equal(t, "Camra", C.GoString(&pm.name[5][0]), "test 301")
+	assert.Equal(t, "Chut", C.GoString(&pm.name[6][0]), "test 301")
+	assert.Equal(t, "Sun", C.GoString(&pm.name[7][0]), "test 301")
+	assert.Equal(t, "10m", C.GoString(&pm.name[8][0]), "test 301")
+	assert.Equal(t, "ATV", C.GoString(&pm.name[9][0]), "test 301")
+	assert.Equal(t, "D6", C.GoString(&pm.name[10][0]), "test 301")
+	assert.Equal(t, "D7", C.GoString(&pm.name[11][0]), "test 301")
+	assert.Equal(t, "D8", C.GoString(&pm.name[12][0]), "test 301")
+
+	telemetry_unit_label_message("N0QBF-11", "v/100,deg.F,deg.F,Mbar,Kft,Click,OPEN,on,on,hi")
+
+	pm = C.t_get_metadata(C.CString("N0QBF-11"))
+
+	assert.Equal(t, "v/100", C.GoString(&pm.unit[0][0]), "test 302")
+	assert.Equal(t, "deg.F", C.GoString(&pm.unit[1][0]), "test 302")
+	assert.Equal(t, "deg.F", C.GoString(&pm.unit[2][0]), "test 302")
+	assert.Equal(t, "Mbar", C.GoString(&pm.unit[3][0]), "test 302")
+	assert.Equal(t, "Kft", C.GoString(&pm.unit[4][0]), "test 302")
+	assert.Equal(t, "Click", C.GoString(&pm.unit[5][0]), "test 302")
+	assert.Equal(t, "OPEN", C.GoString(&pm.unit[6][0]), "test 302")
+	assert.Equal(t, "on", C.GoString(&pm.unit[7][0]), "test 302")
+	assert.Equal(t, "on", C.GoString(&pm.unit[8][0]), "test 302")
+	assert.Equal(t, "hi", C.GoString(&pm.unit[9][0]), "test 302")
+	assert.Empty(t, C.GoString(&pm.unit[10][0]), "test 302")
+	assert.Empty(t, C.GoString(&pm.unit[11][0]), "test 302")
+	assert.Empty(t, C.GoString(&pm.unit[12][0]), "test 302")
+
+	telemetry_coefficents_message("N0QBF-11", "0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,2,3", 0)
+
+	pm = C.t_get_metadata(C.CString("N0QBF-11"))
+
+	if pm.coeff[0][0] != 0 || pm.coeff[0][1] < 5.1999 || pm.coeff[0][1] > 5.2001 || pm.coeff[0][2] != 0 ||
+		pm.coeff[1][0] != 0 || pm.coeff[1][1] < .52999 || pm.coeff[1][1] > .53001 || pm.coeff[1][2] != -32 ||
+		pm.coeff[2][0] != 3 || pm.coeff[2][1] < 4.3899 || pm.coeff[2][1] > 4.3901 || pm.coeff[2][2] != 49 ||
+		pm.coeff[3][0] != -32 || pm.coeff[3][1] != 3 || pm.coeff[3][2] != 18 ||
+		pm.coeff[4][0] != 1 || pm.coeff[4][1] != 2 || pm.coeff[4][2] != 3 {
+		assert.Fail(t, "Wrong result, test 303c\n")
+	}
+
+	if pm.coeff_ndp[0][0] != 0 || pm.coeff_ndp[0][1] != 1 || pm.coeff_ndp[0][2] != 0 ||
+		pm.coeff_ndp[1][0] != 0 || pm.coeff_ndp[1][1] != 2 || pm.coeff_ndp[1][2] != 0 ||
+		pm.coeff_ndp[2][0] != 0 || pm.coeff_ndp[2][1] != 2 || pm.coeff_ndp[2][2] != 0 ||
+		pm.coeff_ndp[3][0] != 0 || pm.coeff_ndp[3][1] != 0 || pm.coeff_ndp[3][2] != 0 ||
+		pm.coeff_ndp[4][0] != 0 || pm.coeff_ndp[4][1] != 0 || pm.coeff_ndp[4][2] != 0 {
+		assert.Fail(t, "Wrong result, test 303n\n")
+	}
+
+	// Error if less than 15 or empty field.
+	// Notice that we keep the previous value in this case.
+
+	telemetry_coefficents_message("N0QBF-11", "0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,2", 0)
+
+	pm = C.t_get_metadata(C.CString("N0QBF-11"))
+
+	if pm.coeff[0][0] != 0 || pm.coeff[0][1] < 5.1999 || pm.coeff[0][1] > 5.2001 || pm.coeff[0][2] != 0 ||
+		pm.coeff[1][0] != 0 || pm.coeff[1][1] < .52999 || pm.coeff[1][1] > .53001 || pm.coeff[1][2] != -32 ||
+		pm.coeff[2][0] != 3 || pm.coeff[2][1] < 4.3899 || pm.coeff[2][1] > 4.3901 || pm.coeff[2][2] != 49 ||
+		pm.coeff[3][0] != -32 || pm.coeff[3][1] != 3 || pm.coeff[3][2] != 18 ||
+		pm.coeff[4][0] != 1 || pm.coeff[4][1] != 2 || pm.coeff[4][2] != 3 {
+		assert.Fail(t, "Wrong result, test 304c\n")
+	}
+
+	if pm.coeff_ndp[0][0] != 0 || pm.coeff_ndp[0][1] != 1 || pm.coeff_ndp[0][2] != 0 ||
+		pm.coeff_ndp[1][0] != 0 || pm.coeff_ndp[1][1] != 2 || pm.coeff_ndp[1][2] != 0 ||
+		pm.coeff_ndp[2][0] != 0 || pm.coeff_ndp[2][1] != 2 || pm.coeff_ndp[2][2] != 0 ||
+		pm.coeff_ndp[3][0] != 0 || pm.coeff_ndp[3][1] != 0 || pm.coeff_ndp[3][2] != 0 ||
+		pm.coeff_ndp[4][0] != 0 || pm.coeff_ndp[4][1] != 0 || pm.coeff_ndp[4][2] != 0 {
+		assert.Fail(t, "Wrong result, test 304n\n")
+	}
+
+	telemetry_coefficents_message("N0QBF-11", "0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,,3", 0)
+
+	pm = C.t_get_metadata(C.CString("N0QBF-11"))
+
+	if pm.coeff[0][0] != 0 || pm.coeff[0][1] < 5.1999 || pm.coeff[0][1] > 5.2001 || pm.coeff[0][2] != 0 ||
+		pm.coeff[1][0] != 0 || pm.coeff[1][1] < .52999 || pm.coeff[1][1] > .53001 || pm.coeff[1][2] != -32 ||
+		pm.coeff[2][0] != 3 || pm.coeff[2][1] < 4.3899 || pm.coeff[2][1] > 4.3901 || pm.coeff[2][2] != 49 ||
+		pm.coeff[3][0] != -32 || pm.coeff[3][1] != 3 || pm.coeff[3][2] != 18 ||
+		pm.coeff[4][0] != 1 || pm.coeff[4][1] != 2 || pm.coeff[4][2] != 3 {
+		assert.Fail(t, "Wrong result, test 305c\n")
+	}
+
+	if pm.coeff_ndp[0][0] != 0 || pm.coeff_ndp[0][1] != 1 || pm.coeff_ndp[0][2] != 0 ||
+		pm.coeff_ndp[1][0] != 0 || pm.coeff_ndp[1][1] != 2 || pm.coeff_ndp[1][2] != 0 ||
+		pm.coeff_ndp[2][0] != 0 || pm.coeff_ndp[2][1] != 2 || pm.coeff_ndp[2][2] != 0 ||
+		pm.coeff_ndp[3][0] != 0 || pm.coeff_ndp[3][1] != 0 || pm.coeff_ndp[3][2] != 0 ||
+		pm.coeff_ndp[4][0] != 0 || pm.coeff_ndp[4][1] != 0 || pm.coeff_ndp[4][2] != 0 {
+		assert.Fail(t, "Wrong result, test 305n\n")
+	}
+
+	telemetry_bit_sense_message("N0QBF-11", "10110000,N0QBF's Big Balloon", 0)
+
+	pm = C.t_get_metadata(C.CString("N0QBF-11"))
+	if pm.sense[0] != 1 || pm.sense[1] != 0 || pm.sense[2] != 1 || pm.sense[3] != 1 ||
+		pm.sense[4] != 0 || pm.sense[5] != 0 || pm.sense[6] != 0 || pm.sense[7] != 0 {
+		assert.Fail(t, "Wrong result, test 306\n")
+	}
+	assert.Equal(t, "N0QBF's Big Balloon", C.GoString(&pm.project[0]), "test 306")
+
+	// Too few and invalid digits.
+	telemetry_bit_sense_message("N0QBF-11", "1011000", 0)
+
+	pm = C.t_get_metadata(C.CString("N0QBF-11"))
+	if pm.sense[0] != 1 || pm.sense[1] != 0 || pm.sense[2] != 1 || pm.sense[3] != 1 ||
+		pm.sense[4] != 0 || pm.sense[5] != 0 || pm.sense[6] != 0 || pm.sense[7] != 0 {
+		assert.Fail(t, "Wrong result, test 307\n")
+	}
+	assert.Empty(t, C.GoString(&pm.project[0]), "test 307")
+
+	telemetry_bit_sense_message("N0QBF-11", "10110008", 0)
+
+	pm = C.t_get_metadata(C.CString("N0QBF-11"))
+	if pm.sense[0] != 1 || pm.sense[1] != 0 || pm.sense[2] != 1 || pm.sense[3] != 1 ||
+		pm.sense[4] != 0 || pm.sense[5] != 0 || pm.sense[6] != 0 || pm.sense[7] != 0 {
+		assert.Fail(t, "Wrong result, test 308\n")
+	}
+	assert.Empty(t, C.GoString(&pm.project[0]), "test 308")
+
+	dw_printf("part 4\n")
+
+	telemetry_coefficents_message("M0XER-3", "0,0.001,0,0,0.001,0,0,0.1,-273.2,0,1,0,0,1,0", 0)
+	telemetry_bit_sense_message("M0XER-3", "11111111,10mW research balloon", 0)
+	telemetry_name_message("M0XER-3", "Vbat,Vsolar,Temp,Sat")
+	telemetry_unit_label_message("M0XER-3", "V,V,C,,m")
+
+	telemetry_data_base91("M0XER-3", "DyR.&^<A!.", result, sizeofResult)
+
+	assert.Equal(t, "10mW research balloon: Seq=3273, Vbat=4.472 V, Vsolar=0.516 V, Temp=-24.3 C, Sat=13", C.GoString(result), "test 401")
+	assert.Empty(t, C.GoString(comment), "test 401")
+
+	telemetry_data_base91("M0XER-3", "cNOv'C?=!-", result, sizeofResult)
+
+	assert.Equal(t, "10mW research balloon: Seq=6051, Vbat=4.271 V, Vsolar=0.580 V, Temp=2.6 C, Sat=12", C.GoString(result), "test 402")
+	assert.Empty(t, C.GoString(comment), "test 402")
+
+	telemetry_data_base91("M0XER-3", "n0RS(:>b!+", result, sizeofResult)
+
+	assert.Equal(t, "10mW research balloon: Seq=7022, Vbat=4.509 V, Vsolar=0.662 V, Temp=-2.8 C, Sat=10", C.GoString(result), "test 403")
+	assert.Empty(t, C.GoString(comment), "test 403")
+
+	telemetry_data_base91("M0XER-3", "x&G=!(8s!,", result, sizeofResult)
+
+	assert.Equal(t, "10mW research balloon: Seq=7922, Vbat=3.486 V, Vsolar=0.007 V, Temp=-55.7 C, Sat=11", C.GoString(result), "test 404")
+	assert.Empty(t, C.GoString(comment), "test 404")
+
+	/* final score. */
+
+	dw_printf("\nTEST WAS SUCCESSFUL.\n")
+}
+
+/*
+	A more complete test can be performed by placing the following
+	in a text file and feeding it into the "decode_aprs" utility.
+
+2E0TOY>APRS::M0XER-3  :BITS.11111111,10mW research balloon
+2E0TOY>APRS::M0XER-3  :PARM.Vbat,Vsolar,Temp,Sat
+2E0TOY>APRS::M0XER-3  :EQNS.0,0.001,0,0,0.001,0,0,0.1,-273.2,0,1,0,0,1,0
+2E0TOY>APRS::M0XER-3  :UNIT.V,V,C,,m
+M0XER-3>APRS63,WIDE2-1:!//Bap'.ZGO JHAE/A=042496|E@Q0%i;5!-|
+M0XER-3>APRS63,WIDE2-1:!/4\;u/)K$O J]YD/A=041216|h`RY(1>q!(|
+M0XER-3>APRS63,WIDE2-1:!/23*f/R$UO Jf'x/A=041600|rxR_'J>+!(|
+
+	The interpretation should look something like this:
+	10mW research balloon: Seq=3307, Vbat=4.383 V, Vsolar=0.436 V, Temp=-34.6 C, Sat=12
+*/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -177,38 +177,6 @@ target_link_libraries(tttexttest
   )
 
 
-# Unit test for telemetry decoding.
-list(APPEND tlmtest_SOURCES
-  ${CUSTOM_SRC_DIR}/telemetry.c
-  ${CUSTOM_SRC_DIR}/ax25_pad.c
-  ${CUSTOM_SRC_DIR}/fcs_calc.c
-  ${CUSTOM_SRC_DIR}/textcolor.c
-  )
-
-if(WIN32 OR CYGWIN)
-  list(REMOVE_ITEM tlmtest_SOURCES
-    ${CUSTOM_SRC_DIR}/dwgpsd.c
-    )
-endif()
-
-add_executable(tlmtest
-  ${tlmtest_SOURCES}
-  )
-
-set_target_properties(tlmtest
-  PROPERTIES COMPILE_FLAGS "-DTEST -DUSE_REGEX_STATIC"
-  )
-
-target_link_libraries(tlmtest
-  ${MISC_LIBRARIES}
-  ${REGEX_LIBRARIES}
-  )
-
-if(WIN32 OR CYGWIN)
-  target_link_libraries(tlmtest ws2_32)
-endif()
-
-
 # Unit test for constructing frames besides UI.
 list(APPEND pad2test_SOURCES
   ${CUSTOM_SRC_DIR}/ax25_pad2.c
@@ -307,7 +275,6 @@ target_link_libraries(il2p_test
 
 add_test(ttest ttest)
 add_test(tttexttest tttexttest)
-add_test(tlmtest tlmtest)
 add_test(pad2test pad2test)
 
 add_test(check-fx25 "${CUSTOM_TEST_BINARY_DIR}/${TEST_CHECK-FX25_FILE}${CUSTOM_SCRIPT_SUFFIX}")


### PR DESCRIPTION
* Move t_metadata_s into telemetry.h for reuse
* Disable cyclop, dupl, and gocyclo, because priorities
