### PR TITLE
test(feature): Allow env overrides for ATEST/GEN_PACKETS in test-scripts

### DIFF
--- a/test-scripts/common
+++ b/test-scripts/common
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-ATEST="$(dirname "$(realpath "$0")")/../dist/samoyed-atest"
+ATEST="${ATEST:-$(dirname "$(realpath "$0")")/../dist/samoyed-atest}"
 export ATEST
 
-FXSEND="$(dirname "$(realpath "$0")")/../dist/samoyed-fxsend"
+FXSEND="${FXSEND:-$(dirname "$(realpath "$0")")/../dist/samoyed-fxsend}"
 export FXSEND
-FXREC="$(dirname "$(realpath "$0")")/../dist/samoyed-fxrec"
+FXREC="${FXREC:-$(dirname "$(realpath "$0")")/../dist/samoyed-fxrec}"
 export FXREC
 
-GEN_PACKETS="$(dirname "$(realpath "$0")")/../dist/samoyed-gen_packets"
+GEN_PACKETS="${GEN_PACKETS:-$(dirname "$(realpath "$0")")/../dist/samoyed-gen_packets}"
 export GEN_PACKETS
 
 function goto_tmpdir() {


### PR DESCRIPTION
Now you can easily compare against direwolf with:

$ ATEST=atest ./test-scripts/check-fx25

or

$ GEN_PACKETS=../direwolf/build/src/gen_packets ./test-scripts/runall
