### PR TITLE
refactor: Move Base 91 code into its own file

### DIFF
--- a/src/base91.go
+++ b/src/base91.go
@@ -1,0 +1,10 @@
+package direwolf
+
+/* Range of digits for Base 91 representation. */
+
+const B91_MIN = '!'
+const B91_MAX = '{'
+
+func isdigit91(c byte) bool {
+	return ((c) >= B91_MIN && (c) <= B91_MAX)
+}

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -49,15 +49,6 @@ import (
 	"unsafe"
 )
 
-/* Range of digits for Base 91 representation. */
-
-const B91_MIN = '!'
-const B91_MAX = '{'
-
-func isdigit91(c byte) bool {
-	return ((c) >= B91_MIN && (c) <= B91_MAX)
-}
-
 /*------------------------------------------------------------------
  *
  * Function:	decode_aprs


### PR DESCRIPTION
This saves a bit of a fight over whether they belong in decode_aprs or
telemetry(!)
