### PR TITLE
feat: Add BPSK support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters:
     exhaustive:
       default-signifies-exhaustive: true  # Soften the check for now...
     gocognit:
-      min-complexity: 1792  # I sure wish this could be lower
+      min-complexity: 1800  # I sure wish this could be lower
     goconst:
       min-occurrences: 10
     gocritic:

--- a/src/atest.go
+++ b/src/atest.go
@@ -157,6 +157,7 @@ func AtestMain() {
 AIS for ship Automatic Identification System.
 EAS for Emergency Alert System (EAS) Specific Area Message Encoding (SAME).`)
 	var g3ruh = pflag.BoolP("g3ruh", "g", false, "Use G3RUH modem rather than default for data rate.")
+	var bpsk = pflag.BoolP("bpsk", "k", false, "Use BPSK modem rather than default for data rate.")
 	var direwolf15compat = pflag.BoolP("direwolf-15-compat", "j", false, "2400 bps QPSK compatible with direwolf <= 1.5.")
 	var mfj2400compat = pflag.BoolP("mfj-2400-compat", "J", false, "2400 bps QPSK compatible with MFJ-2400.")
 	var modemProfile = pflag.StringP("modem-profile", "P", "", "Select the demodulator type such as D (default for 300 bps), E+ (default for 1200 bps), PQRS for 2400 bps, etc.")
@@ -376,6 +377,13 @@ o = DCD output control
 		my_audio_config.achan[0].mark_freq = 0
 		my_audio_config.achan[0].space_freq = 0
 		my_audio_config.achan[0].profiles = " " // avoid getting default later.
+	}
+
+	if *bpsk {
+		my_audio_config.achan[0].modem_type = MODEM_BPSK
+		my_audio_config.achan[0].mark_freq = 0
+		my_audio_config.achan[0].space_freq = 0
+		my_audio_config.achan[0].profiles = ""
 	}
 
 	/*

--- a/src/audio.go
+++ b/src/audio.go
@@ -123,6 +123,7 @@ const (
 	MODEM_64_QAM
 	MODEM_AIS
 	MODEM_EAS
+	MODEM_BPSK
 )
 
 type layer2_t int

--- a/src/config.go
+++ b/src/config.go
@@ -1717,6 +1717,10 @@ func config_init(fname string, p_audio_config *audio_s,
 
 							p_audio_config.achan[channel].offset = 50
 						}
+					} else if strings.EqualFold(t, "BPSK") { /* Force BPSK modem (1 bit/symbol, carrier 1800 Hz). */
+						p_audio_config.achan[channel].modem_type = MODEM_BPSK
+						p_audio_config.achan[channel].mark_freq = 0
+						p_audio_config.achan[channel].space_freq = 0
 					} else if alllettersorpm(t) { /* profile of letter(s) + - */
 						// Will be validated later.
 						p_audio_config.achan[channel].profiles = t

--- a/src/config.go
+++ b/src/config.go
@@ -1721,9 +1721,21 @@ func config_init(fname string, p_audio_config *audio_s,
 						p_audio_config.achan[channel].modem_type = MODEM_BPSK
 						p_audio_config.achan[channel].mark_freq = 0
 						p_audio_config.achan[channel].space_freq = 0
-					} else if alllettersorpm(t) { /* profile of letter(s) + - */
-						// Will be validated later.
-						p_audio_config.achan[channel].profiles = t
+					} else if strings.EqualFold(t, "G3RUH") { /* Force G3RUH modem regardless of default for speed. New in 1.6. */
+						p_audio_config.achan[channel].modem_type = MODEM_SCRAMBLE
+						p_audio_config.achan[channel].mark_freq = 0
+						p_audio_config.achan[channel].space_freq = 0
+					} else if strings.EqualFold(t, "V26A") || /* Compatible with direwolf versions <= 1.5.  New in 1.6. */
+						strings.EqualFold(t, "V26B") { /* Compatible with MFJ-2400.  New in 1.6. */
+						if p_audio_config.achan[channel].modem_type != MODEM_QPSK ||
+							p_audio_config.achan[channel].baud != 2400 {
+							text_color_set(DW_COLOR_ERROR)
+							dw_printf("Line %d: %s option can only be used with 2400 bps PSK.\n", line, t)
+
+							continue
+						}
+
+						p_audio_config.achan[channel].v26_alternative = IfThenElse((strings.EqualFold(t, "V26A")), V26_A, V26_B)
 					} else if t[0] == '/' { /* /div */
 						var n, _ = strconv.Atoi(t[1:])
 
@@ -1742,21 +1754,9 @@ func config_init(fname string, p_audio_config *audio_s,
 							text_color_set(DW_COLOR_ERROR)
 							dw_printf("Line %d: Ignoring unreasonable upsample ratio of %d.\n", line, n)
 						}
-					} else if strings.EqualFold(t, "G3RUH") { /* Force G3RUH modem regardless of default for speed. New in 1.6. */
-						p_audio_config.achan[channel].modem_type = MODEM_SCRAMBLE
-						p_audio_config.achan[channel].mark_freq = 0
-						p_audio_config.achan[channel].space_freq = 0
-					} else if strings.EqualFold(t, "V26A") || /* Compatible with direwolf versions <= 1.5.  New in 1.6. */
-						strings.EqualFold(t, "V26B") { /* Compatible with MFJ-2400.  New in 1.6. */
-						if p_audio_config.achan[channel].modem_type != MODEM_QPSK ||
-							p_audio_config.achan[channel].baud != 2400 {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: %s option can only be used with 2400 bps PSK.\n", line, t)
-
-							continue
-						}
-
-						p_audio_config.achan[channel].v26_alternative = IfThenElse((strings.EqualFold(t, "V26A")), V26_A, V26_B)
+					} else if alllettersorpm(t) { /* profile of letter(s) + - */
+						// Will be validated later.
+						p_audio_config.achan[channel].profiles = t
 					} else {
 						text_color_set(DW_COLOR_ERROR)
 						dw_printf("Line %d: Unrecognized option for MODEM: %s\n", line, t)

--- a/src/demod.go
+++ b/src/demod.go
@@ -560,7 +560,50 @@ func demod_init(pa *audio_s) int {
 					D.sluggish_decay = 0.00012 * 0.2
 				}
 
-				//TODO: how about MODEM_OFF case?
+			case MODEM_BPSK:
+				if save_audio_config_p.achan[channel].profiles == "" {
+					save_audio_config_p.achan[channel].profiles = "LMNO"
+				}
+
+				save_audio_config_p.achan[channel].num_subchan = len(save_audio_config_p.achan[channel].profiles)
+
+				save_audio_config_p.achan[channel].decimate = 1
+
+				text_color_set(DW_COLOR_DEBUG)
+				dw_printf("Channel %d: %d bps, BPSK, %s, %d sample rate",
+					channel, save_audio_config_p.achan[channel].baud,
+					save_audio_config_p.achan[channel].profiles,
+					save_audio_config_p.adev[ACHAN2ADEV(channel)].samples_per_sec)
+
+				if save_audio_config_p.achan[channel].decimate != 1 {
+					dw_printf(" / %d", save_audio_config_p.achan[channel].decimate)
+				}
+
+				dw_printf(", Tx %s", layer2_tx[(int)(save_audio_config_p.achan[channel].layer2_xmit)])
+
+				if save_audio_config_p.achan[channel].dtmf_decode != DTMF_DECODE_OFF {
+					dw_printf(", DTMF decoder enabled")
+				}
+
+				dw_printf(".\n")
+
+				for d := 0; d < save_audio_config_p.achan[channel].num_subchan; d++ {
+					Assert(d >= 0 && d < MAX_SUBCHANS)
+					var D = &demodulator_state[channel][d]
+					var profile = save_audio_config_p.achan[channel].profiles[d]
+
+					demod_psk_init(save_audio_config_p.achan[channel].modem_type,
+						V26_UNSPECIFIED,
+						save_audio_config_p.adev[ACHAN2ADEV(channel)].samples_per_sec/save_audio_config_p.achan[channel].decimate,
+						save_audio_config_p.achan[channel].baud,
+						rune(profile),
+						D)
+
+					D.quick_attack = 0.080 * 0.2
+					D.sluggish_decay = 0.00012 * 0.2
+				}
+
+			//TODO: how about MODEM_OFF case?
 
 			default: /* Not AFSK */
 				/*
@@ -901,7 +944,7 @@ func demod_process_sample(channel int, subchan int, sam int) {
 			demod_afsk_process_sample(channel, subchan, sam, D)
 		}
 
-	case MODEM_QPSK, MODEM_8PSK:
+	case MODEM_QPSK, MODEM_8PSK, MODEM_BPSK:
 		if save_audio_config_p.achan[channel].decimate > 1 {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Invalid combination of options.  Exiting.\n")
@@ -951,7 +994,7 @@ func demod_get_audio_level_real(channel int, subchan int) alevel_t {
 		/* For AFSK, we have mark and space amplitudes. */
 		alevel.mark = (int)((D.alevel_mark_peak)*100.0 + 0.5)
 		alevel.space = (int)((D.alevel_space_peak)*100.0 + 0.5)
-	case MODEM_QPSK, MODEM_8PSK:
+	case MODEM_QPSK, MODEM_8PSK, MODEM_BPSK:
 		alevel.mark = -1
 		alevel.space = -1
 	default:

--- a/src/demod_psk.go
+++ b/src/demod_psk.go
@@ -66,7 +66,7 @@ import (
 var DCD_CONFIG_PSK = &DCDConfig{
 	DCD_THRESH_ON:  30, // Hysteresis: Can miss 2 out of 32 for detecting lock.
 	DCD_THRESH_OFF: 6,  // Might want a little more fine tuning.
-	DCD_GOOD_WIDTH: 512,
+	DCD_GOOD_WIDTH: 1024,
 }
 
 /* TODO KG
@@ -79,6 +79,7 @@ var DCD_CONFIG_PSK = &DCDConfig{
 	} }
 */
 
+var phase_to_gray_bpsk = [2]int{0, 1}
 var phase_to_gray_v26 = [4]int{0, 1, 3, 2}
 var phase_to_gray_v27 = [8]int{1, 0, 2, 3, 7, 6, 4, 5}
 
@@ -91,7 +92,7 @@ var phase_to_gray_v27 = [8]int{1, 0, 2, 3, 7, 6, 4, 5}
  * Purpose:     Initialization for a PSK demodulator.
  *		Select appropriate parameters and set up filters.
  *
- * Inputs:   	modem_type	- MODEM_QPSK or MODEM_8PSK.
+ * Inputs:   	modem_type	- MODEM_QPSK or MODEM_8PSK or MODEM_BPSK.
  *
  *		v26_alt		- V26_A (classic) or V26_B (MFJ compatible)
  *
@@ -110,6 +111,10 @@ var phase_to_gray_v27 = [8]int{1, 0, 2, 3, 7, 6, 4, 5}
  *				  For 8-PSK:
  *
  *					T, U, V, W  same as above.
+ *
+ *                For BPSK:
+ *
+ *					L, M, N, O  same as above.
  *
  *		D		- Pointer to demodulator state for given channel.
  *
@@ -140,7 +145,74 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
 	var correct_baud int // baud is not same as bits/sec here!
 	var carrier_freq int
 
-	if modem_type == MODEM_QPSK {
+	if modem_type == MODEM_BPSK {
+		correct_baud = bps // 1 bit per symbol
+		carrier_freq = 1800
+
+		switch unicode.ToUpper(profile) {
+		case 'L': /* Self correlation technique. */
+			D.u.psk.use_prefilter = 0 /* No bandpass filter. */
+
+			D.u.psk.lpf_baud = 0.60
+			D.u.psk.lp_filter_width_sym = 1.061
+			D.u.psk.lp_window = BP_WINDOW_COSINE
+
+			D.pll_locked_inertia = 0.95
+			D.pll_searching_inertia = 0.50
+
+		case 'M': /* Self correlation technique. */
+			D.u.psk.use_prefilter = 1 /* Add a bandpass filter. */
+			D.u.psk.prefilter_baud = 1.3
+			D.u.psk.pre_filter_width_sym = 1.497
+			D.u.psk.pre_window = BP_WINDOW_COSINE
+
+			D.u.psk.lpf_baud = 0.60
+			D.u.psk.lp_filter_width_sym = 1.061
+			D.u.psk.lp_window = BP_WINDOW_COSINE
+
+			D.pll_locked_inertia = 0.87
+			D.pll_searching_inertia = 0.50
+
+		default: //nolint: gocritic
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Invalid demodulator profile %c for BPSK.  Valid choices are L, M, N, O.  Using default.\n", profile)
+
+			fallthrough
+
+		case 'N': /* Mix with local oscillator. */
+			D.u.psk.psk_use_lo = 1
+
+			D.u.psk.use_prefilter = 0 /* No bandpass filter. */
+
+			D.u.psk.lpf_baud = 0.55 // tightened from 0.70; BPSK signal bandwidth is baud/2, 0.55 gives modest margin with less noise
+			D.u.psk.lp_filter_width_sym = 1.007
+			D.u.psk.lp_window = BP_WINDOW_TRUNCATED
+
+			D.pll_locked_inertia = 0.925
+			D.pll_searching_inertia = 0.50
+
+		case 'O': /* Mix with local oscillator. */
+			D.u.psk.psk_use_lo = 1
+
+			D.u.psk.use_prefilter = 1    /* Add a bandpass filter. */
+			D.u.psk.prefilter_baud = 1.0 // was 0.55 (copied from QPSK S profile where correct_baud=bps/2); BPSK main lobe spans ±baud, so ±0.55*baud caused ISI at 300 baud
+			D.u.psk.pre_filter_width_sym = 2.014
+			D.u.psk.pre_window = BP_WINDOW_FLATTOP
+
+			D.u.psk.lpf_baud = 0.60
+			D.u.psk.lp_filter_width_sym = 1.061
+			D.u.psk.lp_window = BP_WINDOW_COSINE
+
+			D.pll_locked_inertia = 0.925
+			D.pll_searching_inertia = 0.50
+		}
+
+		D.u.psk.delay_line_width_sym = 1.25
+
+		D.u.psk.coffs = int(math.Round((11.0 / 12.0) * samples_per_sec / float64(correct_baud)))
+		D.u.psk.boffs = int(math.Round(samples_per_sec / float64(correct_baud)))
+		D.u.psk.soffs = int(math.Round((13.0 / 12.0) * samples_per_sec / float64(correct_baud)))
+	} else if modem_type == MODEM_QPSK {
 		Assert(D.u.psk.v26_alt != V26_UNSPECIFIED)
 
 		correct_baud = bps / 2
@@ -492,23 +564,23 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
  *
  * Name:        phase_shift_to_symbol
  *
- * Purpose:     Translate phase shift, between two symbols, into 2 or 3 bits.
+ * Purpose:     Translate phase shift, between two symbols, into some bits.
  *
  * Inputs:	phase_shift	- in radians.
  *
- *		bits_per_symbol	- 2 for QPSK, 3 for 8PSK.
+ *		bits_per_symbol	- 1 for BPSK, 2 for QPSK, 3 for 8PSK.
  *
  * Outputs:	bit_quality[]	- Value of 0 (at threshold) to 100 (perfect) for each bit.
  *
- * Returns:	2 or 3 bit symbol value in Gray code.
+ * Returns:	1-3 bit symbol value in Gray code.
  *
  *--------------------------------------------------------------------*/
 
 func phase_shift_to_symbol(phase_shift float64, bits_per_symbol int, bit_quality []int) int {
 	// Number of different symbol states.
-	Assert(bits_per_symbol == 2 || bits_per_symbol == 3)
+	Assert(bits_per_symbol == 1 || bits_per_symbol == 2 || bits_per_symbol == 3)
 	var N = 1 << bits_per_symbol
-	Assert(N == 4 || N == 8)
+	Assert(N == 2 || N == 4 || N == 8)
 
 	// Scale angle to 1 per symbol then separate into integer and fractional parts.
 	var a = phase_shift * float64(N) / (math.Pi * 2.0)
@@ -533,9 +605,13 @@ func phase_shift_to_symbol(phase_shift float64, bits_per_symbol int, bit_quality
 
 	for b := range bits_per_symbol {
 		var demod float64
-		if bits_per_symbol == 2 {
+
+		switch bits_per_symbol {
+		case 1:
+			demod = float64((phase_to_gray_bpsk[i]>>b)&1)*(1.0-f) + float64((phase_to_gray_bpsk[(i+1)&1]>>b)&1)*f
+		case 2:
 			demod = float64((phase_to_gray_v26[i]>>b)&1)*(1.0-f) + float64((phase_to_gray_v26[(i+1)&3]>>b)&1)*f
-		} else {
+		default:
 			demod = float64((phase_to_gray_v27[i]>>b)&1)*(1.0-f) + float64((phase_to_gray_v27[(i+1)&7]>>b)&1)*f
 		}
 		// Slice to get boolean value and quality measurement.
@@ -645,13 +721,16 @@ func demod_psk_process_sample(channel int, subchannel int, sam int, D *demodulat
 		var gray int
 		var bit_quality [3]int
 
-		if D.modem_type == MODEM_QPSK {
+		switch D.modem_type {
+		case MODEM_BPSK:
+			gray = phase_shift_to_symbol(delta, 1, bit_quality[:]) // BPSK
+		case MODEM_QPSK:
 			if D.u.psk.v26_alt == V26_B {
 				gray = phase_shift_to_symbol(delta+(-math.Pi/4), 2, bit_quality[:]) // MFJ compatible
 			} else {
 				gray = phase_shift_to_symbol(delta, 2, bit_quality[:]) // Classic
 			}
-		} else {
+		default:
 			gray = phase_shift_to_symbol(delta, 3, bit_quality[:]) // 8-PSK
 		}
 
@@ -676,13 +755,16 @@ func demod_psk_process_sample(channel int, subchannel int, sam int, D *demodulat
 		var bit_quality [3]int
 		var delta = float64(math.Atan2(float64(I), float64(Q)))
 
-		if D.modem_type == MODEM_QPSK {
+		switch D.modem_type {
+		case MODEM_BPSK:
+			gray = phase_shift_to_symbol(delta+float64(math.Pi/2), 1, bit_quality[:]) // BPSK
+		case MODEM_QPSK:
 			if D.u.psk.v26_alt == V26_B {
 				gray = phase_shift_to_symbol(delta+float64(math.Pi/2), 2, bit_quality[:]) // MFJ compatible
 			} else {
 				gray = phase_shift_to_symbol(delta+float64(3*math.Pi/4), 2, bit_quality[:]) // Classic
 			}
-		} else {
+		default:
 			gray = phase_shift_to_symbol(delta+(3*math.Pi/2), 3, bit_quality[:])
 		}
 
@@ -724,14 +806,20 @@ func nudge_pll_psk(channel int, subchannel int, slice int, demod_bits int, D *de
 	if D.slicer[slice].data_clock_pll < 0 && D.slicer[slice].prev_d_c_pll >= 0 {
 		/* Overflow of PLL counter. */
 		/* This is where we sample the data. */
-		if D.modem_type == MODEM_QPSK {
+		switch D.modem_type {
+		case MODEM_BPSK:
+			var gray = demod_bits
+
+			hdlc_rec_bit_new(channel, subchannel, slice, gray&1, false, bit_quality[0],
+				&(D.slicer[slice].pll_nudge_total), &(D.slicer[slice].pll_symbol_count))
+		case MODEM_QPSK:
 			var gray = demod_bits
 
 			hdlc_rec_bit_new(channel, subchannel, slice, (gray>>1)&1, false, bit_quality[1],
 				&(D.slicer[slice].pll_nudge_total), &(D.slicer[slice].pll_symbol_count))
 			hdlc_rec_bit_new(channel, subchannel, slice, gray&1, false, bit_quality[0],
 				&(D.slicer[slice].pll_nudge_total), &(D.slicer[slice].pll_symbol_count))
-		} else {
+		default:
 			var gray = demod_bits
 
 			hdlc_rec_bit_new(channel, subchannel, slice, (gray>>2)&1, false, bit_quality[2],

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -90,6 +90,7 @@ func DirewolfMain() {
 AIS for ship Automatic Identification System.
 EAS for Emergency Alert System (EAS) Specific Area Message Encoding (SAME).`)
 	var g3ruh = pflag.BoolP("g3ruh", "g", false, "Use G3RUH modem rather than default for data rate.")
+	var bpsk = pflag.BoolP("bpsk", "k", false, "Use BPSK modem rather than default for data rate.")
 	var direwolf15compat = pflag.BoolP("direwolf-15-compat", "j", false, "2400 bps QPSK compatible with direwolf <= 1.5.")
 	var mfj2400compat = pflag.BoolP("mfj-2400-compat", "J", false, "2400 bps QPSK compatible with MFJ-2400.")
 	var modemProfile = pflag.StringP("modem-profile", "P", "", "Select the modem type such as D (default for 300 bps), E+ (default for 1200 bps), PQRS for 2400 bps, etc.")
@@ -389,6 +390,14 @@ x = Silence FX.25 information.`)
 		// Force G3RUH mode, overriding default for speed.
 		//   Example:   -B 2400 -g
 		audio_config.achan[0].modem_type = MODEM_SCRAMBLE
+		audio_config.achan[0].mark_freq = 0
+		audio_config.achan[0].space_freq = 0
+	}
+
+	if *bpsk {
+		// Force BPSK mode, overriding default for speed.
+		//   Example:   -B 300 -k
+		audio_config.achan[0].modem_type = MODEM_BPSK
 		audio_config.achan[0].mark_freq = 0
 		audio_config.achan[0].space_freq = 0
 	}

--- a/src/gen_packets.go
+++ b/src/gen_packets.go
@@ -140,6 +140,7 @@ AIS for ship Automatic Identification System.
 EAS for Emergency Alert System (EAS) Specific Area Message Encoding (SAME).`)
 	var bitrateOverrideStr = pflag.StringP("bitrate-override", "b", "", "Bits / second for data.")
 	var g3ruh = pflag.BoolP("g3ruh", "g", false, "Use G3RUH modem rather than default for data rate.")
+	var bpsk = pflag.BoolP("bpsk", "k", false, "Use BPSK modem rather than default for data rate.")
 	var direwolf15compat = pflag.BoolP("direwolf-15-compat", "j", false, "2400 bps QPSK compatible with direwolf <= 1.5.")
 	var mfj2400compat = pflag.BoolP("mfj-2400-compat", "J", false, "2400 bps QPSK compatible with MFJ-2400.")
 	var markFrequency = pflag.IntP("mark", "m", 0, "Mark frequency.")
@@ -402,6 +403,12 @@ EAS for Emergency Alert System (EAS) Specific Area Message Encoding (SAME).`)
 
 		text_color_set(DW_COLOR_INFO)
 		fmt.Printf("Using G3RUH mode regardless of bit rate.\n")
+	}
+
+	if *bpsk { /* -k for BPSK */
+		modem.achan[0].modem_type = MODEM_BPSK
+		modem.achan[0].mark_freq = 0
+		modem.achan[0].space_freq = 0
 	}
 
 	if *direwolf15compat { /* -j V.26 compatible with earlier direwolf. */
@@ -861,6 +868,8 @@ func send_packet(str string) {
 				samples_per_symbol = modem.adev[0].samples_per_sec / (modem.achan[c].baud / 2)
 			case MODEM_8PSK:
 				samples_per_symbol = modem.adev[0].samples_per_sec / (modem.achan[c].baud / 3)
+			case MODEM_BPSK:
+				samples_per_symbol = modem.adev[0].samples_per_sec / modem.achan[c].baud
 			default:
 				samples_per_symbol = modem.adev[0].samples_per_sec / modem.achan[c].baud
 			}

--- a/src/gen_tone.go
+++ b/src/gen_tone.go
@@ -140,6 +140,18 @@ func gen_tone_init(audio_config_p *audio_s, amp int, gen_packets bool) int { //n
 			// ticks_per_bit should be ticks_per_symbol.
 
 			switch save_audio_config_p.achan[channel].modem_type {
+			case MODEM_BPSK:
+				audio_config_p.achan[channel].mark_freq = 1800
+				audio_config_p.achan[channel].space_freq = audio_config_p.achan[channel].mark_freq // Not Used.
+
+				// 1 bit per symbol, so symbol time equals bit time
+				ticks_per_bit[channel] = (int)((TICKS_PER_CYCLE / float64(audio_config_p.achan[channel].baud)) + 0.5)
+				f1_change_per_sample[channel] = (uint)((float64(audio_config_p.achan[channel].mark_freq) * TICKS_PER_CYCLE / float64(audio_config_p.adev[a].samples_per_sec)) + 0.5)
+				f2_change_per_sample[channel] = f1_change_per_sample[channel] // Not used.
+				samples_per_symbol[channel] = float64(audio_config_p.adev[a].samples_per_sec) / float64(audio_config_p.achan[channel].baud)
+
+				tone_phase[channel] = PHASE_SHIFT_45
+
 			case MODEM_QPSK:
 				audio_config_p.achan[channel].mark_freq = 1800
 				audio_config_p.achan[channel].space_freq = audio_config_p.achan[channel].mark_freq // Not Used.
@@ -321,6 +333,16 @@ func tone_gen_put_bit_real(channel int, dat int) {
 
 	// TODO: change to switch instead of if if if
 
+	if save_audio_config_p.achan[channel].modem_type == MODEM_BPSK {
+		dat &= 1 // Keep only LSB to be extra safe.
+
+		// For BPSK, each bit is one symbol.
+		// Bit 1 shifts phase by 180 degrees; bit 0 leaves phase unchanged.
+		if dat == 1 {
+			tone_phase[channel] += PHASE_SHIFT_180
+		}
+	}
+
 	if save_audio_config_p.achan[channel].modem_type == MODEM_QPSK {
 		dat &= 1 // Keep only LSB to be extra safe.
 
@@ -428,6 +450,11 @@ func tone_gen_put_bit_real(channel int, dat int) {
 			}
 
 			tone_phase[channel] += change
+			sam = int(sine_table[(tone_phase[channel]>>24)&0xff])
+			gen_tone_put_sample(channel, a, sam)
+
+		case MODEM_BPSK:
+			tone_phase[channel] += f1_change_per_sample[channel]
 			sam = int(sine_table[(tone_phase[channel]>>24)&0xff])
 			gen_tone_put_sample(channel, a, sam)
 

--- a/test-scripts/check-modem1200-bpsk
+++ b/test-scripts/check-modem1200-bpsk
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+source "$(dirname "$(realpath "$0")")/common"
+
+goto_tmpdir
+
+$GEN_PACKETS -B1200 -k -n 100 -o test12-bpsk.wav
+$ATEST -B1200 -k -F0 -L88 -G94 test12-bpsk.wav
+$ATEST -B1200 -k -F1 -L93 -G99 test12-bpsk.wav

--- a/test-scripts/check-modem300-bpsk
+++ b/test-scripts/check-modem300-bpsk
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+source "$(dirname "$(realpath "$0")")/common"
+
+goto_tmpdir
+
+$GEN_PACKETS -B300 -k -n 100 -o test300-bpsk.wav
+$ATEST -B300 -k -F0 -L78 -G82 test300-bpsk.wav
+$ATEST -B300 -k -F1 -L78 -G82 test300-bpsk.wav


### PR DESCRIPTION
* Use it in direwolf.conf with e.g. `MODEM 300 BPSK`
* Use it in atest / gen_packets with `--bpsk` or `-k`

With thanks to Nino KK4HEJ for the test data at
https://github.com/ninocarrillo/modem-test-snr