### PR TITLE
ci: Fail release flow on unmatched files

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,4 +63,5 @@ jobs:
 
           CHANGELOG forthcoming.
         files: "samoyed/*.tgz"
+        fail_on_unmatched_files: true
         draft: true  # TODO Fix


### PR DESCRIPTION
https://github.com/doismellburning/samoyed/actions/runs/18574599877/job/52957242608

"Pattern 'samoyed/*.tgz' does not match any files." "samoyed/*.tgz does not include a valid file."

Let's fail properly on that!