### PR TITLE
build(test): Run `go test` with `-v` for more timing info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test: gotest test-scripts
 
 .PHONY: gotest
 gotest:
-	go test -cover -coverpkg=./cmd/...,./src/... -coverprofile $(COVERAGE_FILE) $(SRC_DIRS)  # TODO Construct coverpkg from $SRC_DIRS
+	go test -cover -coverpkg=./cmd/...,./src/... -coverprofile $(COVERAGE_FILE) -v $(SRC_DIRS)  # TODO Construct coverpkg from $SRC_DIRS
 
 # TODO Better output name, non-PHONY target, docs, etc.
 .PHONY: gotest-bin


### PR DESCRIPTION
Also more delineation, which is great because they're all super noisy!
