### PR TITLE
refactor: Remove almost all remaining cgo exports

### DIFF
--- a/src/atest.go
+++ b/src/atest.go
@@ -621,7 +621,6 @@ func audio_get_fake(a C.int) C.int {
 	return (ch)
 }
 
-//export audio_get
 func audio_get(a C.int) C.int {
 	if ATEST_C {
 		return audio_get_fake(a)
@@ -806,7 +805,6 @@ func ptt_set_fake(ot C.int, channel C.int, ptt_signal C.int) {
 	}
 }
 
-//export ptt_set
 func ptt_set(ot C.int, channel C.int, ptt_signal C.int) {
 	if ATEST_C {
 		ptt_set_fake(ot, channel, ptt_signal)
@@ -819,11 +817,10 @@ func get_input_fake(it C.int, channel C.int) C.int {
 	return -1
 }
 
-//export get_input
 func get_input(it C.int, channel C.int) C.int {
 	if ATEST_C {
 		return get_input_fake(it, channel)
 	} else {
-		return C.get_input_real(it, channel)
+		return get_input_real(it, channel)
 	}
 }

--- a/src/ax25_pad.go
+++ b/src/ax25_pad.go
@@ -2460,7 +2460,7 @@ func ax25_hex_dump(this_p *packet_t) {
 
 	}
 
-	C.hex_dump(&fptr[0], flen)
+	hex_dump(&fptr[0], flen)
 
 } /* end ax25_hex_dump */
 

--- a/src/callbacks.go
+++ b/src/callbacks.go
@@ -16,7 +16,6 @@ Only use Go types for the variable because C types end up different (C.int vs di
 
 var KISS_PROCESS_MSG_OVERRIDE func(unsafe.Pointer, int)
 
-//export kiss_process_msg_override
 func kiss_process_msg_override(_kiss_msg *C.uchar, kiss_len C.int) {
 	if KISS_PROCESS_MSG_OVERRIDE == nil {
 		panic("kiss_process_msg_override called but KISS_PROCESS_MSG_OVERRIDE not set!")

--- a/src/cm108.go
+++ b/src/cm108.go
@@ -423,7 +423,6 @@ func cm108_inventory(max_things C.int) ([]*thing_s, error) {
  *
  *------------------------------------------------------------------*/
 
-//export cm108_find_ptt
 func cm108_find_ptt(output_audio_device *C.char, ptt_device *C.char, ptt_device_size C.int) {
 
 	//dw_printf ("DEBUG: cm108_find_ptt('%s')\n", output_audio_device);
@@ -492,7 +491,6 @@ func cm108_find_ptt(output_audio_device *C.char, ptt_device *C.char, ptt_device_
  *
  *------------------------------------------------------------------*/
 
-//export cm108_set_gpio_pin
 func cm108_set_gpio_pin(name *C.char, num C.int, state C.int) C.int {
 
 	if num < 1 || num > 8 {

--- a/src/decode_aprs_main.go
+++ b/src/decode_aprs_main.go
@@ -151,7 +151,7 @@ func DecodeAPRSLine(line string) {
 			var kiss_frame = bytes
 
 			fmt.Printf("--- KISS frame ---\n")
-			C.hex_dump((*C.uchar)(C.CBytes(kiss_frame)), C.int(len(kiss_frame)))
+			hex_dump((*C.uchar)(C.CBytes(kiss_frame)), C.int(len(kiss_frame)))
 
 			// Put FEND at end to keep kiss_unwrap happy.
 			// Having one at the beginning is optional.

--- a/src/gen_packets.go
+++ b/src/gen_packets.go
@@ -912,7 +912,6 @@ func audio_put_fake(a C.int, c C.int) C.int {
 
 } /* end audio_put */
 
-//export audio_put
 func audio_put(a C.int, c C.int) C.int {
 	if GEN_PACKETS {
 		return audio_put_fake(a, c)
@@ -925,7 +924,6 @@ func audio_flush_fake(a C.int) C.int {
 	return 0
 }
 
-//export audio_flush
 func audio_flush(a C.int) C.int {
 	if GEN_PACKETS {
 		return audio_flush_fake(a)
@@ -938,7 +936,6 @@ func audio_flush(a C.int) C.int {
 func dcd_change_fake(channel C.int, subchan C.int, slice C.int, state C.int) {
 }
 
-//export dcd_change
 func dcd_change(channel C.int, subchan C.int, slice C.int, state C.int) {
 	if GEN_PACKETS {
 		dcd_change_fake(channel, subchan, slice, state)

--- a/src/hex_dump.go
+++ b/src/hex_dump.go
@@ -7,7 +7,6 @@ import (
 	"unsafe"
 )
 
-//export hex_dump
 func hex_dump(_p *C.uchar, length C.int) {
 	var p = C.GoBytes(unsafe.Pointer(_p), length)
 	var offset = 0

--- a/src/il2p_test_util.go
+++ b/src/il2p_test_util.go
@@ -34,7 +34,6 @@ func tone_gen_put_bit_fake(channel C.int, data C.int) {
 	il2p_rec_bit(channel, 0, 0, data)
 }
 
-//export tone_gen_put_bit
 func tone_gen_put_bit(channel C.int, data C.int) {
 	if IL2P_TEST {
 		tone_gen_put_bit_fake(channel, data)

--- a/src/kiss.go
+++ b/src/kiss.go
@@ -299,7 +299,7 @@ func kisspt_send_rec_packet(channel C.int, kiss_cmd C.int, fbuf []byte, flen C.i
 			text_color_set(DW_COLOR_DEBUG)
 			dw_printf("\n")
 			dw_printf("Packet content before adding KISS framing and any escapes:\n")
-			C.hex_dump((*C.uchar)(C.CBytes(fbuf)), flen)
+			hex_dump((*C.uchar)(C.CBytes(fbuf)), flen)
 		}
 
 		kiss_buff = kiss_encapsulate(stemp)

--- a/src/kiss_frame.go
+++ b/src/kiss_frame.go
@@ -64,7 +64,6 @@ package direwolf
 // #include <ctype.h>
 // #include <assert.h>
 // #include <string.h>
-// void hex_dump (unsigned char *p, int len);
 import "C"
 
 import (
@@ -347,7 +346,7 @@ func kiss_debug_print(fromto fromto_t, special string, pmsg []byte) {
 		}
 	}
 
-	C.hex_dump((*C.uchar)(C.CBytes(pmsg)), C.int(len(pmsg)))
+	hex_dump((*C.uchar)(C.CBytes(pmsg)), C.int(len(pmsg)))
 }
 
 /*-------------------------------------------------------------------
@@ -477,7 +476,7 @@ func kiss_rec_byte(kf *kiss_frame_t, ch C.uchar, debug C.int,
 				dw_printf("Packet content after removing KISS framing and any escapes:\n")
 				/* Don't include the "type" indicator. */
 				/* It contains the radio channel and type should always be 0 here. */
-				C.hex_dump((*C.uchar)(C.CBytes(unwrapped[1:])), C.int(len(unwrapped)-1))
+				hex_dump((*C.uchar)(C.CBytes(unwrapped[1:])), C.int(len(unwrapped)-1))
 			}
 
 			kiss_process_msg((*C.uchar)(C.CBytes(unwrapped)), C.int(ulen), debug, kps, client, sendfun)

--- a/src/kissnet.go
+++ b/src/kissnet.go
@@ -444,7 +444,7 @@ func kissnet_send_rec_packet(channel C.int, kiss_cmd C.int, fbuf []byte, flen C.
 								text_color_set(DW_COLOR_DEBUG)
 								dw_printf("\n")
 								dw_printf("Packet content before adding KISS framing and any escapes:\n")
-								C.hex_dump((*C.uchar)(C.CBytes(fbuf)), flen)
+								hex_dump((*C.uchar)(C.CBytes(fbuf)), flen)
 							}
 
 							kiss_buff = kiss_encapsulate(stemp)

--- a/src/kissserial.go
+++ b/src/kissserial.go
@@ -219,7 +219,7 @@ func kissserial_send_rec_packet(channel C.int, kiss_cmd C.int, fbuf []byte, flen
 			text_color_set(DW_COLOR_DEBUG)
 			dw_printf("\n")
 			dw_printf("Packet content before adding KISS framing and any escapes:\n")
-			C.hex_dump((*C.uchar)(C.CBytes(fbuf)), flen)
+			hex_dump((*C.uchar)(C.CBytes(fbuf)), flen)
 		}
 
 		kiss_buff = kiss_encapsulate(stemp)

--- a/src/kissutil.go
+++ b/src/kissutil.go
@@ -376,7 +376,7 @@ func send_to_kiss_tnc(channel int, cmd int, data []byte) {
 
 	if verbose {
 		fmt.Printf("Sending to KISS TNC:\n")
-		C.hex_dump((*C.uchar)(C.CBytes(kissed)), C.int(klen))
+		hex_dump((*C.uchar)(C.CBytes(kissed)), C.int(klen))
 	}
 
 	if using_tcp {

--- a/src/nettnc.go
+++ b/src/nettnc.go
@@ -275,7 +275,7 @@ func my_kiss_rec_byte(kf *kiss_frame_t, b C.uchar, debug int, channel_override C
 				dw_printf("Frame content after removing KISS framing and any escapes:\n")
 				/* Don't include the "type" indicator. */
 				/* It contains the radio channel and type should always be 0 here. */
-				C.hex_dump((*C.uchar)(C.CBytes(unwrapped[1:])), C.int(len(unwrapped[1:])))
+				hex_dump((*C.uchar)(C.CBytes(unwrapped[1:])), C.int(len(unwrapped[1:])))
 			}
 
 			// Convert to packet object and send to received packet queue.

--- a/src/ptt.go
+++ b/src/ptt.go
@@ -1008,7 +1008,6 @@ func ptt_init(audio_config_p *audio_s) {
 
 // JWL - save status and new get_ptt function.
 
-//export ptt_set_real
 func ptt_set_real(ot C.int, channel C.int, ptt_signal C.int) {
 
 	var ptt = ptt_signal
@@ -1240,7 +1239,6 @@ func ptt_set_real(ot C.int, channel C.int, ptt_signal C.int) {
  *
  * ------------------------------------------------------------------*/
 
-//export get_input_real
 func get_input_real(it C.int, channel C.int) C.int {
 	Assert(it >= 0 && it < NUM_ICTYPES)
 	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)

--- a/src/server.go
+++ b/src/server.go
@@ -275,7 +275,7 @@ func debug_print(fromto fromto_t, client C.int, pmsg *AGWPEMessage) {
 	dw_printf("\tcall_from = \"%s\", call_to = \"%s\"\n", pmsg.Header.CallFrom, pmsg.Header.CallTo)
 	dw_printf("\tdata_len = %d, user_reserved = %d, data =\n", pmsg.Header.DataLen, pmsg.Header.UserReserved)
 
-	C.hex_dump((*C.uchar)(C.CBytes(pmsg.Data)), C.int(pmsg.Header.DataLen))
+	hex_dump((*C.uchar)(C.CBytes(pmsg.Data)), C.int(pmsg.Header.DataLen))
 }
 
 /*-------------------------------------------------------------------


### PR DESCRIPTION
Turns out I need the Avahi ones still because of the C callbacks...
