### PR TITLE
refactor: Use Go types in encode_aprs.go

### DIFF
--- a/src/beacon.go
+++ b/src/beacon.go
@@ -20,6 +20,7 @@ import "C"
 import (
 	"fmt"
 	"math"
+	"time"
 )
 
 /*
@@ -689,22 +690,22 @@ func beacon_send(j int, gpsinfo *dwgps_info_t) {
 	switch bp.btype {
 	case BEACON_POSITION:
 
-		beacon_text += encode_position(bp.messaging, bp.compress,
-			bp.lat, bp.lon, bp.ambiguity,
-			C.int(math.Round(DW_METERS_TO_FEET(float64(bp.alt_m)))),
-			bp.symtab, bp.symbol,
-			C.int(bp.power), C.int(bp.height), C.int(bp.gain), C.CString(bp.dir),
+		beacon_text += encode_position(bp.messaging != 0, bp.compress != 0,
+			float64(bp.lat), float64(bp.lon), int(bp.ambiguity),
+			int(math.Round(DW_METERS_TO_FEET(float64(bp.alt_m)))),
+			byte(bp.symtab), byte(bp.symbol),
+			int(bp.power), int(bp.height), int(bp.gain), bp.dir,
 			G_UNKNOWN, G_UNKNOWN, /* course, speed */
-			bp.freq, bp.tone, bp.offset,
-			C.CString(super_comment))
+			float64(bp.freq), float64(bp.tone), float64(bp.offset),
+			super_comment)
 
 	case BEACON_OBJECT:
 
-		beacon_text += encode_object(C.CString(bp.objname), bp.compress, 1, bp.lat, bp.lon, bp.ambiguity,
-			bp.symtab, bp.symbol,
-			C.int(bp.power), C.int(bp.height), C.int(bp.gain), C.CString(bp.dir),
+		beacon_text += encode_object(bp.objname, bp.compress != 0, time.Now(), float64(bp.lat), float64(bp.lon), int(bp.ambiguity),
+			byte(bp.symtab), byte(bp.symbol),
+			int(bp.power), int(bp.height), int(bp.gain), bp.dir,
 			G_UNKNOWN, G_UNKNOWN, /* course, speed */
-			bp.freq, bp.tone, bp.offset, C.CString(super_comment))
+			float64(bp.freq), float64(bp.tone), float64(bp.offset), super_comment)
 
 	case BEACON_TRACKER:
 
@@ -713,24 +714,24 @@ func beacon_send(j int, gpsinfo *dwgps_info_t) {
 			/* A positive altitude in the config file enables */
 			/* transmission of altitude from GPS. */
 
-			var my_alt_ft C.int = G_UNKNOWN
+			var my_alt_ft int = G_UNKNOWN
 			if gpsinfo.fix >= 3 && gpsinfo.altitude != G_UNKNOWN && bp.alt_m > 0 {
-				my_alt_ft = C.int(math.Round(DW_METERS_TO_FEET(float64(gpsinfo.altitude))))
+				my_alt_ft = int(math.Round(DW_METERS_TO_FEET(float64(gpsinfo.altitude))))
 			}
 
 			/* Round to nearest integer. retaining unknown state. */
-			var coarse C.int = G_UNKNOWN
+			var coarse int = G_UNKNOWN
 			if gpsinfo.track != G_UNKNOWN {
-				coarse = C.int(math.Round(float64(gpsinfo.track)))
+				coarse = int(math.Round(float64(gpsinfo.track)))
 			}
 
-			beacon_text += encode_position(bp.messaging, bp.compress,
-				gpsinfo.dlat, gpsinfo.dlon, bp.ambiguity, my_alt_ft,
-				bp.symtab, bp.symbol,
-				C.int(bp.power), C.int(bp.height), C.int(bp.gain), C.CString(bp.dir),
-				coarse, C.int(math.Round(float64(gpsinfo.speed_knots))),
-				bp.freq, bp.tone, bp.offset,
-				C.CString(super_comment))
+			beacon_text += encode_position(bp.messaging != 0, bp.compress != 0,
+				float64(gpsinfo.dlat), float64(gpsinfo.dlon), int(bp.ambiguity), my_alt_ft,
+				byte(bp.symtab), byte(bp.symbol),
+				int(bp.power), int(bp.height), int(bp.gain), bp.dir,
+				coarse, int(math.Round(float64(gpsinfo.speed_knots))),
+				float64(bp.freq), float64(bp.tone), float64(bp.offset),
+				super_comment)
 
 			/* Write to log file for testing. */
 			/* The idea is to run log2gpx and map the result rather than */

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -1080,14 +1080,14 @@ func app_process_rec_packet(channel C.int, subchan C.int, slice C.int, pp *packe
 			waypoint_send_ais([]byte(C.GoString((*C.char)(unsafe.Pointer(pinfo)))[3:]))
 
 			if A_opt_ais_to_obj && A.g_lat != G_UNKNOWN && A.g_lon != G_UNKNOWN {
-				var ais_obj_info = encode_object(&A.g_name[0], 0, C.time(nil),
-					A.g_lat, A.g_lon, 0, // no ambiguity
-					A.g_symbol_table, A.g_symbol_code,
-					0, 0, 0, C.CString(""), // power, height, gain, direction.
+				var ais_obj_info = encode_object(C.GoString(&A.g_name[0]), false, time.Now(),
+					float64(A.g_lat), float64(A.g_lon), 0, // no ambiguity
+					byte(A.g_symbol_table), byte(A.g_symbol_code),
+					0, 0, 0, "", // power, height, gain, direction.
 					// Unknown not handled properly.
 					// Should encode_object take floating point here?
-					C.int(A.g_course+0.5), C.int(DW_MPH_TO_KNOTS(float64(A.g_speed_mph))+0.5),
-					0, 0, 0, &A.g_comment[0]) // freq, tone, offset
+					int(A.g_course+0.5), int(DW_MPH_TO_KNOTS(float64(A.g_speed_mph))+0.5),
+					0, 0, 0, C.GoString(&A.g_comment[0])) // freq, tone, offset
 
 				// TODO Bodge
 				var _ais_obj_packet = fmt.Sprintf("%s>%s%1d%1d,NOGATE:%s", C.GoString(&A.g_src[0]), APP_TOCALL, C.MAJOR_VERSION, C.MINOR_VERSION, ais_obj_info)

--- a/src/encode_aprs_test_shim.go
+++ b/src/encode_aprs_test_shim.go
@@ -1,77 +1,11 @@
 package direwolf
 
-// #include <stdlib.h>
-// #include <string.h>
-// #include <stdio.h>
-// #include <unistd.h>
-// #include <ctype.h>
-// #include <time.h>
-// #include <math.h>
-// #include <assert.h>
-import "C"
-
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// Save a lot of re-encoding...
-func _encode_position(
-	messaging C.int, compressed C.int, lat C.double, lon C.double, ambiguity C.int, alt_ft C.int,
-	symtab C.char, symbol C.char, power C.int, height C.int, gain C.int, dir string, course C.int, speed C.int, freq C.float, tone C.float,
-	offset C.float, comment string) string {
-	return encode_position(
-		messaging,
-		compressed,
-		lat,
-		lon,
-		ambiguity,
-		alt_ft,
-		symtab,
-		symbol,
-		power,
-		height,
-		gain,
-		C.CString(dir),
-		course,
-		speed,
-		freq,
-		tone,
-		offset,
-		C.CString(comment),
-	)
-}
-
-func _encode_object(
-	name string, compressed C.int, thyme C.time_t, lat C.double, lon C.double, ambiguity C.int,
-	symtab C.char, symbol C.char, power C.int, height C.int, gain C.int, dir string, course C.int, speed C.int, freq C.float, tone C.float,
-	offset C.float, comment string) string {
-	return encode_object(
-		C.CString(name),
-		compressed,
-		thyme,
-		lat,
-		lon,
-		ambiguity,
-		symtab,
-		symbol,
-		power,
-		height,
-		gain,
-		C.CString(dir),
-		course,
-		speed,
-		freq,
-		tone,
-		offset,
-		C.CString(comment),
-	)
-}
-
-func _encode_message(addressee string, text string, id string) string {
-	return encode_message(C.CString(addressee), C.CString(text), C.CString(id))
-}
 
 func encode_aprs_test_main(t *testing.T) {
 	t.Helper()
@@ -80,50 +14,50 @@ func encode_aprs_test_main(t *testing.T) {
 
 	/***********  Position  ***********/
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		0, 0, 0, "", G_UNKNOWN, 0, 0, 0, 0, "")
 	assert.Equal(t, "!4234.61ND07126.47W&", result)
 
 	/* with PHG. */
 	// TODO:  Need to test specifying some but not all.
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		50, 100, 6, "N", G_UNKNOWN, 0, 0, 0, 0, "")
 	assert.Equal(t, "!4234.61ND07126.47W&PHG7368", result)
 
 	/* with freq & tone.  minus offset, no offset, explicit simplex. */
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		0, 0, 0, "", G_UNKNOWN, 0, 146.955, 74.4, -0.6, "")
 	assert.Equal(t, "!4234.61ND07126.47W&146.955MHz T074 -060 ", result)
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		0, 0, 0, "", G_UNKNOWN, 0, 146.955, 74.4, G_UNKNOWN, "")
 	assert.Equal(t, "!4234.61ND07126.47W&146.955MHz T074 ", result)
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		0, 0, 0, "", G_UNKNOWN, 0, 146.955, 74.4, 0, "")
 	assert.Equal(t, "!4234.61ND07126.47W&146.955MHz T074 +000 ", result)
 
 	/* with course/speed, freq, and comment! */
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		0, 0, 0, "", 180, 55, 146.955, 74.4, -0.6, "River flooding")
 	assert.Equal(t, "!4234.61ND07126.47W&180/055146.955MHz T074 -060 River flooding", result)
 
 	/* Course speed, no tone, + offset */
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		0, 0, 0, "", 180, 55, 146.955, G_UNKNOWN, 0.6, "River flooding")
 	assert.Equal(t, "!4234.61ND07126.47W&180/055146.955MHz +060 River flooding", result)
 
 	/* Course speed, no tone, + offset + altitude */
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, 12345, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, 12345, 'D', '&',
 		0, 0, 0, "", 180, 55, 146.955, G_UNKNOWN, 0.6, "River flooding")
 	assert.Equal(t, "!4234.61ND07126.47W&180/055146.955MHz +060 /A=012345River flooding", result)
 
-	result = _encode_position(0, 0, 42+34.61/60, -(71 + 26.47/60), 0, 12345, 'D', '&',
+	result = encode_position(false, false, 42+34.61/60, -(71 + 26.47/60), 0, 12345, 'D', '&',
 		0, 0, 0, "", 180, 55, 146.955, 0, 0.6, "River flooding")
 	assert.Equal(t, "!4234.61ND07126.47W&180/055146.955MHz Toff +060 /A=012345River flooding", result)
 
@@ -131,19 +65,19 @@ func encode_aprs_test_main(t *testing.T) {
 
 	/*********** Compressed position. ***********/
 
-	result = _encode_position(0, 1, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, true, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		0, 0, 0, "", G_UNKNOWN, 0, 0, 0, 0, "")
 	assert.Equal(t, "!D8yKC<Hn[&  !", result)
 
 	/* with PHG. In this case it is converted to precomputed radio range.  TODO: check on this.  Is 27.4 correct? */
 
-	result = _encode_position(0, 1, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, true, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		50, 100, 6, "N", G_UNKNOWN, 0, 0, 0, 0, "")
 	assert.Equal(t, "!D8yKC<Hn[&{CG", result)
 
 	/* with course/speed, freq, and comment!  Roundoff. 55 knots should be 63 MPH.  we get 62. */
 
-	result = _encode_position(0, 1, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
+	result = encode_position(false, true, 42+34.61/60, -(71 + 26.47/60), 0, G_UNKNOWN, 'D', '&',
 		0, 0, 0, "", 180, 55, 146.955, 74.4, -0.6, "River flooding")
 	assert.Equal(t, "!D8yKC<Hn[&NUG146.955MHz T074 -060 River flooding", result)
 
@@ -151,7 +85,7 @@ func encode_aprs_test_main(t *testing.T) {
 
 	/*********** Object. ***********/
 
-	result = _encode_object("WB1GOF-C", 0, 0, 42+34.61/60, -(71 + 26.47/60), 0, 'D', '&',
+	result = encode_object("WB1GOF-C", false, time.Time{}, 42+34.61/60, -(71 + 26.47/60), 0, 'D', '&',
 		0, 0, 0, "", G_UNKNOWN, 0, 0, 0, 0, "")
 	assert.Equal(t, ";WB1GOF-C *111111z4234.61ND07126.47W&", result)
 
@@ -159,13 +93,13 @@ func encode_aprs_test_main(t *testing.T) {
 
 	/*********** Message. ***********/
 
-	result = _encode_message("N2GH", "some stuff", "")
+	result = encode_message("N2GH", "some stuff", "")
 	assert.Equal(t, ":N2GH     :some stuff", result)
 
-	result = _encode_message("N2GH", "other stuff", "12345")
+	result = encode_message("N2GH", "other stuff", "12345")
 	assert.Equal(t, ":N2GH     :other stuff{12345", result)
 
-	result = _encode_message("WB2OSZ-123", "other stuff", "12345")
+	result = encode_message("WB2OSZ-123", "other stuff", "12345")
 	assert.Equal(t, ":WB2OSZ-12:other stuff{12345", result)
 
 	dw_printf("Encode APRS test PASSED with no errors.\n")

--- a/src/tt_user.go
+++ b/src/tt_user.go
@@ -720,13 +720,13 @@ func xmit_object_report(i int, first_time bool) {
 	}
 
 	// info part of Object Report packet
-	stemp += encode_object(C.CString(object_name), 0, C.long(tt_user[i].last_heard.Unix()), C.double(olat), C.double(olong), C.int(oambig),
-		C.char(tt_user[i].overlay), C.char(tt_user[i].symbol),
-		0, 0, 0, nil, G_UNKNOWN, G_UNKNOWN, /* PHGD, Course/Speed */
-		C.float(freq),
-		C.float(ctcss),
+	stemp += encode_object(object_name, false, tt_user[i].last_heard, olat, olong, oambig,
+		byte(tt_user[i].overlay), byte(tt_user[i].symbol),
+		0, 0, 0, "", G_UNKNOWN, G_UNKNOWN, /* PHGD, Course/Speed */
+		freq,
+		ctcss,
 		G_UNKNOWN, /* CTCSS */
-		C.CString(info_comment))
+		info_comment)
 
 	if TT_TESTS_RUNNING {
 		dw_printf("---> %s\n\n", stemp)

--- a/src/walk96.go
+++ b/src/walk96.go
@@ -108,16 +108,16 @@ func walk96(fix int, lat float64, lon float64, knots float64, course float64, al
 
 	// TODO (high, bug):    Why do we see !4237.13N/07120.84W=PHG0000...   when all values set to unknown.
 
-	var messaging C.int = 0
-	var compressed C.int = 0
+	var messaging = false
+	var compressed = false
 
 	var info = encode_position(messaging, compressed,
-		C.double(lat), C.double(lon), 0, C.int(DW_METERS_TO_FEET(alt)),
+		lat, lon, 0, int(DW_METERS_TO_FEET(alt)),
 		'/', '=',
-		G_UNKNOWN, G_UNKNOWN, G_UNKNOWN, C.CString(""), // PHGd
-		C.int(course), C.int(knots),
+		G_UNKNOWN, G_UNKNOWN, G_UNKNOWN, "", // PHGd
+		int(course), int(knots),
 		445.925, 0, 0,
-		C.CString(comment))
+		comment)
 
 	var position_report = fmt.Sprintf("%s>WALK96:%s", MYCALL, info)
 


### PR DESCRIPTION
This also drops the C import from encode_aprs_test_shim.go, hurrah!
