### PR TITLE
refactor: Use Go types in ax25_get_info and ax25_safe_print

### DIFF
--- a/src/aclients.go
+++ b/src/aclients.go
@@ -53,7 +53,6 @@ import (
 	"strings"
 	"time"
 	"unicode"
-	"unsafe"
 )
 
 /*------------------------------------------------------------------
@@ -259,11 +258,9 @@ func client_thread_net(my_index int, hostname string, port string, description s
 			var alevel alevel_t
 			var pp = ax25_from_frame(data[1:mon_cmd.DataLen], alevel)
 			var result = ax25_format_addrs(pp)
-			var pinfo *C.uchar
-			var info_len = ax25_get_info(pp, &pinfo)
-			_ = info_len
+			var info = ax25_get_info(pp)
 
-			var fullResult = result + C.GoString((*C.char)(unsafe.Pointer(pinfo)))
+			var fullResult = result + string(info)
 			packetChan <- fullResult
 			ax25_delete(pp)
 			packet_count[my_index]++

--- a/src/atest.go
+++ b/src/atest.go
@@ -653,8 +653,7 @@ func dlq_rec_frame_fake(channel C.int, subchan C.int, slice C.int, pp *packet_t,
 
 	var stemp = ax25_format_addrs(pp)
 
-	var pinfo *C.uchar
-	var info_len = ax25_get_info(pp, &pinfo)
+	var info = ax25_get_info(pp)
 
 	/* Print so we can see what is going on. */
 
@@ -742,7 +741,7 @@ func dlq_rec_frame_fake(channel C.int, subchan C.int, slice C.int, pp *packet_t,
 	}
 
 	dw_printf("%s", stemp) /* stations followed by : */
-	ax25_safe_print((*C.char)(unsafe.Pointer(pinfo)), info_len, 0)
+	ax25_safe_print(info, 0)
 	dw_printf("\n")
 
 	/*

--- a/src/ax25_link_test_shim.go
+++ b/src/ax25_link_test_shim.go
@@ -60,7 +60,7 @@ func TestAX25LinkConnectedBasic(t *testing.T) {
 
 	C.strcpy(&addrs[OWNCALL][0], THEIR_CALL)
 	C.strcpy(&addrs[PEERCALL][0], MY_CALL)
-	pp = ax25_u_frame(addrs, 2, cr_cmd, frame_type_U_UA, 1, 1, nil, 0)
+	pp = ax25_u_frame(addrs, 2, cr_cmd, frame_type_U_UA, 1, 1, nil)
 	assert.NotNil(t, pp)
 
 	E = new(dlq_item_t)

--- a/src/ax25_pad2.go
+++ b/src/ax25_pad2.go
@@ -154,16 +154,14 @@ import (
  *				  Normally 0xf0 meaning no level 3.
  *				  Could be other values for NET/ROM, etc.
  *
- *		pinfo		- Pointer to data for Info field.  Allowed only for UI, XID, TEST, FRMR.
- *
- *		info_len	- Length for Info field.
+ *		info		- Info field.  Allowed only for UI, XID, TEST, FRMR.
  *
  *
  * Returns:	Pointer to new packet object.
  *
  *------------------------------------------------------------------------------*/
 
-func ax25_u_frame(addrs [AX25_MAX_ADDRS][AX25_MAX_ADDR_LEN]C.char, num_addr C.int, cr cmdres_t, ftype ax25_frame_type_t, pf int, pid int, pinfo *C.uchar, info_len C.int) *packet_t {
+func ax25_u_frame(addrs [AX25_MAX_ADDRS][AX25_MAX_ADDR_LEN]C.char, num_addr C.int, cr cmdres_t, ftype ax25_frame_type_t, pf int, pid int, info []byte) *packet_t {
 
 	var this_p = ax25_new()
 
@@ -255,18 +253,18 @@ func ax25_u_frame(addrs [AX25_MAX_ADDRS][AX25_MAX_ADDR_LEN]C.char, num_addr C.in
 	}
 
 	if i {
-		if pinfo != nil && info_len > 0 {
-			if info_len > AX25_MAX_INFO_LEN {
+		if len(info) > 0 {
+			if len(info) > AX25_MAX_INFO_LEN {
 				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Internal error in ax25_u_frame: U frame, Invalid information field length %d.\n", info_len)
-				info_len = AX25_MAX_INFO_LEN
+				dw_printf("Internal error in ax25_u_frame: U frame, Invalid information field length %d.\n", len(info))
+				info = info[:AX25_MAX_INFO_LEN]
 			}
-			C.memcpy(unsafe.Pointer(p), unsafe.Pointer(pinfo), C.size_t(info_len))
-			p = (*C.uchar)(unsafe.Add(unsafe.Pointer(p), info_len))
-			this_p.frame_len += info_len
+			C.memcpy(unsafe.Pointer(p), C.CBytes(info), C.size_t(len(info)))
+			p = (*C.uchar)(unsafe.Add(unsafe.Pointer(p), len(info)))
+			this_p.frame_len += C.int(len(info))
 		}
 	} else {
-		if pinfo != nil && info_len > 0 {
+		if len(info) > 0 {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Internal error in ax25_u_frame: Info part not allowed for U frame type.\n")
 		}
@@ -304,9 +302,7 @@ func ax25_u_frame(addrs [AX25_MAX_ADDRS][AX25_MAX_ADDR_LEN]C.char, num_addr C.in
  *
  *		pf		- Poll/Final flag.
  *
- *		pinfo		- Pointer to data for Info field.  Allowed only for SREJ.
- *
- *		info_len	- Length for Info field.
+ *		info		- Info field.  Allowed only for SREJ.
  *
  *
  * Returns:	Pointer to new packet object.
@@ -321,8 +317,7 @@ func ax25_s_frame(
 	modulo ax25_modulo_t,
 	nr int,
 	pf int,
-	pinfo *C.uchar,
-	info_len C.int,
+	info []byte,
 ) *packet_t {
 
 	var this_p = ax25_new()
@@ -399,18 +394,18 @@ func ax25_s_frame(
 	}
 
 	if ftype == frame_type_S_SREJ {
-		if pinfo != nil && info_len > 0 {
-			if info_len > AX25_MAX_INFO_LEN {
+		if len(info) > 0 {
+			if len(info) > AX25_MAX_INFO_LEN {
 				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Internal error in ax25_s_frame: SREJ frame, Invalid information field length %d.\n", info_len)
-				info_len = AX25_MAX_INFO_LEN
+				dw_printf("Internal error in ax25_s_frame: SREJ frame, Invalid information field length %d.\n", len(info))
+				info = info[:AX25_MAX_INFO_LEN]
 			}
-			C.memcpy(unsafe.Pointer(p), unsafe.Pointer(pinfo), C.size_t(info_len))
-			p = (*C.uchar)(unsafe.Add(unsafe.Pointer(p), info_len))
-			this_p.frame_len += info_len
+			C.memcpy(unsafe.Pointer(p), C.CBytes(info), C.size_t(len(info)))
+			p = (*C.uchar)(unsafe.Add(unsafe.Pointer(p), len(info)))
+			this_p.frame_len += C.int(len(info))
 		}
 	} else {
-		if pinfo != nil || info_len != 0 {
+		if len(info) > 0 {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Internal error in ax25_s_frame: Info part not allowed for RR, RNR, REJ frame.\n")
 		}
@@ -449,9 +444,7 @@ func ax25_s_frame(
  *				  Normally 0xf0 meaning no level 3.
  *				  Could be other values for NET/ROM, etc.
  *
- *		pinfo		- Pointer to data for Info field.
- *
- *		info_len	- Length for Info field.
+ *		info		- Info field.
  *
  *
  * Returns:	Pointer to new packet object.
@@ -467,8 +460,7 @@ func ax25_i_frame(
 	ns int,
 	pf int,
 	pid int,
-	pinfo *C.uchar,
-	info_len C.int,
+	info []byte,
 ) *packet_t {
 
 	var this_p = ax25_new()
@@ -541,15 +533,15 @@ func ax25_i_frame(
 	p = (*C.uchar)(unsafe.Add(unsafe.Pointer(p), 1))
 	this_p.frame_len++
 
-	if pinfo != nil && info_len > 0 {
-		if info_len > AX25_MAX_INFO_LEN {
+	if len(info) > 0 {
+		if len(info) > AX25_MAX_INFO_LEN {
 			text_color_set(DW_COLOR_ERROR)
-			dw_printf("Internal error in ax25_i_frame: I frame, Invalid information field length %d.\n", info_len)
-			info_len = AX25_MAX_INFO_LEN
+			dw_printf("Internal error in ax25_i_frame: I frame, Invalid information field length %d.\n", len(info))
+			info = info[:AX25_MAX_INFO_LEN]
 		}
-		C.memcpy(unsafe.Pointer(p), unsafe.Pointer(pinfo), C.size_t(info_len))
-		p = (*C.uchar)(unsafe.Add(unsafe.Pointer(p), info_len))
-		this_p.frame_len += info_len
+		C.memcpy(unsafe.Pointer(p), C.CBytes(info), C.size_t(len(info)))
+		p = (*C.uchar)(unsafe.Add(unsafe.Pointer(p), len(info)))
+		this_p.frame_len += C.int(len(info))
 	}
 
 	*p = 0

--- a/src/ax25_pad_test.go
+++ b/src/ax25_pad_test.go
@@ -1,0 +1,36 @@
+package direwolf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ax25_unwrap_third_party(t *testing.T) {
+	// Taken from the original comments for the function:
+	// Example: Input:      A>B,C:}D>E,F:info
+	// Output:     D>E,F:info
+	// (Except because we're using ax25_format_addrs, the info part isn't shown)
+
+	var pp = ax25_from_text("A>B,C:}D>E,F:info", true)
+	var pp2 = ax25_unwrap_third_party(pp)
+	var addrs = ax25_format_addrs(pp2)
+	assert.Equal(t, "D>E,F:", addrs)
+}
+
+func Test_ax25_set_info(t *testing.T) {
+
+	var p = ax25_from_text("D>E,F:info", true)
+	var initialInfo = ax25_get_info(p)
+	assert.Equal(t, "info", string(initialInfo)) // Make sure I set this up right!
+
+	var s = "badger"
+	ax25_set_info(p, []byte(s))
+
+	// Check info updated
+	var newInfo = ax25_get_info(p)
+	assert.Equal(t, s, string(newInfo))
+
+	// Make sure we didn't break stuff along the way
+	assert.Equal(t, "D>E,F:", ax25_format_addrs(p))
+}

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -216,14 +216,11 @@ func decode_aprs(A *decode_aprs_t, pp *packet_t, quiet C.int, third_party_src *C
 
 	//dw_printf ("DEBUG decode_aprs quiet=%d, third_party=%p\n", quiet, third_party_src);
 
-	var _pinfo *C.uchar
-	var info_len = ax25_get_info(pp, &_pinfo)
+	var pinfo = ax25_get_info(pp)
 
 	//dw_printf ("DEBUG decode_aprs info=\"%s\"\n", pinfo);
 
 	A.g_quiet = quiet
-
-	var pinfo = C.GoBytes(unsafe.Pointer(_pinfo), info_len)
 
 	if unicode.IsPrint(rune(pinfo[0])) {
 		C.strcpy(&A.g_data_type_desc[0], C.CString(fmt.Sprintf("ERROR!!!  Unknown APRS Data Type Indicator \"%c\"", pinfo[0])))
@@ -762,12 +759,12 @@ func decode_aprs_print(A *decode_aprs_t) {
 		n--
 	}
 	if n > 0 {
-		ax25_safe_print(&A.g_weather[0], -1, 0)
+		ax25_safe_print([]byte(C.GoString(&A.g_weather[0])), 0)
 		dw_printf("\n")
 	}
 
 	if C.strlen(&A.g_telemetry[0]) > 0 {
-		ax25_safe_print(&A.g_telemetry[0], -1, 0)
+		ax25_safe_print([]byte(C.GoString(&A.g_telemetry[0])), 0)
 		dw_printf("\n")
 	}
 
@@ -781,7 +778,7 @@ func decode_aprs_print(A *decode_aprs_t) {
 		n--
 	}
 	if n > 0 {
-		ax25_safe_print(&A.g_comment[0], -1, 0)
+		ax25_safe_print([]byte(C.GoString(&A.g_comment[0])), 0)
 		dw_printf("\n")
 
 		/*

--- a/src/decode_aprs_main.go
+++ b/src/decode_aprs_main.go
@@ -70,7 +70,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"unsafe"
 )
 
 func byteSliceToCUChars(data []byte) []C.uchar {
@@ -107,7 +106,7 @@ func DecodeAPRSLine(line string) {
 	/* Try to process it. */
 
 	fmt.Printf("\n")
-	ax25_safe_print(C.CString(line), -1, 0)
+	ax25_safe_print([]byte(line), 0)
 	fmt.Printf("\n")
 
 	// Do we have monitor format, KISS, or AX.25 frame?
@@ -171,8 +170,6 @@ func DecodeAPRSLine(line string) {
 
 		var pp = ax25_from_frame(bytes, alevel)
 		if pp != nil {
-			var pinfo *C.uchar
-
 			fmt.Printf("--- AX.25 frame ---\n")
 			ax25_hex_dump(pp)
 			fmt.Printf("-------------------\n")
@@ -180,8 +177,8 @@ func DecodeAPRSLine(line string) {
 			var addrs = ax25_format_addrs(pp)
 			fmt.Printf("%s", addrs)
 
-			var info_len = ax25_get_info(pp, &pinfo)
-			ax25_safe_print((*C.char)(unsafe.Pointer(pinfo)), info_len, 1) // Display non-ASCII to hexadecimal.
+			var info = ax25_get_info(pp)
+			ax25_safe_print(info, 1) // Display non-ASCII to hexadecimal.
 			fmt.Printf("\n")
 
 			var A decode_aprs_t

--- a/src/digipeater_test_shim.go
+++ b/src/digipeater_test_shim.go
@@ -42,10 +42,9 @@ func digipeater_test(t *testing.T, in, out string) {
 	var pp = ax25_from_text(in, true)
 	assert.NotNil(t, pp)
 
-	var pinfo *C.uchar
 	var rec = ax25_format_addrs(pp)
-	ax25_get_info(pp, &pinfo)
-	rec += C.GoString((*C.char)(unsafe.Pointer(pinfo)))
+	var pinfo = ax25_get_info(pp)
+	rec += string(pinfo)
 
 	if in != rec {
 		text_color_set(DW_COLOR_ERROR)
@@ -69,8 +68,8 @@ func digipeater_test(t *testing.T, in, out string) {
 	pp = ax25_from_frame(C.GoBytes(unsafe.Pointer(&frame[0]), frame_len), alevel)
 	assert.NotNil(t, pp)
 	rec = ax25_format_addrs(pp)
-	ax25_get_info(pp, &pinfo)
-	rec += C.GoString((*C.char)(unsafe.Pointer(pinfo)))
+	pinfo = ax25_get_info(pp)
+	rec += string(pinfo)
 
 	if in != rec {
 		text_color_set(DW_COLOR_ERROR)
@@ -96,8 +95,8 @@ func digipeater_test(t *testing.T, in, out string) {
 	if result != nil {
 		dedupe_remember(result, 0)
 		xmit = ax25_format_addrs(result)
-		ax25_get_info(result, &pinfo)
-		xmit += C.GoString((*C.char)(unsafe.Pointer(pinfo)))
+		pinfo = ax25_get_info(result)
+		xmit += string(pinfo)
 		ax25_delete(result)
 	}
 

--- a/src/il2p_codec.go
+++ b/src/il2p_codec.go
@@ -67,10 +67,9 @@ func il2p_encode_frame(pp *packet_t, max_fec C.int, iout *C.uchar) C.int {
 		}
 
 		// Payload is AX.25 info part.
-		var pinfo *C.uchar
-		var info_len = ax25_get_info(pp, &pinfo)
+		var pinfo = ax25_get_info(pp)
 
-		var k = il2p_encode_payload(pinfo, info_len, max_fec, (*C.uchar)(unsafe.Add(unsafe.Pointer(iout), out_len)))
+		var k = il2p_encode_payload((*C.uchar)(C.CBytes(pinfo)), C.int(len(pinfo)), max_fec, (*C.uchar)(unsafe.Add(unsafe.Pointer(iout), out_len)))
 		if k > 0 {
 			out_len += k
 			// Success. Info part was <= 1023 bytes.
@@ -191,7 +190,7 @@ func il2p_decode_header_payload(uhdr *C.uchar, epayload *C.uchar, symbols_correc
 				dw_printf("IL2P Internal Error: il2p_decode_header_payload(): hdr_type=%d, max_fec=%d, payload_len=%d, e=%d.\n", hdr_type, max_fec, payload_len, e)
 			}
 
-			ax25_set_info(pp, &extracted[0], payload_len)
+			ax25_set_info(pp, C.GoBytes(unsafe.Pointer(&extracted[0]), payload_len))
 		}
 		return (pp)
 	} else {

--- a/src/il2p_header.go
+++ b/src/il2p_header.go
@@ -393,15 +393,13 @@ func il2p_type_1_header(pp *packet_t, max_fec C.int, hdr *C.uchar) C.int {
 	SET_FEC_LEVEL(hdr, max_fec)
 	SET_HDR_TYPE(hdr, 1)
 
-	var pinfo *C.uchar
-
-	var info_len = ax25_get_info(pp, &pinfo)
-	if info_len < 0 || info_len > IL2P_MAX_PAYLOAD_SIZE {
+	var pinfo = ax25_get_info(pp)
+	if len(pinfo) > IL2P_MAX_PAYLOAD_SIZE {
 		return (-2)
 	}
 
-	SET_PAYLOAD_BYTE_COUNT(hdr, info_len)
-	return (info_len)
+	SET_PAYLOAD_BYTE_COUNT(hdr, C.int(len(pinfo)))
+	return C.int(len(pinfo))
 }
 
 // This should create a packet from the IL2P header.
@@ -549,9 +547,8 @@ func il2p_decode_header_type_1(hdr *C.uchar, num_sym_changed C.int) *packet_t {
 		var modulo = modulo_8
 		var nr = int(control>>3) & 0x07
 		var pf = int(control>>6) & 0x01
-		var pinfo *C.uchar // Any info for SREJ will be added later.
-		var info_len C.int = 0
-		return (ax25_s_frame(addrs, num_addr, cr, ftype, modulo, nr, pf, pinfo, info_len))
+		var pinfo []byte // Any info for SREJ will be added later.
+		return (ax25_s_frame(addrs, num_addr, cr, ftype, modulo, nr, pf, pinfo))
 	} else if pid == 1 {
 
 		// 'U' frame other than 'UI'.
@@ -582,9 +579,8 @@ func il2p_decode_header_type_1(hdr *C.uchar, num_sym_changed C.int) *packet_t {
 			ftype = frame_type_U_TEST
 		}
 		var pf = int(control>>6) & 0x01
-		var pinfo *C.uchar // Any info for UI, XID, TEST will be added later.
-		var info_len C.int = 0
-		return (ax25_u_frame(addrs, num_addr, cr, ftype, pf, axpid, pinfo, info_len))
+		var pinfo []byte // Any info for UI, XID, TEST will be added later.
+		return (ax25_u_frame(addrs, num_addr, cr, ftype, pf, axpid, pinfo))
 	} else if ui != 0 {
 
 		// 'UI' frame.
@@ -595,9 +591,8 @@ func il2p_decode_header_type_1(hdr *C.uchar, num_sym_changed C.int) *packet_t {
 		var ftype = frame_type_U_UI
 		var pf = int(control>>6) & 0x01
 		var axpid = decode_pid(GET_PID(hdr))
-		var pinfo *C.uchar // Any info for UI, XID, TEST will be added later.
-		var info_len C.int = 0
-		return (ax25_u_frame(addrs, num_addr, cr, ftype, pf, int(axpid), pinfo, info_len))
+		var pinfo []byte // Any info for UI, XID, TEST will be added later.
+		return (ax25_u_frame(addrs, num_addr, cr, ftype, pf, int(axpid), pinfo))
 	} else {
 
 		// 'I' frame.
@@ -610,9 +605,8 @@ func il2p_decode_header_type_1(hdr *C.uchar, num_sym_changed C.int) *packet_t {
 		var ns = int(control & 0x7)
 		var modulo = modulo_8
 		var axpid = decode_pid(GET_PID(hdr))
-		var pinfo *C.uchar // Any info for UI, XID, TEST will be added later.
-		var info_len C.int = 0
-		return (ax25_i_frame(addrs, num_addr, cr, modulo, nr, ns, pf, int(axpid), pinfo, info_len))
+		var pinfo []byte // Any info for UI, XID, TEST will be added later.
+		return (ax25_i_frame(addrs, num_addr, cr, modulo, nr, ns, pf, int(axpid), pinfo))
 	}
 } // end
 

--- a/src/il2p_test_shim.go
+++ b/src/il2p_test_shim.go
@@ -584,7 +584,8 @@ func enc_dec_compare(t *testing.T, pp1 *packet_t) {
 			ax25_hex_dump(pp2)
 		}
 
-		assert.True(t, len1 == len2 && C.memcmp(unsafe.Pointer(data1), unsafe.Pointer(data2), C.ulong(len1)) == 0)
+		assert.Equal(t, len1, len2)
+		assert.Equal(t, data1, data2)
 
 		ax25_delete(pp2)
 	}
@@ -594,9 +595,8 @@ func all_frame_types(t *testing.T) {
 	t.Helper()
 
 	var addrs [AX25_MAX_ADDRS][AX25_MAX_ADDR_LEN]C.char
-	var pinfo *C.uchar
+	var pinfo []byte
 	var pid = 0xf0
-	var info_len C.int
 
 	C.strcpy(&addrs[0][0], C.CString("W2UB"))
 	C.strcpy(&addrs[1][0], C.CString("WB2OSZ-12"))
@@ -648,7 +648,7 @@ func all_frame_types(t *testing.T) {
 			for cr := cmin; cr <= cmax; cr++ {
 				dw_printf("\nConstruct U frame, cr=%d, ftype=%d, pid=0x%02x\n", cr, ftype, pid)
 
-				var pp = ax25_u_frame(addrs, num_addr, cr, ftype, pf, pid, pinfo, info_len)
+				var pp = ax25_u_frame(addrs, num_addr, cr, ftype, pf, pid, pinfo)
 				ax25_hex_dump(pp)
 				enc_dec_compare(t, pp)
 				ax25_delete(pp)
@@ -676,7 +676,7 @@ func all_frame_types(t *testing.T) {
 
 				dw_printf("\nConstruct S frame, cmd=%d, ftype=%d, pid=0x%02x\n", cr, ftype, pid)
 
-				var pp = ax25_s_frame(addrs, num_addr, cr, ftype, modulo, nr, pf, nil, 0)
+				var pp = ax25_s_frame(addrs, num_addr, cr, ftype, modulo, nr, pf, nil)
 
 				ax25_hex_dump(pp)
 				enc_dec_compare(t, pp)
@@ -694,7 +694,7 @@ func all_frame_types(t *testing.T) {
 
 				dw_printf("\nConstruct S frame, cmd=%d, ftype=%d, pid=0x%02x\n", cr, ftype, pid)
 
-				var pp = ax25_s_frame(addrs, num_addr, cr, ftype, modulo, nr, pf, nil, 0)
+				var pp = ax25_s_frame(addrs, num_addr, cr, ftype, modulo, nr, pf, nil)
 
 				ax25_hex_dump(pp)
 				enc_dec_compare(t, pp)
@@ -705,7 +705,7 @@ func all_frame_types(t *testing.T) {
 
 	/* SREJ is only S frame which can have information part. */
 
-	var srej_info []C.uchar = []C.uchar{1 << 1, 2 << 1, 3 << 1, 4 << 1}
+	var srej_info = []byte{1 << 1, 2 << 1, 3 << 1, 4 << 1}
 
 	var ftype = frame_type_S_SREJ
 	for pf := 0; pf <= 1; pf++ {
@@ -715,7 +715,7 @@ func all_frame_types(t *testing.T) {
 
 		dw_printf("\nConstruct Multi-SREJ S frame, cmd=%d, ftype=%d, pid=0x%02x\n", cr, ftype, pid)
 
-		var pp = ax25_s_frame(addrs, num_addr, cr, ftype, modulo, nr, pf, &srej_info[0], C.int(len(srej_info)))
+		var pp = ax25_s_frame(addrs, num_addr, cr, ftype, modulo, nr, pf, srej_info)
 
 		ax25_hex_dump(pp)
 		enc_dec_compare(t, pp)
@@ -726,8 +726,7 @@ func all_frame_types(t *testing.T) {
 
 	dw_printf("\nI frames...\n")
 
-	pinfo = (*C.uchar)(unsafe.Pointer(C.strdup(C.CString("The rain in Spain stays mainly on the plain."))))
-	info_len = C.int(C.strlen((*C.char)(unsafe.Pointer(pinfo))))
+	pinfo = []byte("The rain in Spain stays mainly on the plain.")
 
 	for pf := 0; pf <= 1; pf++ {
 		var modulo = modulo_8
@@ -737,7 +736,7 @@ func all_frame_types(t *testing.T) {
 		for cr := cmdres_t(1); cr <= 1; cr++ { // can only be command
 			dw_printf("\nConstruct I frame, cmd=%d, ftype=%d, pid=0x%02x\n", cr, ftype, pid)
 
-			var pp = ax25_i_frame(addrs, num_addr, cr, modulo, nr, ns, pf, pid, pinfo, info_len)
+			var pp = ax25_i_frame(addrs, num_addr, cr, modulo, nr, ns, pf, pid, pinfo)
 
 			ax25_hex_dump(pp)
 			enc_dec_compare(t, pp)
@@ -751,7 +750,7 @@ func all_frame_types(t *testing.T) {
 		for cr := cmdres_t(1); cr <= 1; cr++ {
 			dw_printf("\nConstruct I frame, cmd=%d, ftype=%d, pid=0x%02x\n", cr, ftype, pid)
 
-			var pp = ax25_i_frame(addrs, num_addr, cr, modulo, nr, ns, pf, pid, pinfo, info_len)
+			var pp = ax25_i_frame(addrs, num_addr, cr, modulo, nr, ns, pf, pid, pinfo)
 
 			ax25_hex_dump(pp)
 			enc_dec_compare(t, pp)

--- a/src/il2p_test_util.go
+++ b/src/il2p_test_util.go
@@ -6,10 +6,6 @@ package direwolf
 // #include <assert.h>
 import "C"
 
-import (
-	"unsafe"
-)
-
 /*-------------------------------------------------------------
  *
  * Purpose:	Mock functions for unit tests for IL2P protocol functions.
@@ -53,10 +49,9 @@ func multi_modem_process_rec_packet_fake(channel C.int, subchannel C.int, slice 
 
 	// Does it have the the expected content?
 
-	var pinfo *C.uchar
-	var length = ax25_get_info(pp, &pinfo)
-	Assert(length == C.int(len(text)))
-	Assert(text == C.GoString((*C.char)(unsafe.Pointer(pinfo))))
+	var pinfo = ax25_get_info(pp)
+	Assert(len(text) == len(pinfo))
+	Assert(text == string(pinfo))
 
 	dw_printf("Number of symbols corrected: %d\n", retries)
 	if polarity == 2 { // expecting errors corrected.

--- a/src/kissutil.go
+++ b/src/kissutil.go
@@ -544,15 +544,14 @@ func Kissutil_kiss_process_msg(_kiss_msg unsafe.Pointer, _kiss_len int) {
 			// Like source>dest,digi,...,digi:
 			var addrs = ax25_format_addrs(pp)
 
-			var pinfo *C.uchar
-			var info_len = ax25_get_info(pp, &pinfo)
+			var pinfo = ax25_get_info(pp)
 
 			fmt.Printf("%s %s", prefix, addrs) // [channel] Addresses followed by :
 
 			// Safe print will replace any unprintable characters with
 			// hexadecimal representation.
 
-			ax25_safe_print((*C.char)(unsafe.Pointer(pinfo)), info_len, 0)
+			ax25_safe_print(pinfo, 0)
 			fmt.Printf("\n")
 
 			/*
@@ -568,7 +567,7 @@ func Kissutil_kiss_process_msg(_kiss_msg unsafe.Pointer, _kiss_len int) {
 
 				fmt.Printf("Save received frame to %s\n", fullpath)
 
-				var content = fmt.Sprintf("%s %s%s\n", prefix, addrs, C.GoString((*C.char)(unsafe.Pointer(pinfo))))
+				var content = fmt.Sprintf("%s %s%s\n", prefix, addrs, string(pinfo))
 				var err = os.WriteFile(fullpath, []byte(content), 0644)
 
 				if err != nil {

--- a/src/pfilter.go
+++ b/src/pfilter.go
@@ -602,11 +602,15 @@ func parse_filter_spec(pf *pfstate_t) C.int {
 		result = filt_t(pf)
 
 		if pfilter_debug >= 2 {
-			var infop *C.uchar
-			ax25_get_info(pf.pp, &infop)
+			var infop = ax25_get_info(pf.pp)
 
-			text_color_set(DW_COLOR_DEBUG)
-			dw_printf("   %s returns %s for %c data type indicator\n", pf.token_str, bool2text(result), *infop)
+			if len(infop) > 0 {
+				text_color_set(DW_COLOR_DEBUG)
+				dw_printf("   %s returns %s for %c data type indicator\n", pf.token_str, bool2text(result), infop[0])
+			} else {
+				text_color_set(DW_COLOR_DEBUG)
+				dw_printf("   %s returns %s for empty info part\n", pf.token_str, bool2text(result))
+			}
 		}
 	} else if pf.token_str[0] == 'r' && unicode.IsPunct(rune(pf.token_str[1])) {
 		/* r - range */
@@ -639,9 +643,6 @@ func parse_filter_spec(pf *pfstate_t) C.int {
 		result = filt_i(pf)
 
 		if pfilter_debug >= 2 {
-			var infop *C.uchar
-			ax25_get_info(pf.pp, &infop)
-
 			text_color_set(DW_COLOR_DEBUG)
 			if pf.decoded.g_packet_type == packet_type_message {
 				dw_printf("   %s returns %s for message to %s\n", pf.token_str, bool2text(result), C.GoString(&pf.decoded.g_addressee[0]))
@@ -747,10 +748,9 @@ func filt_t(pf *pfstate_t) C.int {
 
 	// TODO KG Why was this here? var src = ax25_get_addr_with_ssid(pf.pp, AX25_SOURCE)
 
-	var infop *C.uchar
-	ax25_get_info(pf.pp, (&infop))
+	var infop = ax25_get_info(pf.pp)
 
-	Assert(infop != nil)
+	Assert(len(infop) > 0)
 
 	for _, f := range pf.token_str[2:] {
 		switch f {

--- a/src/tq.go
+++ b/src/tq.go
@@ -25,7 +25,6 @@ import "C"
 import (
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/lestrrat-go/strftime"
 )
@@ -197,22 +196,21 @@ func tq_append(channel C.int, prio C.int, pp *packet_t) {
 
 		// Formated addresses.
 		var stemp = ax25_format_addrs(pp)
-		var pinfo *C.uchar
-		var info_len = ax25_get_info(pp, &pinfo)
+		var pinfo = ax25_get_info(pp)
 		text_color_set(DW_COLOR_XMIT)
 
 		if save_audio_config_p.chan_medium[channel] == MEDIUM_IGATE {
 
 			dw_printf("[%d>is%s] ", channel, ts)
 			dw_printf("%s", stemp) /* stations followed by : */
-			ax25_safe_print((*C.char)(unsafe.Pointer(pinfo)), info_len, bool2Cint(!ax25_is_aprs(pp)))
+			ax25_safe_print(pinfo, bool2Cint(!ax25_is_aprs(pp)))
 			dw_printf("\n")
 
 			igate_send_rec_packet(int(channel), pp)
 		} else { // network TNC
 			dw_printf("[%d>nt%s] ", channel, ts)
 			dw_printf("%s", stemp) /* stations followed by : */
-			ax25_safe_print((*C.char)(unsafe.Pointer(pinfo)), info_len, bool2Cint(!ax25_is_aprs(pp)))
+			ax25_safe_print(pinfo, bool2Cint(!ax25_is_aprs(pp)))
 			dw_printf("\n")
 
 			nettnc_send_packet(channel, pp)

--- a/src/ttcalc_main.go
+++ b/src/ttcalc_main.go
@@ -111,16 +111,15 @@ func TTCalcMain() {
 
 			var result = ax25_format_addrs(pp)
 
-			var pinfo *C.uchar
-			ax25_get_info(pp, &pinfo)
+			var pinfo = ax25_get_info(pp)
 
-			fmt.Printf("[%d] %s%s\n", channel, result, C.GoString((*C.char)(unsafe.Pointer(pinfo))))
+			fmt.Printf("[%d] %s%s\n", channel, result, string(pinfo))
 
 			/*
 			 * Look for Special touch tone packet with "t" in first position of the Information part.
 			 */
 
-			if *pinfo == 't' {
+			if len(pinfo) > 0 && pinfo[0] == 't' {
 				/*
 				 * Send touch tone sequence to calculator and get the answer.
 				 *
@@ -128,7 +127,7 @@ func TTCalcMain() {
 				 *
 				 *  http://www.tapr.org/pipermail/aprssig/2015-January/044069.html
 				 */
-				var n = calculator(C.GoString((*C.char)(unsafe.Pointer(pinfo)))[1:])
+				var n = calculator(string(pinfo[1:]))
 				fmt.Printf("\nCalculator returns %d\n\n", n)
 
 				/*


### PR DESCRIPTION
This became much bigger than expected, because it felt easier to pass
more things byte slices than go to the faff of converting now only to
port later

Fun side-effect: I got to rip out a *lot* of "unsafe" imports!
