### PR TITLE
feat: Implement ACKMODE (XKISS) support

### DIFF
--- a/src/kiss_ackmode.go
+++ b/src/kiss_ackmode.go
@@ -1,0 +1,47 @@
+//nolint:gochecknoglobals
+package direwolf
+
+import "sync"
+
+// ackPending holds enough state to send an ACKMODE reply after a frame has been transmitted.
+type ackPending struct {
+	seqno   uint16
+	sendfun kiss_sendfun
+	channel int
+	kps     *kissport_status_s
+	client  int
+}
+
+var ackmodeMu sync.Mutex
+var ackmodeMap = map[*packet_t]*ackPending{}
+
+func ackmode_register(pp *packet_t, seqno uint16, channel int,
+	sendfun kiss_sendfun, kps *kissport_status_s, client int) {
+	ackmodeMu.Lock()
+	ackmodeMap[pp] = &ackPending{seqno: seqno, sendfun: sendfun,
+		channel: channel, kps: kps, client: client}
+	ackmodeMu.Unlock()
+}
+
+// ackmode_notify_sent sends an ACKMODE ACK (0x0E + seqno) back to the client
+// after the frame has been transmitted over the air.  Safe to call for every
+// packet; it is a no-op for non-ACKMODE packets.
+func ackmode_notify_sent(pp *packet_t) {
+	ackmodeMu.Lock()
+	var entry, ok = ackmodeMap[pp]
+	delete(ackmodeMap, pp)
+	ackmodeMu.Unlock()
+	if !ok {
+		return
+	}
+	var seqBytes = []byte{byte(entry.seqno >> 8), byte(entry.seqno & 0xFF)}
+	entry.sendfun(entry.channel, XKISS_CMD_POLL, seqBytes, len(seqBytes), entry.kps, entry.client)
+}
+
+// ackmode_discard removes a pending ACK without sending it.
+// Used when a packet is discarded due to channel timeout.
+func ackmode_discard(pp *packet_t) {
+	ackmodeMu.Lock()
+	delete(ackmodeMap, pp)
+	ackmodeMu.Unlock()
+}

--- a/src/kiss_ackmode_test.go
+++ b/src/kiss_ackmode_test.go
@@ -1,0 +1,122 @@
+package direwolf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockSendfun captures the arguments of a single sendfun call.
+type sendfunCapture struct {
+	called  bool
+	channel int
+	cmd     int
+	fbuf    []byte
+	flen    int
+	kps     *kissport_status_s
+	client  int
+}
+
+func (c *sendfunCapture) fn(channel int, cmd int, fbuf []byte, flen int, kps *kissport_status_s, client int) {
+	c.called = true
+	c.channel = channel
+	c.cmd = cmd
+	c.fbuf = fbuf
+	c.flen = flen
+	c.kps = kps
+	c.client = client
+}
+
+// fakePP returns a non-nil *packet_t pointer without allocating a real packet,
+// using the address of a local variable as a unique key.
+func fakePP(t *testing.T) *packet_t {
+	t.Helper()
+	var p packet_t
+	return &p
+}
+
+func TestAckmode_NotifyAfterRegister(t *testing.T) {
+	var capture sendfunCapture
+	var pp = fakePP(t)
+
+	ackmode_register(pp, 0x1234, 2, capture.fn, nil, 5)
+	ackmode_notify_sent(pp)
+
+	assert.True(t, capture.called)
+	assert.Equal(t, 2, capture.channel)
+	assert.Equal(t, XKISS_CMD_POLL, capture.cmd)
+	assert.Equal(t, []byte{0x12, 0x34}, capture.fbuf)
+	assert.Equal(t, 2, capture.flen)
+	assert.Nil(t, capture.kps)
+	assert.Equal(t, 5, capture.client)
+}
+
+func TestAckmode_NotifyUnknownPacket(t *testing.T) {
+	// Calling notify on a packet that was never registered must not panic.
+	var capture sendfunCapture
+	var pp = fakePP(t)
+
+	ackmode_notify_sent(pp)
+
+	assert.False(t, capture.called)
+}
+
+func TestAckmode_NotifyIdempotent(t *testing.T) {
+	// A second notify on the same packet must not send another ACK.
+	var capture sendfunCapture
+	var pp = fakePP(t)
+
+	ackmode_register(pp, 0x0001, 0, capture.fn, nil, 0)
+	ackmode_notify_sent(pp)
+	ackmode_notify_sent(pp)
+
+	assert.True(t, capture.called)
+	// Reset and verify second call was a no-op by checking capture was only set once.
+	var callCount int
+	var pp2 = fakePP(t)
+	var counting kiss_sendfun = func(_ int, _ int, _ []byte, _ int, _ *kissport_status_s, _ int) {
+		callCount++
+	}
+	ackmode_register(pp2, 0x0002, 0, counting, nil, 0)
+	ackmode_notify_sent(pp2)
+	ackmode_notify_sent(pp2)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestAckmode_DiscardNoSend(t *testing.T) {
+	// Discard must remove the entry without invoking the sendfun.
+	var capture sendfunCapture
+	var pp = fakePP(t)
+
+	ackmode_register(pp, 0xABCD, 1, capture.fn, nil, 3)
+	ackmode_discard(pp)
+	ackmode_notify_sent(pp) // should be a no-op now
+
+	assert.False(t, capture.called)
+}
+
+func TestAckmode_DiscardUnknownPacket(t *testing.T) {
+	// Discarding an unregistered packet must not panic.
+	var pp = fakePP(t)
+	ackmode_discard(pp)
+}
+
+func TestAckmode_SeqnoZero(t *testing.T) {
+	var capture sendfunCapture
+	var pp = fakePP(t)
+
+	ackmode_register(pp, 0x0000, 0, capture.fn, nil, 0)
+	ackmode_notify_sent(pp)
+
+	assert.Equal(t, []byte{0x00, 0x00}, capture.fbuf)
+}
+
+func TestAckmode_SeqnoMax(t *testing.T) {
+	var capture sendfunCapture
+	var pp = fakePP(t)
+
+	ackmode_register(pp, 0xFFFF, 0, capture.fn, nil, 0)
+	ackmode_notify_sent(pp)
+
+	assert.Equal(t, []byte{0xFF, 0xFF}, capture.fbuf)
+}

--- a/src/kiss_frame.go
+++ b/src/kiss_frame.go
@@ -44,8 +44,8 @@ package direwolf
  *
  *			_6	SetHardware	TNC specific.
  *
- *			_C	XKISS extension - not supported.
- *			_E	XKISS extension - not supported.
+ *			_C	ACKMODE data frame (ACK required, with 2-byte sequence number).
+ *			_E	ACKMODE ACK (TNC to client, after frame transmitted over radio).
  *
  *			FF	Return		Exit KISS mode.  Ignored.
  *
@@ -73,8 +73,8 @@ const KISS_CMD_SLOTTIME = 3
 const KISS_CMD_TXTAIL = 4
 const KISS_CMD_FULLDUPLEX = 5
 const KISS_CMD_SET_HARDWARE = 6
-const XKISS_CMD_DATA = 12 // Not supported. http://he.fi/pub/oh7lzb/bpq/multi-kiss.pdf
-const XKISS_CMD_POLL = 14 // Not supported.
+const XKISS_CMD_DATA = 12 // ACKMODE: ACK-required data frame. http://he.fi/pub/oh7lzb/bpq/multi-kiss.pdf
+const XKISS_CMD_POLL = 14 // ACKMODE: ACK from TNC to client after transmission.
 const KISS_CMD_END_KISS = 15
 
 /*
@@ -315,7 +315,7 @@ func kiss_debug_print(fromto fromto_t, special string, pmsg []byte) {
 		"Data frame", "TXDELAY", "P", "SlotTime",
 		"TXtail", "FullDuplex", "SetHardware", "Invalid 7",
 		"Invalid 8", "Invalid 9", "Invalid 10", "Invalid 11",
-		"Invalid 12", "Invalid 13", "Invalid 14", "Return"}
+		"ACKMODE Data", "Invalid 13", "ACKMODE ACK", "Return"}
 
 	text_color_set(DW_COLOR_DEBUG)
 
@@ -742,6 +742,41 @@ func kiss_process_msg(kiss_msg []byte, debug int, kps *kissport_status_s, client
 		dw_printf("KISS protocol set hardware \"%s\", channel %d\n", kiss_msg[1:], channel)
 		kiss_set_hardware(channel, kiss_msg[1:], debug, kps, client, sendfun)
 
+	case XKISS_CMD_DATA: /* 12 = ACKMODE data frame with 2-byte sequence number */
+		if len(kiss_msg) < 4 {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("KISS ACKMODE frame too short (need type + 2 seq bytes + data).\n")
+
+			return
+		}
+
+		kissNetSvc.Copy(kiss_msg, channel, int(cmd), kps, client)
+
+		if (channel < 0 || channel >= MAX_TOTAL_CHANS || save_audio_config_p.chan_medium[channel] == MEDIUM_NONE) && save_audio_config_p.chan_medium[channel] != MEDIUM_IGATE {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Invalid transmit channel %d from KISS client app.\n", channel)
+
+			return
+		}
+
+		var seqno = (uint16(kiss_msg[1]) << 8) | uint16(kiss_msg[2])
+
+		alevel = alevel_t{} //nolint:exhaustruct
+
+		var pp = ax25_from_frame(kiss_msg[3:], alevel)
+		if pp == nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("ERROR - Invalid KISS ACKMODE data frame from client app.\n")
+		} else {
+			if ax25_get_num_repeaters(pp) >= 1 &&
+				ax25_get_h(pp, AX25_REPEATER_1) > 0 {
+				tq_append(channel, TQ_PRIO_0_HI, pp)
+			} else {
+				tq_append(channel, TQ_PRIO_1_LO, pp)
+			}
+			ackmode_register(pp, seqno, channel, sendfun, kps, client)
+		}
+
 	case KISS_CMD_END_KISS: /* 15 = End KISS mode, channel should be 15. */
 		/* Ignore it. */
 		text_color_set(DW_COLOR_INFO)
@@ -756,16 +791,6 @@ func kiss_process_msg(kiss_msg []byte, debug int, kps *kissport_status_s, client
 		dw_printf("Troubleshooting tip:\n")
 		dw_printf("Use \"-d kn\" option on direwolf command line to observe\n")
 		dw_printf("all communication with the client application.\n")
-
-		if cmd == XKISS_CMD_DATA || cmd == XKISS_CMD_POLL {
-			dw_printf("\n")
-			dw_printf("It looks like you are trying to use the \"XKISS\" protocol which is not supported.\n")
-			dw_printf("Change your application settings to use standard \"KISS\" rather than some other variant.\n")
-			dw_printf("If you are using Winlink Express, configure like this:\n")
-			dw_printf("    Packet TNC Type:  KISS\n")
-			dw_printf("    Packet TNC Model:  NORMAL      -- Using ACKMODE will cause this error.\n")
-			dw_printf("\n")
-		}
 	}
 } /* end kiss_process_msg */
 

--- a/src/xmit.go
+++ b/src/xmit.go
@@ -469,6 +469,7 @@ func (xs *XmitService) xmit_thread(channel int) {
 					dw_printf("%s", stemp) /* stations followed by : */
 					ax25_safe_print(pinfo, !ax25_is_aprs(pp))
 					dw_printf("\n")
+					ackmode_discard(pp)
 					ax25_delete(pp)
 				} /* wait for clear channel error. */
 			} /* Have pp */
@@ -631,6 +632,7 @@ func (xs *XmitService) xmit_ax25_frames(channel int, prio int, pp *packet_t, max
 		dw_printf ("xmit_thread: t=%.3f, nb=%d, num_bits=%d, numframe=%d\n", dtime_now()-time_ptt, nb, num_bits, numframe);
 	#endif
 	*/
+	ackmode_notify_sent(pp)
 	ax25_delete(pp)
 
 	/*
@@ -678,6 +680,7 @@ func (xs *XmitService) xmit_ax25_frames(channel int, prio int, pp *packet_t, max
 					        dw_printf ("xmit_thread: t=%.3f, nb=%d, num_bits=%d, numframe=%d\n", dtime_now()-time_ptt, nb, num_bits, numframe);
 				#endif
 				*/
+				ackmode_notify_sent(pp)
 				ax25_delete(pp)
 			}
 		} else {


### PR DESCRIPTION
When a KISS client sends ACK-required frames (command 0x0C) containing
a 2-byte sequence number before the AX.25 data, the TNC now sends an
ACK frame (command 0x0E + same sequence number) back to the client
after the frame has been transmitted over the air.

This prevents clients from sending retries before the original frame
has even left the TNC, improving link performance.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
