### PR TITLE
Add libbsd-dev to fix Debian build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: "actions/setup-go@v5"
       with:
         go-version: "1.25"
-    - run: "sudo apt install --yes libudev-dev libhamlib-dev libasound2-dev libavahi-client-dev"
+    - run: "sudo apt install --yes libudev-dev libhamlib-dev libasound2-dev libavahi-client-dev libbsd-dev"
     - run: "sudo apt install --yes morse2ascii"  # For decoding the morse
     - run: "make stats"
     - run: "make cmds"

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -72,7 +72,7 @@ package direwolf
 // extern int q_h_opt;
 // extern int q_d_opt;
 // extern int A_opt_ais_to_obj;
-// #cgo pkg-config: hamlib
+// #cgo pkg-config: hamlib libbsd-overlay
 // #cgo CFLAGS: -I../external/geotranz -DMAJOR_VERSION=0 -DMINOR_VERSION=0 -DUSE_CM108 -DUSE_AVAHI_CLIENT -DUSE_HAMLIB -DUSE_ALSA
 // #cgo LDFLAGS: -lm -ludev -lavahi-common -lavahi-client -lasound
 import "C"


### PR DESCRIPTION
Seems to be Automagically Handled on Ubuntu (which the automated GHA
tests use) but my Debian box was complaining about missing strlcpy
headers and libs etc.

Hurrah for pkg-config!