### PR TITLE
refactor: Use PortAudio via Go bindings for sound

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
         echo "Version: $SAMOYED_VERSION"
         echo "SAMOYED_VERSION=$SAMOYED_VERSION" >> $GITHUB_OUTPUT  # Output to be used by the release job
         echo "SAMOYED_VERSION=$SAMOYED_VERSION" >> $GITHUB_ENV  # Env to be used by the make build
-    - run: "sudo apt update && sudo apt install --yes libudev-dev libhamlib-dev libasound2-dev libavahi-client-dev libbsd-dev libgps-dev"
+    - run: "sudo apt update && sudo apt install --yes libudev-dev libhamlib-dev portaudio19-dev libavahi-client-dev libbsd-dev libgps-dev"
     - run: "sudo apt install --yes morse2ascii"  # For decoding the morse
     - run: "make stats"
     - run: "make cmds"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/brutella/dnssd v1.2.14
 	github.com/creack/pty v1.1.24
 	github.com/golang/geo v0.0.0-20180826223333-635502111454
+	github.com/gordonklaus/portaudio v0.0.0-20250206071425-98a94950218b
 	github.com/jochenvg/go-udev v0.0.0-20240801134859-b65ed646224b
 	github.com/lestrrat-go/strftime v1.1.1
 	github.com/pkg/term v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/geo v0.0.0-20180826223333-635502111454 h1:UiKw4ZsXdOM6qRj2nP54DJY6Mp3Vd+aSu1OhPvPR+94=
 github.com/golang/geo v0.0.0-20180826223333-635502111454/go.mod h1:vgWZ7cu0fq0KY3PpEHsocXOWJpRtkcbKemU4IUw0M60=
+github.com/gordonklaus/portaudio v0.0.0-20250206071425-98a94950218b h1:WEuQWBxelOGHA6z9lABqaMLMrfwVyMdN3UgRLT+YUPo=
+github.com/gordonklaus/portaudio v0.0.0-20250206071425-98a94950218b/go.mod h1:esZFQEUwqC+l76f2R8bIWSwXMaPbp79PppwZ1eJhFco=
 github.com/jkeiser/iter v0.0.0-20200628201005-c8aa0ae784d1 h1:smvLGU3obGU5kny71BtE/ibR0wIXRUiRFDmSn0Nxz1E=
 github.com/jkeiser/iter v0.0.0-20200628201005-c8aa0ae784d1/go.mod h1:fP/NdyhRVOv09PLRbVXrSqHhrfQypdZwgE2L4h2U5C8=
 github.com/jochenvg/go-udev v0.0.0-20240801134859-b65ed646224b h1:Pzf7tldbCVqwl3NnOnTamEWdh/rL41fsoYCn2HdHgRA=

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -17,8 +17,7 @@ package direwolf
 // #include <sys/socket.h>
 // #include <netinet/in.h>
 // #include <netdb.h>
-// #cgo pkg-config: alsa
-// #cgo CFLAGS: -DUSE_CM108 -DUSE_ALSA
+// #cgo CFLAGS: -DUSE_CM108
 // #cgo LDFLAGS: -lm
 import "C"
 


### PR DESCRIPTION
This drops a direct cgo dependency and hopefully unlocks more cross-platform support when I go back to that