### PR TITLE
refactor: Use Go types in ais.go

### DIFF
--- a/src/ais_test_shim.go
+++ b/src/ais_test_shim.go
@@ -1,8 +1,5 @@
 package direwolf
 
-// #include <stdio.h>
-import "C"
-
 import (
 	"testing"
 
@@ -11,8 +8,6 @@ import (
 
 func ais_test_main(t *testing.T) {
 	t.Helper()
-
-	C.setlinebuf(C.stdout) // Hacks to get dw_printf output when things go wrong
 
 	test_sextet(t)
 	test_basic_parse(t)
@@ -31,18 +26,13 @@ func test_basic_parse(t *testing.T) {
 
 	var ais = "!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0*4E" // Example from https://www.aggsoft.com/ais-decoder.htm
 
-	var descr, mssi, comment [256]C.char
-	var lat, lon C.double
-	var knots, course, alt_m C.float
-	var symtab, symbol C.char
+	var aisData, status = ais_parse(ais, false)
 
-	var status = ais_parse(C.CString(ais), 0, &descr[0], C.int(len(descr)), &mssi[0], C.int(len(mssi)), &lat, &lon, &knots, &course, &alt_m, &symtab, &symbol, &comment[0], C.int(len(comment)))
-
-	assert.Equal(t, C.int(0), status)
-	assert.Equal(t, "AIS 1: Position Report Class A", C.GoString(&descr[0]))
-	assert.Equal(t, "366730000", C.GoString(&mssi[0]))
-	assert.Empty(t, C.GoString(&comment[0]))
-	assert.InDelta(t, -122, float64(lon), 1)
-	assert.InDelta(t, 20.8, float64(knots), 1)
-	assert.InDelta(t, 51.3, float64(course), 1)
+	assert.Equal(t, 0, status)
+	assert.Equal(t, "AIS 1: Position Report Class A", aisData.description)
+	assert.Equal(t, "366730000", aisData.mssi)
+	assert.Empty(t, aisData.comment)
+	assert.InDelta(t, -122, aisData.lon, 1)
+	assert.InDelta(t, 20.8, aisData.knots, 1)
+	assert.InDelta(t, 51.3, aisData.course, 1)
 }


### PR DESCRIPTION
A bunch of nolints to ignore G115 int truncation warnings - I don't love
this, but it shouldn't be materially harmful (just reporting / display
issues) and is probably more about me not quite getting the types right
than actual material problems, but I'm not about to sit down with the
AIS spec right now to try to get it perfect
