### PR TITLE
docs: Add a brief AGENTS.md with notes about C.CString memory leaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Review notes
+
+* cgo `C.CString` memory leaks are not a concern while porting - when the port is finished, all the cgo will be gone


### PR DESCRIPTION
GitHub Copilot reviews have been valuable, e.g.:

* Spotting a missed truncation:
https://github.com/doismellburning/samoyed/pull/157#discussion_r2475738021
* Spotting a misread C function:
https://github.com/doismellburning/samoyed/pull/157#discussion_r2475761225

But also it (reasonably) tries to warn me about C.CString memory leaks,
which I'm really not bothered about here because it's all going to be
gone when the Go port is finished and there is no C left.

Hopefully this should get it to chill out.
