### PR TITLE
Extract and Go-ise APRS position structs

### DIFF
--- a/src/aprs.go
+++ b/src/aprs.go
@@ -1,24 +1,22 @@
 package direwolf
 
-import "C"
-
 type position_t struct {
-	lat          [8]C.char
-	sym_table_id C.char /* / \ 0-9 A-Z */
-	lon          [9]C.char
-	symbol_code  C.char
+	lat          [8]byte
+	sym_table_id byte /* / \ 0-9 A-Z */
+	lon          [9]byte
+	symbol_code  byte
 }
 
 type compressed_position_t struct {
-	sym_table_id C.char /* / \ a-j A-Z */
+	sym_table_id byte /* / \ a-j A-Z */
 	/* "The presence of the leading Symbol Table Identifier */
 	/* instead of a digit indicates that this is a compressed */
 	/* Position Report and not a normal lat/long report." */
 
-	y           [4]C.char /* Compressed Latitude. */
-	x           [4]C.char /* Compressed Longitude. */
-	symbol_code C.char
-	c           C.char /* Course/speed or radio range or altitude. */
-	s           C.char
-	t           C.char /* Compression type. */
+	y           [4]byte /* Compressed Latitude. */
+	x           [4]byte /* Compressed Longitude. */
+	symbol_code byte
+	c           byte /* Course/speed or radio range or altitude. */
+	s           byte
+	t           byte /* Compression type. */
 }


### PR DESCRIPTION
- Lift out position_t and compressed_position_t to a central aprs.go
- Use bytes not C.chars for APRS position structs
