### PR TITLE
Use global variable (rather than define) for il2p test functionality

### DIFF
--- a/src/demod.c
+++ b/src/demod.c
@@ -1066,7 +1066,7 @@ void demod_process_sample (int chan, int subchan, int sam)
 /* Cranking up the input level produces no more than 97 or 98. */
 /* We currently produce a message when this goes over 90. */
 
-alevel_t demod_get_audio_level (int chan, int subchan) 
+alevel_t demod_get_audio_level_real (int chan, int subchan)
 {
 	struct demodulator_state_s *D;
 	alevel_t alevel;

--- a/src/gen_tone.c
+++ b/src/gen_tone.c
@@ -361,7 +361,7 @@ static const float ci[8] = { 1,	.7071,	0,	-.7071,	-1,	-.7071,	0,	.7071	};
 static const float sq[8] = { 0,	.7071,	1,	.7071,	0,	-.7071,	-1,	-.7071	};
 #endif
 
-void tone_gen_put_bit (int chan, int dat)
+void tone_gen_put_bit_real (int chan, int dat)
 {
 	int a = ACHAN2ADEV(chan);	/* device for channel. */
 

--- a/src/il2p_test.c
+++ b/src/il2p_test.c
@@ -76,6 +76,8 @@ static char text[] =
 static int rec_count = -1;	// disable deserialized packet test.
 static int polarity = 0;
 
+int IL2P_TEST = 0;
+
 // Serializing calls this which then simulates the demodulator output.
 
 void tone_gen_put_bit_fake (int chan, int data)
@@ -83,9 +85,15 @@ void tone_gen_put_bit_fake (int chan, int data)
 	il2p_rec_bit (chan, 0, 0, data);
 }
 
-#ifdef UNITTEST
-#define tone_gen_put_bit tone_gen_put_bit_fake
-#endif
+void tone_gen_put_bit_real (int chan, int data);
+
+void tone_gen_put_bit (int chan, int data) {
+	if (IL2P_TEST) {
+		tone_gen_put_bit_fake(chan, data);
+	} else {
+		tone_gen_put_bit_real(chan, data);
+	}
+}
 
 // This is called when a complete frame has been deserialized.
 
@@ -113,9 +121,15 @@ void multi_modem_process_rec_packet_fake (int chan, int subchan, int slice, pack
 	ax25_delete (pp);
 }
 
-#ifdef UNITTEST
-#define multi_modem_process_rec_packet multi_modem_process_rec_packet_fake
-#endif
+void multi_modem_process_rec_packet_real (int chan, int subchan, int slice, packet_t pp, alevel_t alevel, retry_t retries, fec_type_t fec_type);
+
+void multi_modem_process_rec_packet (int chan, int subchan, int slice, packet_t pp, alevel_t alevel, retry_t retries, fec_type_t fec_type) {
+	if (IL2P_TEST) {
+		multi_modem_process_rec_packet_fake(chan, subchan, slice, pp, alevel, retries, fec_type);
+	} else {
+		multi_modem_process_rec_packet_real(chan, subchan, slice, pp, alevel, retries, fec_type);
+	}
+}
 
 alevel_t demod_get_audio_level_fake (int chan, int subchan)
 {
@@ -124,8 +138,14 @@ alevel_t demod_get_audio_level_fake (int chan, int subchan)
 	return (alevel);
 }
 
-#ifdef UNITTEST
-#define demod_get_audio_level demod_get_audio_level_fake
-#endif
+alevel_t demod_get_audio_level_real (int chan, int subchan);
+
+alevel_t demod_get_audio_level (int chan, int subchan) {
+	if (IL2P_TEST) {
+		return demod_get_audio_level_fake(chan, subchan);
+	} else {
+		return demod_get_audio_level_real(chan, subchan);
+	}
+}
 
 // end il2p_test.c

--- a/src/il2p_test_shim.go
+++ b/src/il2p_test_shim.go
@@ -10,6 +10,7 @@ package direwolf
 // #include "ax25_pad.h"
 // #include "ax25_pad2.h"
 // #include "multi_modem.h"
+// extern int IL2P_TEST;
 import "C"
 
 import (
@@ -30,6 +31,8 @@ import (
 
 func il2p_test_main(t *testing.T) {
 	t.Helper()
+
+	C.IL2P_TEST = 1
 
 	var enable_color C.int = 1
 	C.text_color_init(enable_color)
@@ -70,6 +73,8 @@ func il2p_test_main(t *testing.T) {
 	// TODO:  More than 2 addresses.
 
 	decode_bitstream(t)
+
+	C.IL2P_TEST = 0
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/multi_modem.c
+++ b/src/multi_modem.c
@@ -359,7 +359,7 @@ void multi_modem_process_rec_frame (int chan, int subchan, int slice, unsigned c
 
 // TODO: Eliminate function above and move code elsewhere?
 
-void multi_modem_process_rec_packet (int chan, int subchan, int slice, packet_t pp, alevel_t alevel, retry_t retries, fec_type_t fec_type)
+void multi_modem_process_rec_packet_real (int chan, int subchan, int slice, packet_t pp, alevel_t alevel, retry_t retries, fec_type_t fec_type)
 {
 	if (pp == NULL) {
 	  text_color_set(DW_COLOR_ERROR);


### PR DESCRIPTION
This makes behaviour clearer, and less likely to end up with the wrong
thing compiled in at the wrong point (because I still don't fully
understand how cgo compilation works with timing and defines and caching
etc.)
