### PR TITLE
test: Stop sleeping for 30s in tt_user tests

### DIFF
--- a/src/tt_user_test_shim.go
+++ b/src/tt_user_test_shim.go
@@ -68,9 +68,4 @@ func tt_user_test_main(t *testing.T) {
 	tt_user_heard("WB1GOF", 12, 'J', 'A', "", G_UNKNOWN, G_UNKNOWN, 0, "146.955MHz", "074", "", ' ', "!T99!")
 	tt_user_heard("679", 12, 'J', 'A', "", G_UNKNOWN, G_UNKNOWN, 0, "", "", "Hello, world", '9', "!T99!")
 	tt_user_dump()
-
-	for range 30 {
-		SLEEP_SEC(1)
-		tt_user_background()
-	}
 }


### PR DESCRIPTION
I can see the value in making repeated periodic calls to
tt_user_background, but I'm not sure it really tested much, and it's a
1m30 test run locally

At some point let's reinstate this with some proper time fiddling and
faking etc., but for now, let's just drop it and cut our test runs by
33%(!)
