### PR TITLE
refactor: Break up config_init in config.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters:
     - "wsl_v5"  # KG 2026-02-26 I don't have concrete data but it feels like wsl is giving me spurious edits/breakages - it might not be wsl, it might be something else, but it only started being an issue once I enabled wsl, so I'm disabling it again for the foreseeable
   settings:
     cyclop:
-      max-complexity: 750  # I sure wish this could be lower
+      max-complexity: 150  # I sure wish this could be lower
     depguard:
       rules:
         main:
@@ -42,7 +42,7 @@ linters:
     exhaustive:
       default-signifies-exhaustive: true  # Soften the check for now...
     gocognit:
-      min-complexity: 1800  # I sure wish this could be lower
+      min-complexity: 300  # I sure wish this could be lower
     goconst:
       min-occurrences: 10
     gocritic:
@@ -62,7 +62,7 @@ linters:
         - "G404"  # Weak RNGs are fine for our uses here, certainly for now(!)
         - "G602"  # "slice index out of range" checks that *may* be valid but it's hard to tell - if they're not false positives, they're niche issues
     nestif:
-      min-complexity: 750  # There's lots of upstream complexity, so let's soft-disable this
+      min-complexity: 100  # There's lots of upstream complexity, so let's soft-disable this
     revive:
       rules:
         - name: "var-naming"

--- a/src/config.go
+++ b/src/config.go
@@ -815,6 +815,111 @@ func rtfm() {
 	dw_printf("    general APRS info:    https://how.aprs.works\n")
 }
 
+// parseState holds the mutable parsing context threaded through config_init.
+type parseState struct {
+	channel int
+	adevice int
+	line    int
+	text    string // current raw scanner line
+	keyword string // original (not uppercased) keyword token
+
+	audio *audio_s
+	digi  *digi_config_s
+	cdigi *cdigi_config_s
+	tt    *tt_config_s
+	igate *igate_config_s
+	misc  *misc_config_s
+}
+
+// configHandler is a keyword handler. It returns true if the outer scanner loop
+// should `continue` (i.e. skip to the next line).
+type configHandler func(ps *parseState) bool
+
+var configHandlers = map[string]configHandler{
+	"ARATE":          handleARATE,
+	"ACHANNELS":      handleACHANNELS,
+	"CHANNEL":        handleCHANNEL,
+	"ICHANNEL":       handleICHANNEL,
+	"NCHANNEL":       handleNCHANNEL,
+	"MYCALL":         handleMYCALL,
+	"MODEM":          handleMODEM,
+	"DTMF":           handleDTMF,
+	"FIX_BITS":       handleFIX_BITS,
+	"PTT":            handlePTTDCDCON,
+	"DCD":            handlePTTDCDCON,
+	"CON":            handlePTTDCDCON,
+	"TXINH":          handleTXINH,
+	"DWAIT":          handleDWAIT,
+	"SLOTTIME":       handleSLOTTIME,
+	"PERSIST":        handlePERSIST,
+	"TXDELAY":        handleTXDELAY,
+	"TXTAIL":         handleTXTAIL,
+	"FULLDUP":        handleFULLDUP,
+	"SPEECH":         handleSPEECH,
+	"FX25TX":         handleFX25TX,
+	"FX25AUTO":       handleFX25AUTO,
+	"IL2PTX":         handleIL2PTX,
+	"DIGIPEAT":       handleDIGIPEAT,
+	"DIGIPEATER":     handleDIGIPEAT,
+	"DEDUPE":         handleDEDUPE,
+	"REGEN":          handleREGEN,
+	"CDIGIPEAT":      handleCDIGIPEAT,
+	"CDIGIPEATER":    handleCDIGIPEAT,
+	"FILTER":         handleFILTER,
+	"CFILTER":        handleCFILTER,
+	"TTCORRAL":       handleTTCORRAL,
+	"TTPOINT":        handleTTPOINT,
+	"TTVECTOR":       handleTTVECTOR,
+	"TTGRID":         handleTTGRID,
+	"TTUTM":          handleTTUTM,
+	"TTUSNG":         handleTTUSNGMGRS,
+	"TTMGRS":         handleTTUSNGMGRS,
+	"TTMHEAD":        handleTTMHEAD,
+	"TTSATSQ":        handleTTSATSQ,
+	"TTAMBIG":        handleTTAMBIG,
+	"TTMACRO":        handleTTMACRO,
+	"TTOBJ":          handleTTOBJ,
+	"TTERR":          handleTTERR,
+	"TTSTATUS":       handleTTSTATUS,
+	"TTCMD":          handleTTCMD,
+	"IGSERVER":       handleIGSERVER,
+	"IGLOGIN":        handleIGLOGIN,
+	"IGTXVIA":        handleIGTXVIA,
+	"IGFILTER":       handleIGFILTER,
+	"IGTXLIMIT":      handleIGTXLIMIT,
+	"IGMSP":          handleIGMSP,
+	"SATGATE":        handleSATGATE,
+	"AGWPORT":        handleAGWPORT,
+	"KISSPORT":       handleKISSPORT,
+	"NULLMODEM":      handleNULLMODEM,
+	"SERIALKISS":     handleNULLMODEM,
+	"SERIALKISSPOLL": handleSERIALKISSPOLL,
+	"KISSCOPY":       handleKISSCOPY,
+	"DNSSD":          handleDNSSD,
+	"DNSSDNAME":      handleDNSSDNAME,
+	"GPSNMEA":        handleGPSNMEA,
+	"GPSD":           handleGPSD,
+	"WAYPOINT":       handleWAYPOINT,
+	"LOGDIR":         handleLOGDIR,
+	"LOGFILE":        handleLOGFILE,
+	"BEACON":         handleBEACON,
+	"PBEACON":        handleXBEACON,
+	"OBEACON":        handleXBEACON,
+	"TBEACON":        handleXBEACON,
+	"CBEACON":        handleXBEACON,
+	"IBEACON":        handleXBEACON,
+	"SMARTBEACON":    handleSMARTBEACON,
+	"SMARTBEACONING": handleSMARTBEACON,
+	"FRACK":          handleFRACK,
+	"RETRY":          handleRETRY,
+	"PACLEN":         handlePACLEN,
+	"MAXFRAME":       handleMAXFRAME,
+	"EMAXFRAME":      handleEMAXFRAME,
+	"MAXV22":         handleMAXV22,
+	"V20":            handleV20,
+	"NOXID":          handleNOXID,
+}
+
 func config_init(fname string, p_audio_config *audio_s,
 	p_digi_config *digi_config_s,
 	p_cdigi_config *cdigi_config_s,
@@ -1013,8 +1118,19 @@ func config_init(fname string, p_audio_config *audio_s,
 	p_misc_config.noxid_count = 0
 
 	// Persistent context as we work through the file
-	var channel = 0
-	var adevice = 0
+	var ps = &parseState{
+		channel: 0,
+		adevice: 0,
+		line:    0,
+		text:    "",
+		keyword: "",
+		audio:   p_audio_config,
+		digi:    p_digi_config,
+		cdigi:   p_cdigi_config,
+		tt:      p_tt_config,
+		igate:   p_igate_config,
+		misc:    p_misc_config,
+	}
 
 	/*
 	 * Try to extract options from a file.
@@ -1050,4220 +1166,46 @@ func config_init(fname string, p_audio_config *audio_s,
 
 	dw_printf("\nReading config file %s\n", absFilePath)
 
-	var line = 0
-
 	var scanner = bufio.NewScanner(fp)
 	for scanner.Scan() {
-		var text = scanner.Text()
-		line++
+		ps.text = scanner.Text()
+		ps.line++
 
-		if text == "" || text[0] == '#' || text[0] == '*' {
+		if ps.text == "" || ps.text[0] == '#' || ps.text[0] == '*' {
 			continue
 		}
 
-		var t = split(text, false)
+		var t = split(ps.text, false)
 
 		if t == "" {
 			continue
 		}
 
-		/*
-		 * ==================== Audio device parameters ====================
-		 */
-
-		/*
-		 * ADEVICE[n] 		- Name of input sound device, and optionally output, if different.
-		 *
-		 *			ADEVICE    plughw:1,0				-- same for in and out.
-		 *			ADEVICE	   plughw:2,0  plughw:3,0		-- different in/out for a channel or channel pair.
-		 *			ADEVICE1   udp:7355  default			-- input from SDR via UDP; output to soundcard.
-		 *			ADEVICE    default   udp:localhost:7355		-- input from soundcard; output via UDP.
-		 *
-		 *	New in 1.8: Ability to map to another audio device.
-		 *	This allows multiple modems (i.e. data speeds) on the same audio interface.
-		 *
-		 *			ADEVICEn   = n				-- Copy from different already defined channel.
-		 */
-
-		/* Note that ALSA name can contain comma such as hw:1,0 */
-
-		if strings.HasPrefix(strings.ToUpper(t), "ADEVICE") {
-			/* "ADEVICE" is equivalent to "ADEVICE0". */
-			adevice = 0
-
-			if len(t) >= 8 {
-				var i, iErr = strconv.Atoi(string(t[7]))
-				if iErr != nil {
-					dw_printf("Config file: Could not parse ADEVICE number on line %d: %s.\n", line, iErr)
-					continue
-				}
-
-				if i < 0 || i >= MAX_ADEVS {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: Device number %d out of range for ADEVICE command on line %d.\n", i, line)
-					dw_printf("If you really need more than %d audio devices, increase MAX_ADEVS and recompile.\n", MAX_ADEVS)
-
-					adevice = 0
-
-					continue
-				}
-
-				adevice = i
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing name of audio device for ADEVICE command on line %d.\n", line)
-				rtfm()
-				exit(1)
-			}
-
-			// Do not allow same adevice to be defined more than once.
-			// Overriding the default for adevice 0 is ok.
-			// In that case defined was 2.  That's why we check for 1, not just non-zero.
-
-			if p_audio_config.adev[adevice].defined == 1 { // 1 means defined by user.
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: ADEVICE%d can't be defined more than once. Line %d.\n", adevice, line)
-
-				continue
-			}
-
-			p_audio_config.adev[adevice].defined = 1
-
-			// New case for release 1.8.
-
-			if t == "=" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: ADEVICE = n (copy-from) is not yet implemented. Line %d.\n", line)
-				continue
-			} else {
-				/* First channel of device is valid. */
-				// This might be changed to UDP or STDIN when the device name is examined.
-				p_audio_config.chan_medium[ADEVFIRSTCHAN(adevice)] = MEDIUM_RADIO
-
-				p_audio_config.adev[adevice].adevice_in = t
-				p_audio_config.adev[adevice].adevice_out = t
-
-				t = split("", false)
-				if t != "" {
-					// Different audio devices for receive and transmit.
-					p_audio_config.adev[adevice].adevice_out = t
-				}
-			}
-		} else if strings.EqualFold(t, "PAIDEVICE") {
-			/*
-			 * PAIDEVICE[n]  input-device
-			 * PAODEVICE[n]  output-device
-			 *
-			 *			This was submitted by KK5VD for the Mac OS X version.  (__APPLE__)
-			 *
-			 *			It looks like device names can contain spaces making it a little
-			 *			more difficult to put two names on the same line unless we come up with
-			 *			some other delimiter between them or a quoting scheme to handle
-			 *			embedded spaces in a name.
-			 *
-			 *			It concerns me that we could have one defined without the other
-			 *			if we don't put in more error checking later.
-			 *
-			 *	version 1.3 dev snapshot C:
-			 *
-			 *		We now have a general quoting scheme so the original ADEVICE can handle this.
-			 *		These options will probably be removed before general 1.3 release.
-			 */
-			adevice = 0
-			if unicode.IsDigit(rune(t[9])) {
-				adevice = int(t[9] - '0')
-			}
-
-			if adevice < 0 || adevice >= MAX_ADEVS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Device number %d out of range for PAIDEVICE command on line %d.\n", adevice, line)
-				adevice = 0
-
-				continue
-			}
-
-			t = split("", true)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing name of audio device for PAIDEVICE command on line %d.\n", line)
-
-				continue
-			}
-
-			p_audio_config.adev[adevice].defined = 1
-
-			/* First channel of device is valid. */
-			p_audio_config.chan_medium[ADEVFIRSTCHAN(adevice)] = MEDIUM_RADIO
-
-			p_audio_config.adev[adevice].adevice_in = t
-		} else if strings.EqualFold(t, "PAODEVICE") {
-			adevice = 0
-			if unicode.IsDigit(rune(t[9])) {
-				adevice = int(t[9] - '0')
-			}
-
-			if adevice < 0 || adevice >= MAX_ADEVS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Device number %d out of range for PAODEVICE command on line %d.\n", adevice, line)
-				adevice = 0
-
-				continue
-			}
-
-			t = split("", true)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing name of audio device for PAODEVICE command on line %d.\n", line)
-
-				continue
-			}
-
-			p_audio_config.adev[adevice].defined = 1
-
-			/* First channel of device is valid. */
-			p_audio_config.chan_medium[ADEVFIRSTCHAN(adevice)] = MEDIUM_RADIO
-
-			p_audio_config.adev[adevice].adevice_out = t
-		} else if strings.EqualFold(t, "ARATE") {
-			/*
-			 * ARATE 		- Audio samples per second, 11025, 22050, 44100, etc.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing audio sample rate for ARATE command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= MIN_SAMPLES_PER_SEC && n <= MAX_SAMPLES_PER_SEC {
-				p_audio_config.adev[adevice].samples_per_sec = n
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Use a more reasonable audio sample rate in range of %d - %d.\n",
-					line, MIN_SAMPLES_PER_SEC, MAX_SAMPLES_PER_SEC)
-			}
-		} else if strings.EqualFold(t, "ACHANNELS") {
-			/*
-			 * ACHANNELS 		- Number of audio channels for current device: 1 or 2
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing number of audio channels for ACHANNELS command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n == 1 || n == 2 {
-				p_audio_config.adev[adevice].num_channels = n
-
-				/* Set valid channels depending on mono or stereo. */
-
-				p_audio_config.chan_medium[ADEVFIRSTCHAN(adevice)] = MEDIUM_RADIO
-				if n == 2 {
-					p_audio_config.chan_medium[ADEVFIRSTCHAN(adevice)+1] = MEDIUM_RADIO
-				}
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Number of audio channels must be 1 or 2.\n", line)
-			}
-		} else if strings.EqualFold(t, "CHANNEL") {
-			/*
-			 * ==================== Radio channel parameters ====================
-			 */
-
-			/*
-			 * CHANNEL n		- Set channel for channel-specific commands.  Only for modem/radio channels.
-			 */
-
-			// TODO: allow full range so mycall can be set for network channels.
-			// Watch out for achan[] out of bounds.
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing channel number for CHANNEL command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 0 && n < MAX_RADIO_CHANS {
-				channel = n
-
-				if p_audio_config.chan_medium[n] != MEDIUM_RADIO {
-					if p_audio_config.adev[ACHAN2ADEV(n)].defined == 0 {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: Channel number %d is not valid because audio device %d is not defined.\n",
-							line, n, ACHAN2ADEV(n))
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: Channel number %d is not valid because audio device %d is not in stereo.\n",
-							line, n, ACHAN2ADEV(n))
-					}
-				}
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Channel number must in range of 0 to %d.\n", line, MAX_RADIO_CHANS-1)
-			}
-		} else if strings.EqualFold(t, "ICHANNEL") {
-			/*
-			 * ICHANNEL n			- Define IGate virtual channel.
-			 *
-			 *	This allows a client application to talk to to APRS-IS
-			 *	by using a channel number outside the normal range for modems.
-			 *	In the future there might be other typs of virtual channels.
-			 *	This does not change the current channel number used by MODEM, PTT, etc.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing virtual channel number for ICHANNEL command.\n", line)
-
-				continue
-			}
-
-			var ichan, _ = strconv.Atoi(t)
-			if ichan >= MAX_RADIO_CHANS && ichan < MAX_TOTAL_CHANS {
-				if p_audio_config.chan_medium[ichan] == MEDIUM_NONE {
-					p_audio_config.chan_medium[ichan] = MEDIUM_IGATE
-
-					// This is redundant but saves the time of searching through all
-					// the channels for each packet.
-					p_audio_config.igate_vchannel = ichan
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: ICHANNEL can't use channel %d because it is already in use.\n", line, ichan)
-				}
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: ICHANNEL number must in range of %d to %d.\n", line, MAX_RADIO_CHANS, MAX_TOTAL_CHANS-1)
-			}
-		} else if strings.EqualFold(t, "NCHANNEL") {
-			/*
-			 * NCHANNEL chan addr port			- Define Network TNC virtual channel.
-			 *
-			 *	This allows a client application to talk to to an external TNC over TCP KISS
-			 *	by using a channel number outside the normal range for modems.
-			 *	This does not change the current channel number used by MODEM, PTT, etc.
-			 *
-			 *	chan = direwolf channel.
-			 *	addr = hostname or IP address of network TNC.
-			 *	port = KISS TCP port on network TNC.
-			 *
-			 *	Future: Might allow selection of channel on the network TNC.
-			 *	For now, ignore incoming and set to 0 for outgoing.
-			 *
-			 * FIXME: Can't set mycall for nchannel.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing virtual channel number for NCHANNEL command.\n", line)
-
-				continue
-			}
-
-			var nchan, _ = strconv.Atoi(t)
-			if nchan >= MAX_RADIO_CHANS && nchan < MAX_TOTAL_CHANS {
-				if p_audio_config.chan_medium[nchan] == MEDIUM_NONE {
-					p_audio_config.chan_medium[nchan] = MEDIUM_NETTNC
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: NCHANNEL can't use channel %d because it is already in use.\n", line, nchan)
-				}
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: NCHANNEL number must in range of %d to %d.\n", line, MAX_RADIO_CHANS, MAX_TOTAL_CHANS-1)
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing network TNC address for NCHANNEL command.\n", line)
-
-				continue
-			}
-
-			p_audio_config.nettnc_addr[nchan] = t
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing network TNC TCP port for NCHANNEL command.\n", line)
-
-				continue
-			}
-			var n, _ = strconv.Atoi(t)
-			p_audio_config.nettnc_port[nchan] = n
-		} else if strings.EqualFold(t, "mycall") {
-			/*
-			 * MYCALL station
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing value for MYCALL command on line %d.\n", line)
-
-				continue
-			} else {
-				var strictness = 2
-
-				/* Silently force upper case. */
-				/* Might change to warning someday. */
-				t = strings.ToUpper(t)
-
-				var _, _, _, ok = ax25_parse_addr(-1, t, strictness)
-
-				if !ok {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: Invalid value for MYCALL command on line %d.\n", line)
-
-					continue
-				}
-
-				// Definitely set for current channel.
-				// Set for other channels which have not been set yet.
-
-				for c := range MAX_TOTAL_CHANS {
-					if c == channel || IsNoCall(p_audio_config.mycall[c]) {
-						p_audio_config.mycall[c] = t
-					}
-				}
-			}
-		} else if strings.EqualFold(t, "MODEM") {
-			/*
-			 * MODEM	- Set modem properties for current channel.
-			 *
-			 *
-			 * Old style:
-			 * 	MODEM  baud [ mark  space  [A][B][C][+]  [  num-decoders spacing ] ]
-			 *
-			 * New style, version 1.2:
-			 *	MODEM  speed [ option ] ...
-			 *
-			 * Options:
-			 *	mark:space	- AFSK tones.  Defaults based on speed.
-			 *	num@offset	- Multiple decoders on different frequencies.
-			 *	/9		- Divide sample rate by specified number.
-			 *	*9		- Upsample ratio for G3RUH.
-			 *	[A-Z+-]+	- Letters, plus, minus for the demodulator "profile."
-			 *	g3ruh		- This modem type regardless of default for speed.
-			 *	v26a or v26b	- V.26 alternative.  a=original, b=MFJ compatible
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: MODEM can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing data transmission speed for MODEM command.\n", line)
-
-				continue
-			}
-
-			var n int
-			if strings.EqualFold(t, "AIS") {
-				n = MAX_BAUD - 1 // Hack - See special case later.
-			} else if strings.EqualFold(t, "EAS") {
-				n = MAX_BAUD - 2 // Hack - See special case later.
-			} else {
-				n, _ = strconv.Atoi(t)
-			}
-
-			if n >= MIN_BAUD && n <= MAX_BAUD {
-				p_audio_config.achan[channel].baud = n
-				if n != 300 && n != 1200 && n != 2400 && n != 4800 && n != 9600 && n != 19200 && n != MAX_BAUD-1 && n != MAX_BAUD-2 {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Warning: Non-standard data rate of %d bits per second.  Are you sure?\n", line, n)
-				}
-			} else {
-				p_audio_config.achan[channel].baud = DEFAULT_BAUD
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Unreasonable data rate. Using %d bits per second.\n",
-					line, p_audio_config.achan[channel].baud)
-			}
-
-			/* Set defaults based on speed. */
-			/* Should be same as -B command line option in direwolf.c. */
-
-			/* We have similar logic in direwolf.c, config.c, gen_packets.c, and atest.c, */
-			/* that need to be kept in sync.  Maybe it could be a common function someday. */
-
-			if p_audio_config.achan[channel].baud < 600 {
-				p_audio_config.achan[channel].modem_type = MODEM_AFSK
-				p_audio_config.achan[channel].mark_freq = 1600
-				p_audio_config.achan[channel].space_freq = 1800
-			} else if p_audio_config.achan[channel].baud < 1800 {
-				p_audio_config.achan[channel].modem_type = MODEM_AFSK
-				p_audio_config.achan[channel].mark_freq = DEFAULT_MARK_FREQ
-				p_audio_config.achan[channel].space_freq = DEFAULT_SPACE_FREQ
-			} else if p_audio_config.achan[channel].baud < 3600 {
-				p_audio_config.achan[channel].modem_type = MODEM_QPSK
-				p_audio_config.achan[channel].mark_freq = 0
-				p_audio_config.achan[channel].space_freq = 0
-			} else if p_audio_config.achan[channel].baud < 7200 {
-				p_audio_config.achan[channel].modem_type = MODEM_8PSK
-				p_audio_config.achan[channel].mark_freq = 0
-				p_audio_config.achan[channel].space_freq = 0
-			} else if p_audio_config.achan[channel].baud == MAX_BAUD-1 {
-				p_audio_config.achan[channel].modem_type = MODEM_AIS
-				p_audio_config.achan[channel].mark_freq = 0
-				p_audio_config.achan[channel].space_freq = 0
-			} else if p_audio_config.achan[channel].baud == MAX_BAUD-2 {
-				p_audio_config.achan[channel].modem_type = MODEM_EAS
-				p_audio_config.achan[channel].baud = 521 // Actually 520.83 but we have an integer field here.
-				// Will make more precise in afsk demod init.
-				p_audio_config.achan[channel].mark_freq = 2083  // Actually 2083.3 - logic 1.
-				p_audio_config.achan[channel].space_freq = 1563 // Actually 1562.5 - logic 0.
-				// ? strlcpy (p_audio_config.achan[channel].profiles, "A", sizeof(p_audio_config.achan[channel].profiles));
-			} else {
-				p_audio_config.achan[channel].modem_type = MODEM_SCRAMBLE
-				p_audio_config.achan[channel].mark_freq = 0
-				p_audio_config.achan[channel].space_freq = 0
-			}
-
-			/* Get any options. */
-
-			t = split("", false)
-			if t == "" {
-				/* all done. */
-				continue
-			}
-
-			if alldigits(t) {
-				/* old style */
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Old style (pre version 1.2) format will no longer be supported in next version.\n", line)
-
-				n, _ = strconv.Atoi(t)
-				/* Originally the upper limit was 3000. */
-				/* Version 1.0 increased to 5000 because someone */
-				/* wanted to use 2400/4800 Hz AFSK. */
-				/* Of course the MIC and SPKR connections won't */
-				/* have enough bandwidth so radios must be modified. */
-				if n >= 300 && n <= 5000 {
-					p_audio_config.achan[channel].mark_freq = n
-				} else {
-					p_audio_config.achan[channel].mark_freq = DEFAULT_MARK_FREQ
-
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Unreasonable mark tone frequency. Using %d.\n",
-						line, p_audio_config.achan[channel].mark_freq)
-				}
-
-				/* Get space frequency */
-
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Missing tone frequency for space.\n", line)
-
-					continue
-				}
-
-				n, _ = strconv.Atoi(t)
-				if n >= 300 && n <= 5000 {
-					p_audio_config.achan[channel].space_freq = n
-				} else {
-					p_audio_config.achan[channel].space_freq = DEFAULT_SPACE_FREQ
-
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Unreasonable space tone frequency. Using %d.\n",
-						line, p_audio_config.achan[channel].space_freq)
-				}
-
-				/* Gently guide users toward new format. */
-
-				if p_audio_config.achan[channel].baud == 1200 &&
-					p_audio_config.achan[channel].mark_freq == 1200 &&
-					p_audio_config.achan[channel].space_freq == 2200 {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: The AFSK frequencies can be omitted when using the 1200 baud default 1200:2200.\n", line)
-				}
-
-				if p_audio_config.achan[channel].baud == 300 &&
-					p_audio_config.achan[channel].mark_freq == 1600 &&
-					p_audio_config.achan[channel].space_freq == 1800 {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: The AFSK frequencies can be omitted when using the 300 baud default 1600:1800.\n", line)
-				}
-
-				/* New feature in 0.9 - Optional filter profile(s). */
-
-				t = split("", false)
-				if t != "" {
-					/* Look for some combination of letter(s) and + */
-					if unicode.IsLetter(rune(t[0])) || t[0] == '+' {
-						/* Here we only catch something other than letters and + mixed in. */
-						/* Later, we check for valid letters and no more than one letter if + specified. */
-						if strings.ContainsFunc(t, func(r rune) bool {
-							return !(unicode.IsLetter(r) || r == '+' || r == '-')
-						}) {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Demodulator type can only contain letters and + character.\n", line)
-						}
-
-						p_audio_config.achan[channel].profiles = t
-
-						t = split("", false)
-						if len(p_audio_config.achan[channel].profiles) > 1 && t != "" {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Can't combine multiple demodulator types and multiple frequencies.\n", line)
-
-							continue
-						}
-					}
-				}
-
-				/* New feature in 0.9 - optional number of decoders and frequency offset between. */
-
-				if t != "" {
-					n, _ = strconv.Atoi(t)
-					if n < 1 || n > MAX_SUBCHANS {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: Number of demodulators is out of range. Using 3.\n", line)
-
-						n = 3
-					}
-
-					p_audio_config.achan[channel].num_freq = n
-
-					t = split("", false)
-					if t != "" {
-						n, _ = strconv.Atoi(t)
-						if n < 5 || n > int(math.Abs(float64(p_audio_config.achan[channel].mark_freq-p_audio_config.achan[channel].space_freq))/2) {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Unreasonable value for offset between modems.  Using 50 Hz.\n", line)
-
-							n = 50
-						}
-
-						p_audio_config.achan[channel].offset = n
-
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: New style for multiple demodulators is %d@%d\n", line,
-							p_audio_config.achan[channel].num_freq, p_audio_config.achan[channel].offset)
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: Missing frequency offset between modems.  Using 50 Hz.\n", line)
-
-						p_audio_config.achan[channel].offset = 50
-					}
-				}
-			} else {
-				/* New style in version 1.2. */
-				for t != "" {
-					if strings.Contains(t, ":") { /* mark:space */
-						var markStr, spaceStr, _ = strings.Cut(t, ":")
-						var mark, _ = strconv.Atoi(markStr)
-						var space, _ = strconv.Atoi(spaceStr)
-
-						p_audio_config.achan[channel].mark_freq = mark
-						p_audio_config.achan[channel].space_freq = space
-
-						if p_audio_config.achan[channel].mark_freq == 0 && p_audio_config.achan[channel].space_freq == 0 {
-							p_audio_config.achan[channel].modem_type = MODEM_SCRAMBLE
-						} else {
-							p_audio_config.achan[channel].modem_type = MODEM_AFSK
-
-							if p_audio_config.achan[channel].mark_freq < 300 || p_audio_config.achan[channel].mark_freq > 5000 {
-								p_audio_config.achan[channel].mark_freq = DEFAULT_MARK_FREQ
-
-								text_color_set(DW_COLOR_ERROR)
-								dw_printf("Line %d: Unreasonable mark tone frequency. Using %d instead.\n",
-									line, p_audio_config.achan[channel].mark_freq)
-							}
-
-							if p_audio_config.achan[channel].space_freq < 300 || p_audio_config.achan[channel].space_freq > 5000 {
-								p_audio_config.achan[channel].space_freq = DEFAULT_SPACE_FREQ
-
-								text_color_set(DW_COLOR_ERROR)
-								dw_printf("Line %d: Unreasonable space tone frequency. Using %d instead.\n",
-									line, p_audio_config.achan[channel].space_freq)
-							}
-						}
-					} else if strings.Contains(t, "@") { /* num@offset */
-						var numStr, offsetStr, _ = strings.Cut(t, "@")
-						var num, _ = strconv.Atoi(numStr)
-						var offset, _ = strconv.Atoi(offsetStr)
-
-						p_audio_config.achan[channel].num_freq = num
-						p_audio_config.achan[channel].offset = offset
-
-						if p_audio_config.achan[channel].num_freq < 1 || p_audio_config.achan[channel].num_freq > MAX_SUBCHANS {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Number of demodulators is out of range. Using 3.\n", line)
-
-							p_audio_config.achan[channel].num_freq = 3
-						}
-
-						if p_audio_config.achan[channel].offset < 5 ||
-							float64(p_audio_config.achan[channel].offset) > math.Abs(float64(p_audio_config.achan[channel].mark_freq-p_audio_config.achan[channel].space_freq))/2 {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Offset between demodulators is unreasonable. Using 50 Hz.\n", line)
-
-							p_audio_config.achan[channel].offset = 50
-						}
-					} else if strings.EqualFold(t, "BPSK") { /* Force BPSK modem (1 bit/symbol, carrier 1800 Hz). */
-						p_audio_config.achan[channel].modem_type = MODEM_BPSK
-						p_audio_config.achan[channel].mark_freq = 0
-						p_audio_config.achan[channel].space_freq = 0
-					} else if strings.EqualFold(t, "G3RUH") { /* Force G3RUH modem regardless of default for speed. New in 1.6. */
-						p_audio_config.achan[channel].modem_type = MODEM_SCRAMBLE
-						p_audio_config.achan[channel].mark_freq = 0
-						p_audio_config.achan[channel].space_freq = 0
-					} else if strings.EqualFold(t, "V26A") || /* Compatible with direwolf versions <= 1.5.  New in 1.6. */
-						strings.EqualFold(t, "V26B") { /* Compatible with MFJ-2400.  New in 1.6. */
-						if p_audio_config.achan[channel].modem_type != MODEM_QPSK ||
-							p_audio_config.achan[channel].baud != 2400 {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: %s option can only be used with 2400 bps PSK.\n", line, t)
-
-							continue
-						}
-
-						p_audio_config.achan[channel].v26_alternative = IfThenElse((strings.EqualFold(t, "V26A")), V26_A, V26_B)
-					} else if t[0] == '/' { /* /div */
-						var n, _ = strconv.Atoi(t[1:])
-
-						if n >= 1 && n <= 8 {
-							p_audio_config.achan[channel].decimate = n
-						} else {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Ignoring unreasonable sample rate division factor of %d.\n", line, n)
-						}
-					} else if t[0] == '*' { /* *upsample */
-						var n, _ = strconv.Atoi(t[1:])
-
-						if n >= 1 && n <= 4 {
-							p_audio_config.achan[channel].upsample = n
-						} else {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Ignoring unreasonable upsample ratio of %d.\n", line, n)
-						}
-					} else if alllettersorpm(t) { /* profile of letter(s) + - */
-						// Will be validated later.
-						p_audio_config.achan[channel].profiles = t
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: Unrecognized option for MODEM: %s\n", line, t)
-					}
-
-					t = split("", false)
-				}
-
-				/* A later place catches disallowed combination of + and @. */
-				/* A later place sets /n for 300 baud if not specified by user. */
-
-				//dw_printf ("debug: div = %d\n", p_audio_config.achan[channel].decimate);
-			}
-		} else if strings.EqualFold(t, "DTMF") {
-			/*
-			 * DTMF  		- Enable DTMF decoder.
-			 *
-			 * Future possibilities:
-			 *	Option to determine if it goes to APRStt gateway and/or application.
-			 *	Disable normal demodulator to reduce CPU requirements.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: DTMF can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			p_audio_config.achan[channel].dtmf_decode = DTMF_DECODE_ON
-		} else if strings.EqualFold(t, "FIX_BITS") {
-			/*
-			 * FIX_BITS  n  [ APRS | AX25 | NONE ] [ PASSALL ]
-			 *
-			 *	- Attempt to fix frames with bad FCS.
-			 *	- n is maximum number of bits to attempt fixing.
-			 *	- Optional sanity check & allow everything even with bad FCS.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: FIX_BITS can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing value for FIX_BITS command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if BitFixLevel(n) >= RETRY_NONE && BitFixLevel(n) < RETRY_MAX { // MAX is actually last valid +1
-				p_audio_config.achan[channel].fix_bits = BitFixLevel(n)
-			} else {
-				p_audio_config.achan[channel].fix_bits = DEFAULT_FIX_BITS
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid value %d for FIX_BITS. Using default of %d.\n",
-					line, n, p_audio_config.achan[channel].fix_bits)
-			}
-
-			if p_audio_config.achan[channel].fix_bits > DEFAULT_FIX_BITS {
-				text_color_set(DW_COLOR_INFO)
-				dw_printf("Line %d: Using a FIX_BITS value greater than %d is not recommended for normal operation.\n",
-					line, DEFAULT_FIX_BITS)
-				dw_printf("FIX_BITS > 1 was an interesting experiment but turned out to be a bad idea.\n")
-				dw_printf("Don't be surprised if it takes 100%% CPU, direwolf can't keep up with the audio stream,\n")
-				dw_printf("and you see messages like \"Audio input device 0 error code -32: Broken pipe\"\n")
-			}
-
-			t = split("", false)
-			for t != "" {
-				// If more than one sanity test, we silently take the last one.
-				if strings.EqualFold(t, "APRS") {
-					p_audio_config.achan[channel].sanity_test = SANITY_APRS
-				} else if strings.EqualFold(t, "AX25") || strings.EqualFold(t, "AX.25") {
-					p_audio_config.achan[channel].sanity_test = SANITY_AX25
-				} else if strings.EqualFold(t, "NONE") {
-					p_audio_config.achan[channel].sanity_test = SANITY_NONE
-				} else if strings.EqualFold(t, "PASSALL") {
-					p_audio_config.achan[channel].passall = true
-
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: There is an old saying, \"Be careful what you ask for because you might get it.\"\n", line)
-					dw_printf("The PASSALL option means allow all frames even when they are invalid.\n")
-					dw_printf("You are asking to receive random trash and you WILL get your wish.\n")
-					dw_printf("Don't complain when you see all sorts of random garbage.  That's what you asked for.\n")
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Invalid option '%s' for FIX_BITS.\n", line, t)
-				}
-
-				t = split("", false)
-			}
-		} else if strings.EqualFold(t, "PTT") || strings.EqualFold(t, "DCD") || strings.EqualFold(t, "CON") {
-			/*
-			 * PTT 		- Push To Talk signal line.
-			 * DCD		- Data Carrier Detect indicator.
-			 * CON		- Connected to another station indicator.
-			 *
-			 * xxx  serial-port [-]rts-or-dtr [ [-]rts-or-dtr ]
-			 * xxx  GPIO  [-]gpio-num
-			 * xxx  LPT  [-]bit-num
-			 * PTT  RIG  model  port [ rate ]
-			 * PTT  RIG  AUTO  port [ rate ]
-			 * PTT  CM108 [ [-]bit-num ] [ hid-device ]
-			 *
-			 * 		When model is 2, port would host:port like 127.0.0.1:4532
-			 *		Otherwise, port would be a serial port like /dev/ttyS0
-			 *
-			 *
-			 * Applies to most recent CHANNEL command.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: PTT can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-			var ot int
-			var otname string
-
-			if strings.EqualFold(t, "PTT") {
-				ot = OCTYPE_PTT
-				otname = "PTT"
-			} else if strings.EqualFold(t, "DCD") {
-				ot = OCTYPE_DCD
-				otname = "DCD"
-			} else {
-				ot = OCTYPE_CON
-				otname = "CON"
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file line %d: Missing output control device for %s command.\n",
-					line, otname)
-
-				continue
-			}
-
-			if strings.EqualFold(t, "GPIO") {
-				/* GPIO case, Linux only. */
-
-				/* TODO KG
-				   #if __WIN32__
-				   	      text_color_set(DW_COLOR_ERROR);
-				   	      dw_printf ("Config file line %d: %s with GPIO is only available on Linux.\n", line, otname);
-				   #else
-				*/
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Missing GPIO number for %s.\n", line, otname)
-
-					continue
-				}
-
-				var gpio, _ = strconv.Atoi(t)
-				if gpio < 0 {
-					p_audio_config.achan[channel].octrl[ot].out_gpio_num = -1 * gpio
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = true
-				} else {
-					p_audio_config.achan[channel].octrl[ot].out_gpio_num = gpio
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = false
-				}
-
-				p_audio_config.achan[channel].octrl[ot].ptt_method = PTT_METHOD_GPIO
-				// #endif
-			} else if strings.EqualFold(t, "GPIOD") {
-				/*
-					#if __WIN32__
-						      text_color_set(DW_COLOR_ERROR);
-						      dw_printf ("Config file line %d: %s with GPIOD is only available on Linux.\n", line, otname);
-					#else
-				*/
-				// #if defined(USE_GPIOD)
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Missing GPIO chip name for %s.\n", line, otname)
-					dw_printf("Use the \"gpioinfo\" command to get a list of gpio chip names and corresponding I/O lines.\n")
-
-					continue
-				}
-
-				// Issue 590.  Originally we used the chip name, like gpiochip3, and fed it into
-				// gpiod_chip_open_by_name.   This function has disappeared in Debian 13 Trixie.
-				// We must now specify the full device path, like /dev/gpiochip3, for the only
-				// remaining open function gpiod_chip_open.
-				// We will allow the user to specify either the name or full device path.
-				// While we are here, also allow only the number as used by the gpiod utilities.
-
-				if t[0] == '/' { // Looks like device path.  Use as given.
-					p_audio_config.achan[channel].octrl[ot].out_gpio_name = t
-				} else if unicode.IsDigit(rune(t[0])) { // or if digit, prepend "/dev/gpiochip"
-					p_audio_config.achan[channel].octrl[ot].out_gpio_name = "/dev/gpiochip" + t
-				} else { // otherwise, prepend "/dev/" to the name
-					p_audio_config.achan[channel].octrl[ot].out_gpio_name = "/dev/" + t
-				}
-
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Missing GPIO number for %s.\n", line, otname)
-
-					continue
-				}
-
-				var gpio, _ = strconv.Atoi(t)
-				if gpio < 0 {
-					p_audio_config.achan[channel].octrl[ot].out_gpio_num = -1 * gpio
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = true
-				} else {
-					p_audio_config.achan[channel].octrl[ot].out_gpio_num = gpio
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = false
-				}
-
-				p_audio_config.achan[channel].octrl[ot].ptt_method = PTT_METHOD_GPIOD
-				/* TODO KG
-				#else
-					      text_color_set(DW_COLOR_ERROR);
-					      dw_printf ("Application was not built with optional support for GPIOD.\n");
-					      dw_printf ("Install packages gpiod and libgpiod-dev, remove 'build' subdirectory, then rebuild.\n");
-				#endif // USE_GPIOD
-				*/
-				//#endif /* __WIN32__ */
-			} else if strings.EqualFold(t, "LPT") {
-				/* Parallel printer case, x86 Linux only. */
-
-				//#if  ( defined(__i386__) || defined(__x86_64__) ) && ( defined(__linux__) || defined(__unix__) )
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Missing LPT bit number for %s.\n", line, otname)
-
-					continue
-				}
-
-				var lpt, _ = strconv.Atoi(t)
-				if lpt < 0 {
-					p_audio_config.achan[channel].octrl[ot].ptt_lpt_bit = -1 * lpt
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = true
-				} else {
-					p_audio_config.achan[channel].octrl[ot].ptt_lpt_bit = lpt
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = false
-				}
-
-				p_audio_config.achan[channel].octrl[ot].ptt_method = PTT_METHOD_LPT
-				/*
-					#else
-						      text_color_set(DW_COLOR_ERROR);
-						      dw_printf ("Config file line %d: %s with LPT is only available on x86 Linux.\n", line, otname);
-					#endif
-				*/
-			} else if strings.EqualFold(t, "RIG") {
-				// TODO KG #ifdef USE_HAMLIB
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Missing model number for hamlib.\n", line)
-
-					continue
-				}
-
-				if strings.EqualFold(t, "AUTO") {
-					p_audio_config.achan[channel].octrl[ot].ptt_model = -1
-				} else {
-					if !alldigits(t) {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Config file line %d: A rig number, not a name, is required here.\n", line)
-						dw_printf("For example, if you have a Yaesu FT-847, specify 101.\n")
-						dw_printf("See https://github.com/Hamlib/Hamlib/wiki/Supported-Radios for more details.\n")
-
-						continue
-					}
-
-					var n, _ = strconv.Atoi(t)
-					if n < 1 || n > 9999 {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Config file line %d: Unreasonable model number %d for hamlib.\n", line, n)
-
-						continue
-					}
-
-					p_audio_config.achan[channel].octrl[ot].ptt_model = n
-				}
-
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Missing port for hamlib.\n", line)
-
-					continue
-				}
-
-				p_audio_config.achan[channel].octrl[ot].ptt_device = t
-
-				// Optional serial port rate for CAT control PTT.
-
-				t = split("", false)
-				if t != "" {
-					if !alldigits(t) {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Config file line %d: An optional number is required here for CAT serial port speed: %s\n", line, t)
-
-						continue
-					}
-					var n, _ = strconv.Atoi(t)
-					p_audio_config.achan[channel].octrl[ot].ptt_rate = n
-				}
-
-				t = split("", false)
-				if t != "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: %s was not expected after model & port for hamlib.\n", line, t)
-				}
-
-				p_audio_config.achan[channel].octrl[ot].ptt_method = PTT_METHOD_HAMLIB
-
-				// #else
-				/* TODO KG
-				   #if __WIN32__
-				   	      text_color_set(DW_COLOR_ERROR);
-				   	      dw_printf ("Config file line %d: Windows version of direwolf does not support HAMLIB.\n", line);
-				   	      exit (EXIT_FAILURE);
-				   #else
-				*/
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file line %d: %s with RIG is only available when hamlib support is enabled.\n", line, otname)
-				dw_printf("You must rebuild direwolf with hamlib support.\n")
-				dw_printf("See User Guide for details.\n")
-				// #endif
-
-				//#endif
-			} else if strings.EqualFold(t, "CM108") {
-				/* CM108 - GPIO of USB sound card. case, Linux and Windows only. */
-
-				// TODO KG #if USE_CM108
-				if ot != OCTYPE_PTT {
-					// Future project:  Allow DCD and CON via the same device.
-					// This gets more complicated because we can't selectively change a single GPIO bit.
-					// We would need to keep track of what is currently there, change one bit, in our local
-					// copy of the status and then write out the byte for all of the pins.
-					// Let's keep it simple with just PTT for the first stab at this.
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: PTT CM108 option is only valid for PTT, not %s.\n", line, otname)
-
-					continue
-				}
-
-				p_audio_config.achan[channel].octrl[ot].out_gpio_num = 3 // All known designs use GPIO 3.
-				// User can override for special cases.
-				p_audio_config.achan[channel].octrl[ot].ptt_invert = false // High for transmit.
-				p_audio_config.achan[channel].octrl[ot].ptt_device = ""
-
-				// Try to find PTT device for audio output device.
-				// Simplifiying assumption is that we have one radio per USB Audio Adapter.
-				// Failure at this point is not an error.
-				// See if config file sets it explicitly before complaining.
-
-				p_audio_config.achan[channel].octrl[ot].ptt_device = cm108_find_ptt(p_audio_config.adev[ACHAN2ADEV(channel)].adevice_out)
-
-				for {
-					t = split("", false)
-					if t == "" {
-						break
-					}
-
-					if t[0] == '-' {
-						var gpio, _ = strconv.Atoi(t[1:])
-						p_audio_config.achan[channel].octrl[ot].out_gpio_num = -1 * gpio
-						p_audio_config.achan[channel].octrl[ot].ptt_invert = true
-					} else if unicode.IsDigit(rune(t[0])) {
-						var gpio, _ = strconv.Atoi(t)
-						p_audio_config.achan[channel].octrl[ot].out_gpio_num = gpio
-						p_audio_config.achan[channel].octrl[ot].ptt_invert = false
-					} else if t[0] == '/' {
-						p_audio_config.achan[channel].octrl[ot].ptt_device = t
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Config file line %d: Found \"%s\" when expecting GPIO number or device name like /dev/hidraw1.\n", line, t)
-
-						continue
-					}
-				}
-
-				if p_audio_config.achan[channel].octrl[ot].out_gpio_num < 1 || p_audio_config.achan[channel].octrl[ot].out_gpio_num > 8 {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: CM108 GPIO number %d is not in range of 1 thru 8.\n", line,
-						p_audio_config.achan[channel].octrl[ot].out_gpio_num)
-
-					continue
-				}
-
-				if p_audio_config.achan[channel].octrl[ot].ptt_device == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Could not determine USB Audio GPIO PTT device for audio output %s.\n", line,
-						p_audio_config.adev[ACHAN2ADEV(channel)].adevice_out)
-					/* TODO KG
-					#if __WIN32__
-						        dw_printf ("You must explicitly mention a HID path.\n");
-					#else
-					*/
-					dw_printf("You must explicitly mention a device name such as /dev/hidraw1.\n")
-					dw_printf("Run \"cm108\" utility to get a list.\n")
-					dw_printf("See Interface Guide for details.\n")
-
-					continue
-				}
-
-				p_audio_config.achan[channel].octrl[ot].ptt_method = PTT_METHOD_CM108
-
-				/* TODO KG
-				#else
-					      text_color_set(DW_COLOR_ERROR);
-					      dw_printf ("Config file line %d: %s with CM108 is only available when USB Audio GPIO support is enabled.\n", line, otname);
-					      dw_printf ("You must rebuild direwolf with CM108 Audio Adapter GPIO PTT support.\n");
-					      dw_printf ("See Interface Guide for details.\n");
-					      rtfm();
-					      exit (EXIT_FAILURE);
-				#endif
-				*/
-			} else {
-				/* serial port case. */
-				p_audio_config.achan[channel].octrl[ot].ptt_device = t
-
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Missing RTS or DTR after %s device name.\n",
-						line, otname)
-
-					continue
-				}
-
-				if strings.EqualFold(t, "rts") {
-					p_audio_config.achan[channel].octrl[ot].ptt_line = PTT_LINE_RTS
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = false
-				} else if strings.EqualFold(t, "dtr") {
-					p_audio_config.achan[channel].octrl[ot].ptt_line = PTT_LINE_DTR
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = false
-				} else if strings.EqualFold(t, "-rts") {
-					p_audio_config.achan[channel].octrl[ot].ptt_line = PTT_LINE_RTS
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = true
-				} else if strings.EqualFold(t, "-dtr") {
-					p_audio_config.achan[channel].octrl[ot].ptt_line = PTT_LINE_DTR
-					p_audio_config.achan[channel].octrl[ot].ptt_invert = true
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Expected RTS or DTR after %s device name.\n",
-						line, otname)
-
-					continue
-				}
-
-				p_audio_config.achan[channel].octrl[ot].ptt_method = PTT_METHOD_SERIAL
-
-				/* In version 1.2, we allow a second one for same serial port. */
-				/* Some interfaces want the two control lines driven with opposite polarity. */
-				/* e.g.   PTT COM1 RTS -DTR  */
-
-				t = split("", false)
-				if t != "" {
-					if strings.EqualFold(t, "rts") {
-						p_audio_config.achan[channel].octrl[ot].ptt_line2 = PTT_LINE_RTS
-						p_audio_config.achan[channel].octrl[ot].ptt_invert2 = false
-					} else if strings.EqualFold(t, "dtr") {
-						p_audio_config.achan[channel].octrl[ot].ptt_line2 = PTT_LINE_DTR
-						p_audio_config.achan[channel].octrl[ot].ptt_invert2 = false
-					} else if strings.EqualFold(t, "-rts") {
-						p_audio_config.achan[channel].octrl[ot].ptt_line2 = PTT_LINE_RTS
-						p_audio_config.achan[channel].octrl[ot].ptt_invert2 = true
-					} else if strings.EqualFold(t, "-dtr") {
-						p_audio_config.achan[channel].octrl[ot].ptt_line2 = PTT_LINE_DTR
-						p_audio_config.achan[channel].octrl[ot].ptt_invert2 = true
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Config file line %d: Expected RTS or DTR after first RTS or DTR.\n",
-							line)
-
-						continue
-					}
-
-					/* Would not make sense to specify the same one twice. */
-
-					if p_audio_config.achan[channel].octrl[ot].ptt_line == p_audio_config.achan[channel].octrl[ot].ptt_line2 {
-						dw_printf("Config file line %d: Doesn't make sense to specify the some control line twice.\n",
-							line)
-					}
-				} /* end of second serial port control line. */
-			} /* end of serial port case. */
-			/* end of PTT, DCD, CON */
-		} else if strings.EqualFold(t, "TXINH") {
-			/*
-			 * INPUTS
-			 *
-			 * TXINH - TX holdoff input
-			 *
-			 * TXINH GPIO [-]gpio-num (only type supported so far)
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TXINH can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-			var itname = "TXINH"
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file line %d: Missing input type name for %s command.\n", line, itname)
-
-				continue
-			}
-
-			if strings.EqualFold(t, "GPIO") {
-				/* TODO KG
-				#if __WIN32__
-					      text_color_set(DW_COLOR_ERROR);
-					      dw_printf ("Config file line %d: %s with GPIO is only available on Linux.\n", line, itname);
-				#else
-				*/
-				t = split("", false)
-				if t == "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file line %d: Missing GPIO number for %s.\n", line, itname)
-
-					continue
-				}
-
-				var gpio, _ = strconv.Atoi(t)
-				if gpio < 0 {
-					p_audio_config.achan[channel].ictrl[ICTYPE_TXINH].in_gpio_num = -1 * gpio
-					p_audio_config.achan[channel].ictrl[ICTYPE_TXINH].invert = true
-				} else {
-					p_audio_config.achan[channel].ictrl[ICTYPE_TXINH].in_gpio_num = gpio
-					p_audio_config.achan[channel].ictrl[ICTYPE_TXINH].invert = false
-				}
-
-				p_audio_config.achan[channel].ictrl[ICTYPE_TXINH].method = PTT_METHOD_GPIO
-				// #endif
-			}
-		} else if strings.EqualFold(t, "DWAIT") {
-			/*
-			 * DWAIT n		- Extra delay for receiver squelch. n = 10 mS units.
-			 *
-			 * Why did I do this?  Just add more to TXDELAY.
-			 * Now undocumented in User Guide.  Might disappear someday.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: DWAIT can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing delay time for DWAIT command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 0 && n <= 255 {
-				p_audio_config.achan[channel].dwait = n
-			} else {
-				p_audio_config.achan[channel].dwait = DEFAULT_DWAIT
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid delay time for DWAIT. Using %d.\n",
-					line, p_audio_config.achan[channel].dwait)
-			}
-		} else if strings.EqualFold(t, "SLOTTIME") {
-			/*
-			 * SLOTTIME n		- For non-digipeat transmit delay timing. n = 10 mS units.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: SLOTTIME can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing delay time for SLOTTIME command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 5 && n < 50 {
-				// 0 = User has no clue.  This would be no delay.
-				// 10 = Default.
-				// 50 = Half second.  User might think it is mSec and use 100.
-				p_audio_config.achan[channel].slottime = n
-			} else {
-				p_audio_config.achan[channel].slottime = DEFAULT_SLOTTIME
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid delay time for persist algorithm. Using default %d.\n",
-					line, p_audio_config.achan[channel].slottime)
-				dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
-				dw_printf("section, to understand what this means.\n")
-				dw_printf("Why don't you just use the default?\n")
-			}
-		} else if strings.EqualFold(t, "PERSIST") {
-			/*
-			 * PERSIST 		- For non-digipeat transmit delay timing.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: PERSIST can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing probability for PERSIST command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 5 && n <= 250 {
-				p_audio_config.achan[channel].persist = n
-			} else {
-				p_audio_config.achan[channel].persist = DEFAULT_PERSIST
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid probability for persist algorithm. Using default %d.\n",
-					line, p_audio_config.achan[channel].persist)
-				dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
-				dw_printf("section, to understand what this means.\n")
-				dw_printf("Why don't you just use the default?\n")
-			}
-		} else if strings.EqualFold(t, "TXDELAY") {
-			/*
-			 * TXDELAY n		- For transmit delay timing. n = 10 mS units.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TXDELAY can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing time for TXDELAY command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 0 && n <= 255 {
-				text_color_set(DW_COLOR_ERROR)
-
-				if n < 10 {
-					dw_printf("Line %d: Setting TXDELAY this small is a REALLY BAD idea if you want other stations to hear you.\n",
-						line)
-					dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
-					dw_printf("section, to understand what this means.\n")
-					dw_printf("Why don't you just use the default rather than reducing reliability?\n")
-				} else if n >= 100 {
-					dw_printf("Line %d: Keeping with tradition, going back to the 1980s, TXDELAY is in 10 millisecond units.\n",
-						line)
-					dw_printf("Line %d: The value %d would be %.3f seconds which seems rather excessive.  Are you sure you want that?\n",
-						line, n, float64(n)*10./1000.)
-					dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
-					dw_printf("section, to understand what this means.\n")
-					dw_printf("Why don't you just use the default?\n")
-				}
-
-				p_audio_config.achan[channel].txdelay = n
-			} else {
-				p_audio_config.achan[channel].txdelay = DEFAULT_TXDELAY
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid time for transmit delay. Using %d.\n",
-					line, p_audio_config.achan[channel].txdelay)
-			}
-		} else if strings.EqualFold(t, "TXTAIL") {
-			/*
-			 * TXTAIL n		- For transmit timing. n = 10 mS units.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TXTAIL can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing time for TXTAIL command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 0 && n <= 255 {
-				if n < 5 {
-					dw_printf("Line %d: Setting TXTAIL that small is a REALLY BAD idea if you want other stations to hear you.\n",
-						line)
-					dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
-					dw_printf("section, to understand what this means.\n")
-					dw_printf("Why don't you just use the default rather than reducing reliability?\n")
-				} else if n >= 50 {
-					dw_printf("Line %d: Keeping with tradition, going back to the 1980s, TXTAIL is in 10 millisecond units.\n",
-						line)
-					dw_printf("Line %d: The value %d would be %.3f seconds which seems rather excessive.  Are you sure you want that?\n",
-						line, n, float64(n)*10./1000.)
-					dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
-					dw_printf("section, to understand what this means.\n")
-					dw_printf("Why don't you just use the default?\n")
-				}
-
-				p_audio_config.achan[channel].txtail = n
-			} else {
-				p_audio_config.achan[channel].txtail = DEFAULT_TXTAIL
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid time for transmit timing. Using %d.\n",
-					line, p_audio_config.achan[channel].txtail)
-			}
-		} else if strings.EqualFold(t, "FULLDUP") {
-			/*
-			 * FULLDUP  {on|off} 		- Full Duplex
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: FULLDUP can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing parameter for FULLDUP command.  Expecting ON or OFF.\n", line)
-
-				continue
-			}
-
-			if strings.EqualFold(t, "ON") {
-				p_audio_config.achan[channel].fulldup = true
-			} else if strings.EqualFold(t, "OFF") {
-				p_audio_config.achan[channel].fulldup = false
-			} else {
-				p_audio_config.achan[channel].fulldup = false
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Expected ON or OFF for FULLDUP.\n", line)
-			}
-		} else if strings.EqualFold(t, "SPEECH") {
-			/*
-			 * SPEECH  script
-			 *
-			 * Specify script for text-to-speech function.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: SPEECH can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing script for Text-to-Speech function.\n", line)
-
-				continue
-			}
-
-			/* See if we can run it. */
-
-			/* TODO KG Do we *actually* want to do this...? If so, let's do it when we've ported this to Go...
-			    if (xmit_speak_it(t, -1, " ") == 0) {
-			      if (strlcpy (p_audio_config.tts_script, t, sizeof(p_audio_config.tts_script)) >= sizeof(p_audio_config.tts_script)) {
-			        text_color_set(DW_COLOR_ERROR);
-			        dw_printf ("Line %d: Script for text-to-speech function is too long.\n", line);
-			      }
-			    } else {
-			      text_color_set(DW_COLOR_ERROR);
-			      dw_printf ("Line %d: Error trying to run Text-to-Speech function.\n", line);
-			      continue;
-			   }
-			*/
-		} else if strings.EqualFold(t, "FX25TX") {
-			/*
-			 * FX25TX n		- Enable FX.25 transmission.  Default off.
-			 *				0 = off, 1 = auto mode, others are suggestions for testing
-			 *				or special cases.  16, 32, 64 is number of parity bytes to add.
-			 *				Also set by "-X n" command line option.
-			 *				V1.7 changed from global to per-channel setting.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: FX25TX can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing FEC mode for FX25TX command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 0 && n < 200 {
-				p_audio_config.achan[channel].fx25_strength = n
-				p_audio_config.achan[channel].layer2_xmit = LAYER2_FX25
-			} else {
-				p_audio_config.achan[channel].fx25_strength = 1
-				p_audio_config.achan[channel].layer2_xmit = LAYER2_FX25
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Unreasonable value for FX.25 transmission mode. Using %d.\n",
-					line, p_audio_config.achan[channel].fx25_strength)
-			}
-		} else if strings.EqualFold(t, "FX25AUTO") {
-			/*
-			 * FX25AUTO n		- Enable Automatic use of FX.25 for connected mode.  *** Not Implemented ***
-			 *				Automatically enable, for that session only, when an identical
-			 *				frame is sent more than this number of times.
-			 *				Default 5 based on half of default RETRY.
-			 *				0 to disable feature.
-			 *				Current a global setting.  Could be per channel someday.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: FX25AUTO can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing count for FX25AUTO command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 0 && n < 20 {
-				p_audio_config.fx25_auto_enable = n
-			} else {
-				p_audio_config.fx25_auto_enable = AX25_N2_RETRY_DEFAULT / 2
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Unreasonable count for connected mode automatic FX.25. Using %d.\n",
-					line, p_audio_config.fx25_auto_enable)
-			}
-		} else if strings.EqualFold(t, "IL2PTX") {
-			/*
-			 * IL2PTX  [ + - ] [ 0 1 ]	- Enable IL2P transmission.  Default off.
-			 *				"+" means normal polarity. Redundant since it is the default.
-			 *					(command line -I for first channel)
-			 *				"-" means inverted polarity. Do not use for 1200 bps.
-			 *					(command line -i for first channel)
-			 *				"0" means weak FEC.  Not recommended.
-			 *				"1" means stronger FEC.  "Max FEC."  Default if not specified.
-			 */
-			if channel < 0 || channel >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: IL2PTX can only be used with radio channel 0 - %d.\n", line, MAX_RADIO_CHANS-1)
-
-				continue
-			}
-
-			p_audio_config.achan[channel].layer2_xmit = LAYER2_IL2P
-			p_audio_config.achan[channel].il2p_max_fec = 1
-			p_audio_config.achan[channel].il2p_invert_polarity = 0
-
-			for {
-				t = split("", false)
-				if t == "" {
-					break
-				}
-
-				for _, c := range t {
-					switch c {
-					case '+':
-						p_audio_config.achan[channel].il2p_invert_polarity = 0
-					case '-':
-						p_audio_config.achan[channel].il2p_invert_polarity = 1
-					case '0':
-						p_audio_config.achan[channel].il2p_max_fec = 0
-					case '1':
-						p_audio_config.achan[channel].il2p_max_fec = 1
-					default:
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: Invalid parameter '%c' for IL2PTX command.\n", line, c)
-
-						continue
-					}
-				}
-			}
-		} else if strings.EqualFold(t, "DIGIPEAT") || strings.EqualFold(t, "DIGIPEATER") {
-			/*
-			 * ==================== APRS Digipeater parameters ====================
-			 */
-
-			/*
-			 * DIGIPEAT  from-chan  to-chan  alias-pattern  wide-pattern  [ OFF|DROP|MARK|TRACE | ATGP=alias ]
-			 *
-			 * ATGP is an ugly hack for the specific need of ATGP which needs more that 8 digipeaters.
-			 * DO NOT put this in the User Guide.  On a need to know basis.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing FROM-channel on line %d.\n", line)
-
-				continue
-			}
-
-			if !alldigits(t) {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: '%s' is not allowed for FROM-channel.  It must be a number.\n",
-					line, t)
-
-				continue
-			}
-
-			var from_chan, _ = strconv.Atoi(t)
-			if from_chan < 0 || from_chan >= MAX_TOTAL_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: FROM-channel must be in range of 0 to %d on line %d.\n",
-					MAX_TOTAL_CHANS-1, line)
-
-				continue
-			}
-
-			// Channels specified must be radio channels or network TNCs.
-
-			if p_audio_config.chan_medium[from_chan] != MEDIUM_RADIO &&
-				p_audio_config.chan_medium[from_chan] != MEDIUM_NETTNC {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
-					line, from_chan)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing TO-channel on line %d.\n", line)
-
-				continue
-			}
-
-			if !alldigits(t) {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: '%s' is not allowed for TO-channel.  It must be a number.\n",
-					line, t)
-
-				continue
-			}
-
-			var to_chan, _ = strconv.Atoi(t)
-			if to_chan < 0 || to_chan >= MAX_TOTAL_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: TO-channel must be in range of 0 to %d on line %d.\n",
-					MAX_TOTAL_CHANS-1, line)
-
-				continue
-			}
-
-			if p_audio_config.chan_medium[to_chan] != MEDIUM_RADIO &&
-				p_audio_config.chan_medium[to_chan] != MEDIUM_NETTNC {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
-					line, to_chan)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing alias pattern on line %d.\n", line)
-
-				continue
-			}
-
-			var r, err = regexp.Compile(t)
-			if err != nil {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Invalid alias matching pattern on line %d:\n%s\n", line, err)
-
-				continue
-			}
-
-			p_digi_config.alias[from_chan][to_chan] = r
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing wide pattern on line %d.\n", line)
-
-				continue
-			}
-
-			r, err = regexp.Compile(t)
-			if err != nil {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Invalid wide matching pattern on line %d:\n%s\n", line, err)
-
-				continue
-			}
-
-			p_digi_config.wide[from_chan][to_chan] = r
-
-			p_digi_config.enabled[from_chan][to_chan] = true
-			p_digi_config.preempt[from_chan][to_chan] = PREEMPT_OFF
-
-			t = split("", false)
-			if t != "" {
-				if strings.EqualFold(t, "OFF") {
-					p_digi_config.preempt[from_chan][to_chan] = PREEMPT_OFF
-					t = split("", false)
-				} else if strings.EqualFold(t, "DROP") {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: Preemptive digipeating DROP option is discouraged.\n", line)
-					dw_printf("It can create a via path which is misleading about the actual path taken.\n")
-					dw_printf("PREEMPT is the best choice for this feature.\n")
-
-					p_digi_config.preempt[from_chan][to_chan] = PREEMPT_DROP
-					t = split("", false)
-				} else if strings.EqualFold(t, "MARK") {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: Preemptive digipeating MARK option is discouraged.\n", line)
-					dw_printf("It can create a via path which is misleading about the actual path taken.\n")
-					dw_printf("PREEMPT is the best choice for this feature.\n")
-
-					p_digi_config.preempt[from_chan][to_chan] = PREEMPT_MARK
-					t = split("", false)
-				} else if (strings.EqualFold(t, "TRACE")) || (strings.HasPrefix(strings.ToUpper(t), "PREEMPT")) {
-					p_digi_config.preempt[from_chan][to_chan] = PREEMPT_TRACE
-					t = split("", false)
-				} else if strings.HasPrefix(strings.ToUpper(t), "ATGP=") {
-					p_digi_config.atgp[from_chan][to_chan] = t[5:]
-					t = split("", false)
-				}
-			}
-
-			if t != "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: Found \"%s\" where end of line was expected.\n", line, t)
-			}
-		} else if strings.EqualFold(t, "DEDUPE") {
-			/*
-			 * DEDUPE 		- Time to suppress digipeating of duplicate APRS packets.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing time for DEDUPE command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 0 && n < 600 {
-				p_digi_config.dedupe_time = n
-			} else {
-				p_digi_config.dedupe_time = DEFAULT_DEDUPE
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Unreasonable value for dedupe time. Using %d.\n",
-					line, p_digi_config.dedupe_time)
-			}
-		} else if strings.EqualFold(t, "regen") {
-			/*
-			 * REGEN 		- Signal regeneration.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing FROM-channel on line %d.\n", line)
-
-				continue
-			}
-
-			if !alldigits(t) {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: '%s' is not allowed for FROM-channel.  It must be a number.\n",
-					line, t)
-
-				continue
-			}
-
-			var from_chan, _ = strconv.Atoi(t)
-			if from_chan < 0 || from_chan >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: FROM-channel must be in range of 0 to %d on line %d.\n",
-					MAX_RADIO_CHANS-1, line)
-
-				continue
-			}
-
-			// Only radio channels are valid for regenerate.
-
-			if p_audio_config.chan_medium[from_chan] != MEDIUM_RADIO {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
-					line, from_chan)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing TO-channel on line %d.\n", line)
-
-				continue
-			}
-
-			if !alldigits(t) {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: '%s' is not allowed for TO-channel.  It must be a number.\n",
-					line, t)
-
-				continue
-			}
-
-			var to_chan, _ = strconv.Atoi(t)
-			if to_chan < 0 || to_chan >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: TO-channel must be in range of 0 to %d on line %d.\n",
-					MAX_RADIO_CHANS-1, line)
-
-				continue
-			}
-
-			if p_audio_config.chan_medium[to_chan] != MEDIUM_RADIO {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
-					line, to_chan)
-
-				continue
-			}
-
-			p_digi_config.regen[from_chan][to_chan] = true
-		} else if strings.EqualFold(t, "CDIGIPEAT") || strings.EqualFold(t, "CDIGIPEATER") {
-			/*
-			 * ==================== Connected Digipeater parameters ====================
-			 */
-
-			/*
-			 * CDIGIPEAT  from-chan  to-chan [ alias-pattern ]
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing FROM-channel on line %d.\n", line)
-
-				continue
-			}
-
-			if !alldigits(t) {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: '%s' is not allowed for FROM-channel.  It must be a number.\n",
-					line, t)
-
-				continue
-			}
-
-			var from_chan, _ = strconv.Atoi(t)
-			if from_chan < 0 || from_chan >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: FROM-channel must be in range of 0 to %d on line %d.\n",
-					MAX_RADIO_CHANS-1, line)
-
-				continue
-			}
-
-			// For connected mode Link layer, only internal modems should be allowed.
-			// A network TNC probably would not provide information about channel status.
-			// There is discussion about this in the document called
-			// Why-is-9600-only-twice-as-fast-as-1200.pdf
-
-			if p_audio_config.chan_medium[from_chan] != MEDIUM_RADIO {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
-					line, from_chan)
-				dw_printf("Only internal modems can be used for connected mode packet.\n")
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing TO-channel on line %d.\n", line)
-
-				continue
-			}
-
-			if !alldigits(t) {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: '%s' is not allowed for TO-channel.  It must be a number.\n",
-					line, t)
-
-				continue
-			}
-
-			var to_chan, _ = strconv.Atoi(t)
-			if to_chan < 0 || to_chan >= MAX_RADIO_CHANS {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: TO-channel must be in range of 0 to %d on line %d.\n",
-					MAX_RADIO_CHANS-1, line)
-
-				continue
-			}
-
-			if p_audio_config.chan_medium[to_chan] != MEDIUM_RADIO {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
-					line, to_chan)
-				dw_printf("Only internal modems can be used for connected mode packet.\n")
-
-				continue
-			}
-
-			t = split("", false)
-			if t != "" {
-				var r, err = regexp.Compile(t)
-				if err == nil {
-					p_cdigi_config.alias[from_chan][to_chan] = r
-					p_cdigi_config.has_alias[from_chan][to_chan] = true
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: Invalid alias matching pattern on line %d:\n%s\n", line, err)
-
-					continue
-				}
-
-				t = split("", false)
-			}
-
-			p_cdigi_config.enabled[from_chan][to_chan] = true
-
-			if t != "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: Found \"%s\" where end of line was expected.\n", line, t)
-			}
-		} else if strings.EqualFold(t, "FILTER") {
-			/*
-			 * ==================== Packet Filtering for APRS digipeater or IGate ====================
-			 */
-
-			/*
-			 * FILTER  from-chan  to-chan  filter_specification_expression
-			 * FILTER  from-chan  IG       filter_specification_expression
-			 * FILTER  IG         to-chan  filter_specification_expression
-			 *
-			 *
-			 * Note that we have three different config file filter commands:
-			 *
-			 *	FILTER		- Originally for APRS digipeating but later enhanced
-			 *			  to include IGate client side.  Maybe it should be
-			 *			  renamed AFILTER to make it clearer after adding CFILTER.
-			 *
-			 *			  Both internal modem and NET TNC channels allowed here.
-			 *			  "IG" should be used for the IGate, NOT a virtual channel
-			 *			  assigned to it.
-			 *
-			 *	CFILTER		- Similar for connected moded digipeater.
-			 *
-			 *			  Only internal modems can be used because they provide
-			 *			  information about radio channel status.
-			 *			  A remote network TNC might not provide the necessary
-			 *			  status for correct operation.
-			 *			  There is discussion about this in the document called
-			 *			  Why-is-9600-only-twice-as-fast-as-1200.pdf
-			 *
-			 *	IGFILTER	- APRS-IS (IGate) server side - completely different.
-			 *			  I'm not happy with this name because IG sounds like IGate
-			 *			  which is really the client side.  More comments later.
-			 *			  Maybe it should be called subscribe or something like that
-			 *			  because the subscriptions are cumulative.
-			 */
-			var from_chan int
-			var to_chan int
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing FROM-channel on line %d.\n", line)
-
-				continue
-			}
-
-			if t[0] == 'i' || t[0] == 'I' {
-				from_chan = MAX_TOTAL_CHANS
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: FILTER IG ... on line %d.\n", line)
-				dw_printf("Warning! Don't mess with IS>RF filtering unless you are an expert and have an unusual situation.\n")
-				dw_printf("Warning! The default is fine for nearly all situations.\n")
-				dw_printf("Warning! Be sure to read carefully and understand  \"Successful-APRS-Gateway-Operation.pdf\" .\n")
-				dw_printf("Warning! If you insist, be sure to add \" | i/180 \" so you don't break messaging.\n")
-			} else {
-				var fromChanErr error
-
-				from_chan, fromChanErr = strconv.Atoi(t)
-				if from_chan < 0 || from_chan >= MAX_TOTAL_CHANS || fromChanErr != nil {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: Filter FROM-channel must be in range of 0 to %d or \"IG\" on line %d.\n",
-						MAX_TOTAL_CHANS-1, line)
-
-					continue
-				}
-
-				if p_audio_config.chan_medium[from_chan] != MEDIUM_RADIO &&
-					p_audio_config.chan_medium[from_chan] != MEDIUM_NETTNC {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
-						line, from_chan)
-
-					continue
-				}
-
-				if p_audio_config.chan_medium[from_chan] == MEDIUM_IGATE {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: Use 'IG' rather than %d for FROM-channel.\n",
-						line, from_chan)
-
-					continue
-				}
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing TO-channel on line %d.\n", line)
-
-				continue
-			}
-
-			if t[0] == 'i' || t[0] == 'I' {
-				to_chan = MAX_TOTAL_CHANS
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: FILTER ... IG ... on line %d.\n", line)
-				dw_printf("Warning! Don't mess with RF>IS filtering unless you are an expert and have an unusual situation.\n")
-				dw_printf("Warning! Expected behavior is for everything to go from RF to IS.\n")
-				dw_printf("Warning! The default is fine for nearly all situations.\n")
-				dw_printf("Warning! Be sure to read carefully and understand  \"Successful-APRS-Gateway-Operation.pdf\" .\n")
-			} else {
-				var toChanErr error
-
-				to_chan, toChanErr = strconv.Atoi(t)
-				if to_chan < 0 || to_chan >= MAX_TOTAL_CHANS || toChanErr != nil {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: Filter TO-channel must be in range of 0 to %d or \"IG\" on line %d.\n",
-						MAX_TOTAL_CHANS-1, line)
-
-					continue
-				}
-
-				if p_audio_config.chan_medium[to_chan] != MEDIUM_RADIO &&
-					p_audio_config.chan_medium[to_chan] != MEDIUM_NETTNC {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
-						line, to_chan)
-
-					continue
-				}
-
-				if p_audio_config.chan_medium[to_chan] == MEDIUM_IGATE {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: Use 'IG' rather than %d for TO-channel.\n",
-						line, to_chan)
-
-					continue
-				}
-			}
-
-			t = split("", true) /* Take rest of line including spaces. */
-
-			if t == "" {
-				t = " " /* Empty means permit nothing. */
-			}
-
-			if p_digi_config.filter_str[from_chan][to_chan] != "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: Replacing previous filter for same from/to pair:\n        %s\n", line, p_digi_config.filter_str[from_chan][to_chan])
-				p_digi_config.filter_str[from_chan][to_chan] = ""
-			}
-
-			p_digi_config.filter_str[from_chan][to_chan] = t
-
-			//TODO:  Do a test run to see errors now instead of waiting.
-		} else if strings.EqualFold(t, "CFILTER") {
-			/*
-			 * ==================== Packet Filtering for connected digipeater ====================
-			 */
-
-			/*
-			 * CFILTER  from-chan  to-chan  filter_specification_expression
-			 *
-			 * Why did I put this here?
-			 * What would be a useful use case?  Perhaps block by source or destination?
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing FROM-channel on line %d.\n", line)
-
-				continue
-			}
-
-			var from_chan, fromChanErr = strconv.Atoi(t)
-			if from_chan < 0 || from_chan >= MAX_RADIO_CHANS || fromChanErr != nil {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Filter FROM-channel must be in range of 0 to %d on line %d.\n",
-					MAX_RADIO_CHANS-1, line)
-
-				continue
-			}
-
-			// DO NOT allow a network TNC here.
-			// Must be internal modem to have necessary knowledge about channel status.
-
-			if p_audio_config.chan_medium[from_chan] != MEDIUM_RADIO {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
-					line, from_chan)
-
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing TO-channel on line %d.\n", line)
-
-				continue
-			}
-
-			var to_chan, toChanErr = strconv.Atoi(t)
-			if to_chan < 0 || to_chan >= MAX_RADIO_CHANS || toChanErr != nil {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Filter TO-channel must be in range of 0 to %d on line %d.\n",
-					MAX_RADIO_CHANS-1, line)
-
-				continue
-			}
-
-			if p_audio_config.chan_medium[to_chan] != MEDIUM_RADIO {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
-					line, to_chan)
-
-				continue
-			}
-
-			t = split("", true) /* Take rest of line including spaces. */
-
-			if t == "" {
-				t = " " /* Empty means permit nothing. */
-			}
-
-			p_cdigi_config.cfilter_str[from_chan][to_chan] = t
-
-			//TODO1.2:  Do a test run to see errors now instead of waiting.
-		} else if strings.EqualFold(t, "TTCORRAL") {
-			/*
-			 * ==================== APRStt gateway ====================
-			 */
-
-			/*
-			 * TTCORRAL 		- How to handle unknown positions
-			 *
-			 * TTCORRAL  latitude  longitude  offset-or-ambiguity
-			 */
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing latitude for TTCORRAL command.\n", line)
-				continue
-			}
-			p_tt_config.corral_lat = parse_ll(t, LAT, line)
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing longitude for TTCORRAL command.\n", line)
-				continue
-			}
-			p_tt_config.corral_lon = parse_ll(t, LON, line)
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing longitude for TTCORRAL command.\n", line)
-				continue
-			}
-			p_tt_config.corral_offset = parse_ll(t, LAT, line)
-			if p_tt_config.corral_offset == 1 ||
-				p_tt_config.corral_offset == 2 ||
-				p_tt_config.corral_offset == 3 {
-				p_tt_config.corral_ambiguity = int(p_tt_config.corral_offset)
-				p_tt_config.corral_offset = 0
-			}
-
-			//dw_printf ("DEBUG: corral %f %f %f %d\n", p_tt_config.corral_lat,
-			//	p_tt_config.corral_lon, p_tt_config.corral_offset, p_tt_config.corral_ambiguity);
-		} else if strings.EqualFold(t, "TTPOINT") {
-			/*
-			 * TTPOINT 		- Define a point represented by touch tone sequence.
-			 *
-			 * TTPOINT   pattern  latitude  longitude
-			 */
-
-			var tl = new(ttloc_s)
-			tl.ttlocType = TTLOC_POINT
-
-			// Pattern: B and digits
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTPOINT command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			if t[0] != 'B' {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTPOINT pattern must begin with upper case 'B'.\n", line)
-			}
-
-			for _, j := range t[1:] {
-				if !unicode.IsDigit(j) {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTPOINT pattern must be B and digits only.\n", line)
-				}
-			}
-
-			// Latitude
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing latitude for TTPOINT command.\n", line)
-				continue
-			}
-			tl.point.lat = parse_ll(t, LAT, line)
-
-			// Longitude
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing longitude for TTPOINT command.\n", line)
-				continue
-			}
-			tl.point.lon = parse_ll(t, LON, line)
-
-			p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-		} else if strings.EqualFold(t, "TTVECTOR") {
-			/*
-			 * TTVECTOR 		- Touch tone location with bearing and distance.
-			 *
-			 * TTVECTOR   pattern  latitude  longitude  scale  unit
-			 */
-
-			var tl = new(ttloc_s)
-			tl.ttlocType = TTLOC_VECTOR
-			tl.pattern = ""
-			tl.vector.lat = 0
-			tl.vector.lon = 0
-			tl.vector.scale = 1
-
-			// Pattern: B5bbbd...
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTVECTOR command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			if t[0] != 'B' {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTVECTOR pattern must begin with upper case 'B'.\n", line)
-			}
-			if !strings.HasPrefix(t[1:], "5bbb") {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTVECTOR pattern would normally contain \"5bbb\".\n", line)
-			}
-			for j := 1; j < len(t); j++ {
-				if !unicode.IsDigit(rune(t[j])) && t[j] != 'b' && t[j] != 'd' {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTVECTOR pattern must contain only B, digits, b, and d.\n", line)
-				}
-			}
-
-			// Latitude
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing latitude for TTVECTOR command.\n", line)
-				continue
-			}
-			tl.vector.lat = parse_ll(t, LAT, line)
-
-			// Longitude
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing longitude for TTVECTOR command.\n", line)
-				continue
-			}
-			tl.vector.lon = parse_ll(t, LON, line)
-
-			// Longitude
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing scale for TTVECTOR command.\n", line)
-				continue
-			}
-			var scale, _ = strconv.ParseFloat(t, 64)
-
-			// Unit.
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing unit for TTVECTOR command.\n", line)
-				continue
-			}
-
-			var meters float64
-			for j := 0; j < len(units) && meters == 0; j++ {
-				if strings.EqualFold(units[j].name, t) {
-					meters = units[j].meters
-				}
-			}
-			if meters == 0 {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Unrecognized unit for TTVECTOR command.  Using miles.\n", line)
-				meters = 1609.344
-			}
-			tl.vector.scale = scale * meters
-
-			p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-		} else if strings.EqualFold(t, "TTGRID") {
-			/*
-			 * TTGRID 		- Define a grid for touch tone locations.
-			 *
-			 * TTGRID   pattern  min-latitude  min-longitude  max-latitude  max-longitude
-			 */
-
-			var tl = new(ttloc_s)
-			tl.ttlocType = TTLOC_GRID
-
-			// Pattern: B [digit] x... y...
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTGRID command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			if t[0] != 'B' {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTGRID pattern must begin with upper case 'B'.\n", line)
-			}
-			for j := 1; j < len(t); j++ {
-				if !unicode.IsDigit(rune(t[j])) && t[j] != 'x' && t[j] != 'y' {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTGRID pattern must be B, optional digit, xxx, yyy.\n", line)
-				}
-			}
-
-			// Minimum Latitude - all zeros in received data
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing minimum latitude for TTGRID command.\n", line)
-				continue
-			}
-			tl.grid.lat0 = parse_ll(t, LAT, line)
-
-			// Minimum Longitude - all zeros in received data
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing minimum longitude for TTGRID command.\n", line)
-				continue
-			}
-			tl.grid.lon0 = parse_ll(t, LON, line)
-
-			// Maximum Latitude - all nines in received data
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing maximum latitude for TTGRID command.\n", line)
-				continue
-			}
-			tl.grid.lat9 = parse_ll(t, LAT, line)
-
-			// Maximum Longitude - all nines in received data
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing maximum longitude for TTGRID command.\n", line)
-				continue
-			}
-			tl.grid.lon9 = parse_ll(t, LON, line)
-
-			p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-		} else if strings.EqualFold(t, "TTUTM") {
-			/*
-			 * TTUTM 		- Specify UTM zone for touch tone locations.
-			 *
-			 * TTUTM   pattern  zone [ scale [ x-offset y-offset ] ]
-			 */
-
-			var tl = new(ttloc_s)
-			tl.ttlocType = TTLOC_UTM
-			tl.utm.scale = 1
-
-			// Pattern: B [digit] x... y...
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTUTM command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			if t[0] != 'B' {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTUTM pattern must begin with upper case 'B'.\n", line)
-				continue
-			}
-			for j := 1; j < len(t); j++ {
-				if !unicode.IsDigit(rune(t[j])) && t[j] != 'x' && t[j] != 'y' {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTUTM pattern must be B, optional digit, xxx, yyy.\n", line)
-					// Bail out somehow.  continue would match inner for.
-				}
-			}
-
-			// Zone 1 - 60 and optional latitudinal letter.
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing zone for TTUTM command.\n", line)
-				continue
-			}
-
-			tl.utm.latband, tl.utm.hemi, tl.utm.lzone = parse_utm_zone(t)
-
-			// Optional scale.
-
-			t = split("", false)
-			if t != "" {
-
-				tl.utm.scale, _ = strconv.ParseFloat(t, 64)
-
-				// Optional x offset.
-
-				t = split("", false)
-				if t != "" {
-
-					tl.utm.x_offset, _ = strconv.ParseFloat(t, 64)
-
-					// Optional y offset.
-
-					t = split("", false)
-					if t != "" {
-
-						tl.utm.y_offset, _ = strconv.ParseFloat(t, 64)
-					}
-				}
-			}
-
-			// Practice run to see if conversion might fail later with actual location.
-
-			var utm = coordconv.UTMCoord{
-				Zone:       tl.utm.lzone,
-				Hemisphere: HemisphereRuneToCoordconvHemisphere(tl.utm.hemi),
-				Easting:    tl.utm.x_offset + 5*tl.utm.scale,
-				Northing:   tl.utm.y_offset + 5*tl.utm.scale,
-			}
-			var _, geoErr = coordconv.DefaultUTMConverter.ConvertToGeodetic(utm)
-
-			if geoErr != nil {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid UTM location: \n%s\n", line, geoErr)
-				continue
-			}
-
-			p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-		} else if strings.EqualFold(t, "TTUSNG") || strings.EqualFold(t, "TTMGRS") {
-			/*
-			 * TTUSNG, TTMGRS 		- Specify zone/square for touch tone locations.
-			 *
-			 * TTUSNG   pattern  zone_square
-			 * TTMGRS   pattern  zone_square
-			 */
-
-			var tl = new(ttloc_s)
-
-			// TODO1.2: in progress...
-			if strings.EqualFold(t, "TTMGRS") {
-				tl.ttlocType = TTLOC_MGRS
-			} else {
-				tl.ttlocType = TTLOC_USNG
-			}
-
-			// Pattern: B [digit] x... y...
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTUSNG/TTMGRS command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			if t[0] != 'B' {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTUSNG/TTMGRS pattern must begin with upper case 'B'.\n", line)
-				continue
-			}
-			var num_x = 0
-			var num_y = 0
-			for j := 1; j < len(t); j++ {
-				if !unicode.IsDigit(rune(t[j])) && t[j] != 'x' && t[j] != 'y' {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTUSNG/TTMGRS pattern must be B, optional digit, xxx, yyy.\n", line)
-					// Bail out somehow.  continue would match inner for.
-				}
-				if t[j] == 'x' {
-					num_x++
-				}
-				if t[j] == 'y' {
-					num_y++
-				}
-			}
-			if num_x < 1 || num_x > 5 || num_x != num_y {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTUSNG/TTMGRS must have 1 to 5 x and same number y.\n", line)
-				continue
-			}
-
-			// Zone 1 - 60 and optional latitudinal letter.
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing zone & square for TTUSNG/TTMGRS command.\n", line)
-				continue
-			}
-			tl.mgrs.zone = t
-
-			// Try converting it rather do our own error checking.
-
-			var _, convertErr = coordconv.DefaultMGRSConverter.ConvertToGeodetic(tl.mgrs.zone)
-			if convertErr != nil {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid USNG/MGRS zone & square:  %s\n%s\n", line, tl.mgrs.zone, convertErr)
-				continue
-			}
-
-			// Should be the end.
-
-			t = split("", false)
-			if t != "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Unexpected stuff at end ignored:  %s\n", line, t)
-			}
-
-			p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-		} else if strings.EqualFold(t, "TTMHEAD") {
-			/*
-			 * TTMHEAD 		- Define pattern to be used for Maidenhead Locator.
-			 *
-			 * TTMHEAD   pattern   [ prefix ]
-			 *
-			 *			Pattern would be  B[0-9A-D]xxxx...
-			 *			Optional prefix is 10, 6, or 4 digits.
-			 *
-			 *			The total number of digts in both must be 4, 6, 10, or 12.
-			 */
-
-			// TODO1.3:  TTMHEAD needs testing.
-
-			var tl = new(ttloc_s)
-			tl.ttlocType = TTLOC_MHEAD
-
-			// Pattern: B, optional additional button, some number of xxxx... for matching
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTMHEAD command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			if t[0] != 'B' {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTMHEAD pattern must begin with upper case 'B'.\n", line)
-				continue
-			}
-
-			// Optionally one of 0-9ABCD
-
-			var j int
-			if len(t) > 1 && (strings.ContainsRune("ABCD", rune(t[1])) || unicode.IsDigit(rune(t[1]))) {
-				j = 2
-			} else {
-				j = 1
-			}
-
-			var count_x = 0
-			var count_other = 0
-			for k := j; k < len(t); k++ {
-				if t[k] == 'x' {
-					count_x++
-				} else {
-					count_other++
-				}
-			}
-
-			if count_other != 0 {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTMHEAD must have only lower case x to match received data.\n", line)
-				continue
-			}
-
-			// optional prefix
-
-			t = split("", false)
-			if t != "" {
-				tl.mhead.prefix = t
-
-				if !alldigits(t) || (len(t) != 4 && len(t) != 6 && len(t) != 10) {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTMHEAD prefix must be 4, 6, or 10 digits.\n", line)
-					continue
-				}
-
-				var _, mhErrors = tt_mhead_to_text(t, false)
-				if mhErrors != 0 {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTMHEAD prefix not a valid DTMF sequence.\n", line)
-					continue
-				}
-			}
-
-			var k = len(tl.mhead.prefix) + count_x
-
-			if k != 4 && k != 6 && k != 10 && k != 12 {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTMHEAD prefix and user data must have a total of 4, 6, 10, or 12 digits.\n", line)
-				continue
-			}
-
-			p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-		} else if strings.EqualFold(t, "TTSATSQ") {
-			/*
-			 * TTSATSQ 		- Define pattern to be used for Satellite square.
-			 *
-			 * TTSATSQ   pattern
-			 *
-			 *			Pattern would be  B[0-9A-D]xxxx
-			 *
-			 *			Must have exactly 4 x.
-			 */
-
-			// TODO1.2:  TTSATSQ To be continued...
-
-			var tl = new(ttloc_s)
-			tl.ttlocType = TTLOC_SATSQ
-
-			// Pattern: B, optional additional button, exactly xxxx for matching
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTSATSQ command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			if t[0] != 'B' {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTSATSQ pattern must begin with upper case 'B'.\n", line)
-				continue
-			}
-
-			// Optionally one of 0-9ABCD
-
-			var j int
-			if len(t) > 1 && (strings.ContainsRune("ABCD", rune(t[1])) || unicode.IsDigit(rune(t[1]))) {
-				j = 2
-			} else {
-				j = 1
-			}
-
-			if t[j:] != "xxxx" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTSATSQ pattern must end with exactly xxxx in lower case.\n", line)
-				continue
-			}
-
-			p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-		} else if strings.EqualFold(t, "TTAMBIG") {
-			/*
-			 * TTAMBIG 		- Define pattern to be used for Object Location Ambiguity.
-			 *
-			 * TTAMBIG   pattern
-			 *
-			 *			Pattern would be  B[0-9A-D]x
-			 *
-			 *			Must have exactly one x.
-			 */
-
-			// TODO1.3:  TTAMBIG To be continued...
-
-			var tl = new(ttloc_s)
-			tl.ttlocType = TTLOC_AMBIG
-
-			// Pattern: B, optional additional button, exactly x for matching
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTAMBIG command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			if t[0] != 'B' {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTAMBIG pattern must begin with upper case 'B'.\n", line)
-				continue
-			}
-
-			// Optionally one of 0-9ABCD
-
-			var j int
-			if len(t) > 1 && (strings.ContainsRune("ABCD", rune(t[1])) || unicode.IsDigit(rune(t[1]))) {
-				j = 2
-			} else {
-				j = 1
-			}
-
-			if t[j:] != "x" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: TTAMBIG pattern must end with exactly one x in lower case.\n", line)
-				continue
-			}
-
-			p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-		} else if strings.EqualFold(t, "TTMACRO") {
-			/*
-			 * TTMACRO 		- Define compact message format with full expansion
-			 *
-			 * TTMACRO   pattern  definition
-			 *
-			 *		pattern can contain:
-			 *			0-9 which must match exactly.
-			 *				In version 1.2, also allow A,B,C,D for exact match.
-			 *			x, y, z which are used for matching of variable fields.
-			 *
-			 *		definition can contain:
-			 *			0-9, A, B, C, D, *, #, x, y, z.
-			 *			Not sure why # was included in there.
-			 *
-			 *	    new for version 1.3 - in progress
-			 *
-			 *			AA{objname}
-			 *			AB{symbol}
-			 *			AC{call}
-			 *
-			 *		These provide automatic conversion from plain text to the TT encoding.
-			 *
-			 */
-
-			var tl = new(ttloc_s)
-			tl.ttlocType = TTLOC_MACRO
-
-			// Pattern: Any combination of digits, x, y, and z.
-			// Also make note of which letters are used in pattern and definition.
-			// Version 1.2: also allow A,B,C,D in the pattern.
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing pattern for TTMACRO command.\n", line)
-				continue
-			}
-			tl.pattern = t
-
-			var p_count [3]int
-			var tt_error = 0
-
-			for j := 0; j < len(t); j++ {
-				if !strings.ContainsRune("0123456789ABCDxyz", rune(t[j])) {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTMACRO pattern can contain only digits, A, B, C, D, and lower case x, y, or z.\n", line)
-					tt_error++
-					break
-				}
-				// Count how many x, y, z in the pattern.
-				if t[j] >= 'x' && t[j] <= 'z' {
-					p_count[t[j]-'x']++
-				}
-			}
-
-			//text_color_set(DW_COLOR_DEBUG);
-			//dw_printf ("Line %d: TTMACRO pattern \"%s\" p_count = %d %d %d.\n", line, t, p_count[0], p_count[1], p_count[2]);
-
-			// Next we should find the definition.
-			// It can contain touch tone characters and lower case x, y, z for substitutions.
-
-			t = split("", true)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing definition for TTMACRO command.\n", line)
-				tl.macro.definition = "" // Don't die on null pointer later.
-				continue
-			}
-
-			// Make a pass over the definition, looking for the xx{...} substitutions.
-			// These are done just once when reading the configuration file.
-
-			var tmp = t               // Chomp through this
-			var otemp strings.Builder // Result after any substitution
-
-			tmp = strings.TrimSpace(tmp)
-
-			for len(tmp) != 0 {
-
-				if strings.HasPrefix(tmp, "AC{") {
-					// Convert to fixed length 10 digit callsign.
-					tmp = tmp[3:]
-					var stemp strings.Builder
-					for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
-						stemp.WriteString(string(tmp[0]))
-						tmp = tmp[1:]
-					}
-					if len(tmp) > 0 && tmp[0] == '}' {
-						var ttemp, errs = tt_text_to_call10(stemp.String(), false)
-						if errs == 0 {
-							//text_color_set(DW_COLOR_DEBUG);
-							//dw_printf ("DEBUG Line %d: AC{%s} -> AC%s\n", line, stemp, ttemp);
-							otemp.WriteString("AC" + ttemp)
-						} else {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: AC{%s} could not be converted to tones for callsign.\n", line, stemp.String())
-							tt_error++
-						}
-						tmp = tmp[1:]
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: AC{... is missing matching } in TTMACRO definition.\n", line)
-						tt_error++
-					}
-				} else if strings.HasPrefix(tmp, "AA{") {
-
-					// Convert to object name.
-
-					tmp = tmp[3:]
-					var stemp string
-					for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
-						stemp += string(tmp[0])
-						tmp = tmp[1:]
-					}
-					if len(tmp) > 0 && tmp[0] == '}' {
-						if len(stemp) > 9 {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Object name %s has been truncated to 9 characters.\n", line, stemp)
-							stemp = stemp[:9]
-						}
-						var ttemp, errs = tt_text_to_two_key(stemp, false)
-						if errs == 0 {
-							//text_color_set(DW_COLOR_DEBUG);
-							//dw_printf ("DEBUG Line %d: AA{%s} -> AA%s\n", line, stemp, ttemp);
-							otemp.WriteString("AA" + ttemp)
-						} else {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: AA{%s} could not be converted to tones for object name.\n", line, stemp)
-							tt_error++
-						}
-						tmp = tmp[1:]
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: AA{... is missing matching } in TTMACRO definition.\n", line)
-						tt_error++
-					}
-				} else if strings.HasPrefix(tmp, "AB{") {
-
-					// Attempt conversion from description to symbol code.
-
-					tmp = tmp[3:]
-					var stemp strings.Builder
-					for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
-						stemp.WriteString(string(tmp[0]))
-						tmp = tmp[1:]
-					}
-					if len(tmp) > 0 && tmp[0] == '}' {
-						// First try to find something matching the description.
-
-						var symtab, symbol, ok = aprsSymbolData.symbols_code_from_description(' ', stemp.String())
-
-						if !ok {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Couldn't convert \"%s\" to APRS symbol code.  Using default.\n", line, stemp.String())
-							symtab = '\\' // Alternate
-							symbol = 'A'  // Box
-						}
-
-						// Convert symtab(overlay) & symbol to tone sequence.
-
-						var ttemp = aprsSymbolData.symbols_to_tones(symtab, symbol)
-
-						//text_color_set(DW_COLOR_DEBUG);
-						//dw_printf ("DEBUG config file Line %d: AB{%s} -> %s\n", line, stemp, ttemp);
-
-						otemp.WriteString(ttemp)
-						tmp = tmp[1:]
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: AB{... is missing matching } in TTMACRO definition.\n", line)
-						tt_error++
-					}
-				} else if strings.HasPrefix(tmp, "CA{") {
-
-					// Convert to enhanced comment that can contain any ASCII character.
-
-					tmp = tmp[3:]
-					var stemp strings.Builder
-					for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
-						stemp.WriteString(string(tmp[0]))
-						tmp = tmp[1:]
-					}
-					if len(tmp) > 0 && tmp[0] == '}' {
-						var ttemp, errs = tt_text_to_ascii2d(stemp.String(), false)
-						if errs == 0 {
-							//text_color_set(DW_COLOR_DEBUG);
-							//dw_printf ("DEBUG Line %d: CA{%s} -> CA%s\n", line, stemp, ttemp);
-							otemp.WriteString("CA" + ttemp)
-						} else {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: CA{%s} could not be converted to tones for enhanced comment.\n", line, stemp.String())
-							tt_error++
-						}
-						tmp = tmp[1:]
-					} else {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: CA{... is missing matching } in TTMACRO definition.\n", line)
-						tt_error++
-					}
-				} else if strings.ContainsRune("0123456789ABCD*#xyz", rune(tmp[0])) {
-					otemp.WriteString(string(tmp[0]))
-					tmp = tmp[1:]
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: TTMACRO definition can contain only 0-9, A, B, C, D, *, #, x, y, z.\n", line)
-					tt_error++
-					tmp = tmp[1:]
-				}
-			}
-
-			// Make sure that number of x, y, z, in pattern and definition match.
-
-			var d_count [3]int
-
-			for j := 0; j < len(otemp.String()); j++ {
-				if otemp.String()[j] >= 'x' && otemp.String()[j] <= 'z' {
-					d_count[otemp.String()[j]-'x']++
-				}
-			}
-
-			// A little validity checking.
-
-			for j := range 3 {
-				if p_count[j] > 0 && d_count[j] == 0 {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: '%c' is in TTMACRO pattern but is not used in definition.\n", line, 'x'+j)
-				}
-				if d_count[j] > 0 && p_count[j] == 0 {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: '%c' is referenced in TTMACRO definition but does not appear in the pattern.\n", line, 'x'+j)
-				}
-			}
-
-			//text_color_set(DW_COLOR_DEBUG);
-			//dw_printf ("DEBUG Config Line %d: %s -> %s\n", line, t, otemp);
-
-			if tt_error == 0 {
-				tl.macro.definition = otemp.String()
-			}
-
-			if tt_error == 0 {
-				p_tt_config.ttlocs = append(p_tt_config.ttlocs, tl)
-			} else {
-				dw_printf("Line %d: Errors found in TTMACRO, skipping.\n", line)
-			}
-		} else if strings.EqualFold(t, "TTOBJ") {
-			/*
-			 * TTOBJ 		- TT Object Report options.
-			 *
-			 * TTOBJ  recv-chan  where-to  [ via-path ]
-			 *
-			 *	whereto is any combination of transmit channel, APP, IG.
-			 */
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing DTMF receive channel for TTOBJ command.\n", line)
-				continue
-			}
-
-			var r, rErr = strconv.Atoi(t)
-			if r < 0 || r > MAX_RADIO_CHANS-1 || rErr != nil {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: DTMF receive channel must be in range of 0 to %d on line %d.\n",
-					MAX_RADIO_CHANS-1, line)
-				continue
-			}
-
-			// I suppose we need internal modem channel here.
-			// otherwise a DTMF decoder would not be available.
-
-			if p_audio_config.chan_medium[r] != MEDIUM_RADIO {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: TTOBJ DTMF receive channel %d is not valid.\n",
-					line, r)
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing transmit channel for TTOBJ command.\n", line)
-				continue
-			}
-
-			// Can have any combination of number, APP, IG.
-			// Would it be easier with strtok?
-
-			var x = -1
-			var app = 0
-			var ig = 0
-
-			for _, p := range t {
-				if unicode.IsDigit(p) {
-					x = int(p - '0')
-					if x < 0 || x > MAX_TOTAL_CHANS-1 {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n", MAX_TOTAL_CHANS-1, line)
-						x = -1
-					} else if p_audio_config.chan_medium[x] != MEDIUM_RADIO &&
-						p_audio_config.chan_medium[x] != MEDIUM_NETTNC {
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Config file, line %d: TTOBJ transmit channel %d is not valid.\n", line, x)
-						x = -1
-					}
-				} else if p == 'a' || p == 'A' {
-					app = 1
-				} else if p == 'i' || p == 'I' {
-					ig = 1
-				} else if strings.ContainsRune("pPgG,", p) {
-					// Skip?
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: Expected comma separated list with some combination of transmit channel, APP, and IG.\n", line)
-				}
-			}
-
-			// This enables the DTMF decoder on the specified channel.
-			// Additional channels can be enabled with the DTMF command.
-			// Note that DTMF command does not enable the APRStt gateway.
-
-			//text_color_set(DW_COLOR_DEBUG);
-			//dw_printf ("Debug TTOBJ r=%d, x=%d, app=%d, ig=%d\n", r, x, app, ig);
-
-			p_audio_config.achan[r].dtmf_decode = DTMF_DECODE_ON
-			p_tt_config.gateway_enabled = 1
-			p_tt_config.obj_recv_chan = r
-			p_tt_config.obj_xmit_chan = x
-			p_tt_config.obj_send_to_app = app
-			p_tt_config.obj_send_to_ig = ig
-
-			t = split("", false)
-			if t != "" {
-
-				if check_via_path(t) >= 0 {
-					p_tt_config.obj_xmit_via = t
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: invalid via path.\n", line)
-				}
-			}
-		} else if strings.EqualFold(t, "TTERR") {
-			/*
-			 * TTERR 		- TT responses for success or errors.
-			 *
-			 * TTERR  msg_id  method  text...
-			 */
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing message identifier for TTERR command.\n", line)
-				continue
-			}
-
-			var msg_num = -1
-			for n := range TT_ERROR_MAXP1 {
-				if strings.EqualFold(t, ttErrorString(n)) {
-					msg_num = n
-					break
-				}
-			}
-			if msg_num < 0 {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid message identifier for TTERR command.\n", line)
-				// pick one of ...
-				continue
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing method (SPEECH, MORSE) for TTERR command.\n", line)
-				continue
-			}
-
-			t = strings.ToUpper(t)
-
-			var method, _, _, ok = ax25_parse_addr(-1, t, 1)
-			if !ok {
-				continue // function above prints any error message
-			}
-
-			if method != "MORSE" && method != "SPEECH" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Response method of %s must be SPEECH or MORSE for TTERR command.\n", line, method)
-				continue
-			}
-
-			t = split("", true)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing response text for TTERR command.\n", line)
-				continue
-			}
-
-			//text_color_set(DW_COLOR_DEBUG);
-			//dw_printf ("Line %d: TTERR debug %d %s-%d \"%s\"\n", line, msg_num, method, ssid, t);
-
-			Assert(msg_num >= 0 && msg_num < TT_ERROR_MAXP1)
-
-			p_tt_config.response[msg_num].method = method
-
-			// TODO1.3: Need SSID too!
-
-			p_tt_config.response[msg_num].mtext = t
-		} else if strings.EqualFold(t, "TTSTATUS") {
-			/*
-			 * TTSTATUS 		- TT custom status messages.
-			 *
-			 * TTSTATUS  status_id  text...
-			 */
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing status number for TTSTATUS command.\n", line)
-				continue
-			}
-
-			var status_num, _ = strconv.Atoi(t)
-
-			if status_num < 1 || status_num > 9 {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Status number for TTSTATUS command must be in range of 1 to 9.\n", line)
-				continue
-			}
-
-			t = split("", true)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing status text for TTSTATUS command.\n", line)
-				continue
-			}
-
-			//text_color_set(DW_COLOR_DEBUG);
-			//dw_printf ("Line %d: TTSTATUS debug %d \"%s\"\n", line, status_num, t);
-
-			t = strings.TrimSpace(t)
-
-			p_tt_config.status[status_num] = t
-		} else if strings.EqualFold(t, "TTCMD") {
-			/*
-			 * TTCMD 		- Command to run when valid sequence is received.
-			 *			  Any text generated will be sent back to user.
-			 *
-			 * TTCMD ...
-			 */
-			t = split("", true)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing command for TTCMD command.\n", line)
-				continue
-			}
-
-			p_tt_config.ttcmd = t
-		} else if strings.EqualFold(t, "IGSERVER") {
-			/*
-			 * ==================== Internet gateway ====================
-			 */
-
-			/*
-			 * IGSERVER 		- Name of IGate server.
-			 *
-			 * IGSERVER  hostname [ port ] 				-- original implementation.
-			 *
-			 * IGSERVER  hostname:port				-- more in line with usual conventions.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing IGate server name for IGSERVER command.\n", line)
-
-				continue
-			}
-
-			p_igate_config.t2_server_name = t
-
-			/* If there is a : in the name, split it out as the port number. */
-
-			if strings.Contains(t, ":") {
-				var hostname, portStr, _ = strings.Cut(t, ":")
-				p_igate_config.t2_server_name = hostname
-
-				var port, portErr = strconv.Atoi(portStr)
-				if port >= MIN_IP_PORT_NUMBER && port <= MAX_IP_PORT_NUMBER && portErr == nil {
-					p_igate_config.t2_server_port = port
-				} else {
-					p_igate_config.t2_server_port = DEFAULT_IGATE_PORT
-
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Invalid port number for IGate server. Using default %d.\n",
-						line, p_igate_config.t2_server_port)
-				}
-			}
-
-			/* Alternatively, the port number could be separated by white space. */
-
-			t = split("", false)
-			if t != "" {
-				var n, _ = strconv.Atoi(t)
-				if n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER {
-					p_igate_config.t2_server_port = n
-				} else {
-					p_igate_config.t2_server_port = DEFAULT_IGATE_PORT
-
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Invalid port number for IGate server. Using default %d.\n",
-						line, p_igate_config.t2_server_port)
-				}
-			}
-			//dw_printf ("DEBUG  server=%s   port=%d\n", p_igate_config.t2_server_name, p_igate_config.t2_server_port);
-			//exit (0);
-		} else if strings.EqualFold(t, "IGLOGIN") {
-			/*
-			 * IGLOGIN 		- Login callsign and passcode for IGate server
-			 *
-			 * IGLOGIN  callsign  passcode
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing login callsign for IGLOGIN command.\n", line)
-
-				continue
-			}
-			// TODO: Wouldn't hurt to do validity checking of format.
-			p_igate_config.t2_login = t
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing passcode for IGLOGIN command.\n", line)
-
-				continue
-			}
-
-			p_igate_config.t2_passcode = t
-		} else if strings.EqualFold(t, "IGTXVIA") {
-			/*
-			 * IGTXVIA 		- Transmit channel and VIA path for messages from IGate server
-			 *
-			 * IGTXVIA  channel  [ path ]
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing transmit channel for IGTXVIA command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n < 0 || n > MAX_TOTAL_CHANS-1 {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n",
-					MAX_TOTAL_CHANS-1, line)
-
-				continue
-			}
-
-			p_igate_config.tx_chan = n
-
-			t = split("", false)
-			if t != "" {
-				// TODO KG#if 1	// proper checking
-				n = check_via_path(t)
-				if n >= 0 {
-					p_igate_config.max_digi_hops = n
-					p_igate_config.tx_via = "," + t
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file, line %d: invalid via path.\n", line)
-				}
-
-				/* TODO KG #else	// previously
-
-				   	      char *p;
-				   	      p_igate_config.tx_via[0] = ',';
-				   	      strlcpy (p_igate_config.tx_via + 1, t, sizeof(p_igate_config.tx_via)-1);
-				   	      for (p = p_igate_config.tx_via; *p != 0; p++) {
-				   	        if (islower(*p)) {
-				   		  *p = toupper(*p);	// silently force upper case.
-				   	        }
-				   	      }
-				   #endif
-				*/
-			}
-		} else if strings.EqualFold(t, "IGFILTER") {
-			/*
-			 * IGFILTER 		- IGate Server side filters.
-			 *			  Is this name too confusing.  Too similar to FILTER IG 0 ...
-			 *			  Maybe SSFILTER suggesting Server Side.
-			 *			  SUBSCRIBE might be better because it's not a filter that limits.
-			 *
-			 * IGFILTER  filter-spec ...
-			 */
-			t = split("", true) /* Take rest of line as one string. */
-
-			if p_igate_config.t2_filter != "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Warning - IGFILTER already configured (%s), this one (%s) will be ignored.\n", line, p_igate_config.t2_filter, t)
-
-				continue
-			}
-
-			if t != "" {
-				p_igate_config.t2_filter = t
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Warning - IGFILTER is a rarely needed expert level feature.\n", line)
-				dw_printf("If you don't have a special situation and a good understanding of\n")
-				dw_printf("how this works, you probably should not be messing with it.\n")
-				dw_printf("The default behavior is appropriate for most situations.\n")
-				dw_printf("Please read \"Successful-APRS-IGate-Operation.pdf\".\n")
-			}
-		} else if strings.EqualFold(t, "IGTXLIMIT") {
-			/*
-			 * IGTXLIMIT 		- Limit transmissions during 1 and 5 minute intervals.
-			 *
-			 * IGTXLIMIT  one-minute-limit  five-minute-limit
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing one minute limit for IGTXLIMIT command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n < 1 {
-				p_igate_config.tx_limit_1 = 1
-			} else if n <= IGATE_TX_LIMIT_1_MAX {
-				p_igate_config.tx_limit_1 = n
-			} else {
-				p_igate_config.tx_limit_1 = IGATE_TX_LIMIT_1_MAX
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: One minute transmit limit has been reduced to %d.\n",
-					line, p_igate_config.tx_limit_1)
-				dw_printf("You won't make friends by setting a limit this high.\n")
-			}
-
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing five minute limit for IGTXLIMIT command.\n", line)
-
-				continue
-			}
-
-			n, _ = strconv.Atoi(t)
-			if n < 1 {
-				p_igate_config.tx_limit_5 = 1
-			} else if n <= IGATE_TX_LIMIT_5_MAX {
-				p_igate_config.tx_limit_5 = n
-			} else {
-				p_igate_config.tx_limit_5 = IGATE_TX_LIMIT_5_MAX
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Five minute transmit limit has been reduced to %d.\n",
-					line, p_igate_config.tx_limit_5)
-				dw_printf("You won't make friends by setting a limit this high.\n")
-			}
-		} else if strings.EqualFold(t, "IGMSP") {
-			/*
-			 * IGMSP 		- Number of times to send position of message sender.
-			 *
-			 * IGMSP  n
-			 */
-			t = split("", false)
-			if t != "" {
-				var n, _ = strconv.Atoi(t)
-				if n >= 0 && n <= 10 {
-					p_igate_config.igmsp = n
-				} else {
-					p_igate_config.igmsp = 1
-
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Unreasonable number of times for message sender position.  Using default 1.\n", line)
-				}
-			} else {
-				p_igate_config.igmsp = 1
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing number of times for message sender position.  Using default 1.\n", line)
-			}
-		} else if strings.EqualFold(t, "SATGATE") {
-			/*
-			 * SATGATE 		- Special SATgate mode to delay packets heard directly.
-			 *
-			 * SATGATE [ n ]
-			 */
-			text_color_set(DW_COLOR_INFO)
-			dw_printf("Line %d: SATGATE is pretty useless and will be removed in a future version.\n", line)
-
-			t = split("", false)
-			if t != "" {
-				var n, _ = strconv.Atoi(t)
-				if n >= MIN_SATGATE_DELAY && n <= MAX_SATGATE_DELAY {
-					p_igate_config.satgate_delay = n
-				} else {
-					p_igate_config.satgate_delay = DEFAULT_SATGATE_DELAY
-
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Unreasonable SATgate delay.  Using default.\n", line)
-				}
-			} else {
-				p_igate_config.satgate_delay = DEFAULT_SATGATE_DELAY
-			}
-		} else if strings.EqualFold(t, "AGWPORT") {
-			/*
-			 * ==================== All the left overs ====================
-			 */
-
-			/*
-			 * AGWPORT 		- Port number for "AGW TCPIP Socket Interface"
-			 *
-			 * In version 1.2 we allow 0 to disable listening.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing port number for AGWPORT command.\n", line)
-
-				continue
-			}
-			var n, _ = strconv.Atoi(t)
-
-			t = split("", false)
-			if t != "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Unexpected \"%s\" after the port number.\n", line, t)
-				dw_printf("Perhaps you were trying to use feature available only with KISSPORT.\n")
-
+		ps.keyword = t
+		var keyword = strings.ToUpper(t)
+		// Some config keywords actually incorporate a device number, e.g. ADEVICE0
+		if strings.HasPrefix(keyword, "ADEVICE") {
+			if handleADEVICE(ps) {
 				continue
 			}
-
-			if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
-				p_misc_config.agwpe_port = n
-			} else {
-				p_misc_config.agwpe_port = DEFAULT_AGWPE_PORT
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid port number for AGW TCPIP Socket Interface. Using %d.\n",
-					line, p_misc_config.agwpe_port)
-			}
-		} else if strings.EqualFold(t, "KISSPORT") {
-			/*
-			 * KISSPORT port [ chan ]		- Port number for KISS over IP.
-			 */
-
-			// Previously we allowed only a single TCP port for KISS.
-			// An increasing number of people want to run multiple radios.
-			// Unfortunately, most applications don't know how to deal with multi-radio TNCs.
-			// They ignore the channel on receive and always transmit to channel 0.
-			// Running multiple instances of direwolf is a work-around but this leads to
-			// more complex configuration and we lose the cross-channel digipeating capability.
-			// In release 1.7 we add a new feature to assign a single radio channel to a TCP port.
-			// e.g.
-			//	KISSPORT 8001		# default, all channels.  Radio channel = KISS channel.
-			//
-			//	KISSPORT 7000 0		# Only radio channel 0 for receive.
-			//				# Transmit to radio channel 0, ignoring KISS channel.
-			//
-			//	KISSPORT 7001 1		# Only radio channel 1 for receive.  KISS channel set to 0.
-			//				# Transmit to radio channel 1, ignoring KISS channel.
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing TCP port number for KISSPORT command.\n", line)
-
-				continue
-			}
-			var n, _ = strconv.Atoi(t)
-
-			var tcp_port int
-			if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
-				tcp_port = n
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid TCP port number for KISS TCPIP Socket Interface.\n", line)
-				dw_printf("Use something in the range of %d to %d.\n", MIN_IP_PORT_NUMBER, MAX_IP_PORT_NUMBER)
-
-				continue
-			}
-
-			t = split("", false)
-			var channel = -1 // optional.  default to all if not specified.
-
-			if t != "" {
-				var channelErr error
-
-				channel, channelErr = strconv.Atoi(t)
-				if channel < 0 || channel >= MAX_TOTAL_CHANS || channelErr != nil {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Invalid channel %d for KISSPORT command.  Must be in range 0 thru %d.\n", line, channel, MAX_TOTAL_CHANS-1)
-
-					continue
-				}
-			}
-
-			// "KISSPORT 0" is used to remove the default entry.
-
-			if tcp_port == 0 {
-				p_misc_config.kiss_port[0] = 0 // Should all be wiped out?
-			} else {
-				// Try to find an empty slot.
-				// A duplicate TCP port number will overwrite the previous value.
-				var slot = -1
-				for i := 0; i < MAX_KISS_TCP_PORTS && slot == -1; i++ {
-					if p_misc_config.kiss_port[i] == tcp_port { //nolint:staticcheck
-						slot = i
-						if !(slot == 0 && tcp_port == DEFAULT_KISS_PORT) {
-							text_color_set(DW_COLOR_ERROR)
-							dw_printf("Line %d: Warning: Duplicate TCP port %d will overwrite previous value.\n", line, tcp_port)
-						}
-					} else if p_misc_config.kiss_port[i] == 0 {
-						slot = i
-					}
-				}
-
-				if slot >= 0 {
-					p_misc_config.kiss_port[slot] = tcp_port
-					p_misc_config.kiss_chan[slot] = channel
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Too many KISSPORT commands.\n", line)
-				}
-			}
-		} else if strings.EqualFold(t, "NULLMODEM") || strings.EqualFold(t, "SERIALKISS") {
-			/*
-			 * NULLMODEM name [ speed ]	- Device name for serial port or our end of the virtual "null modem"
-			 * SERIALKISS name  [ speed ]
-			 *
-			 * Version 1.5:  Added SERIALKISS which is equivalent to NULLMODEM.
-			 * The original name sort of made sense when it was used only for one end of a virtual
-			 * null modem cable on Windows only.  Now it is also available for Linux.
-			 * TODO1.5: In retrospect, this doesn't seem like such a good name.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing serial port name on line %d.\n", line)
-
-				continue
-			} else {
-				if p_misc_config.kiss_serial_port != "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: Warning serial port name on line %d replaces earlier value.\n", line)
-				}
-
-				p_misc_config.kiss_serial_port = t
-				p_misc_config.kiss_serial_speed = 0
-				p_misc_config.kiss_serial_poll = 0
-			}
-
-			t = split("", false)
-			if t != "" {
-				p_misc_config.kiss_serial_speed, _ = strconv.Atoi(t)
-			}
-		} else if strings.EqualFold(t, "SERIALKISSPOLL") {
-			/*
-			 * SERIALKISSPOLL name		- Poll for serial port name that might come and go.
-			 *			  	  e.g. /dev/rfcomm0 for bluetooth.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing serial port name on line %d.\n", line)
-
-				continue
-			} else {
-				if p_misc_config.kiss_serial_port != "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: Warning serial port name on line %d replaces earlier value.\n", line)
-				}
-
-				p_misc_config.kiss_serial_port = t
-				p_misc_config.kiss_serial_speed = 0
-				p_misc_config.kiss_serial_poll = 1 // set polling.
-			}
-		} else if strings.EqualFold(t, "KISSCOPY") {
-			/*
-			 * KISSCOPY 		- Data from network KISS client is copied to all others.
-			 *			  This does not apply to pseudo terminal KISS.
-			 */
-			p_misc_config.kiss_copy = true
-		} else if strings.EqualFold(t, "DNSSD") {
-			/*
-			 * DNSSD 		- Enable or disable (1/0) dns-sd, DNS Service Discovery announcements
-			 * DNSSDNAME            - Set DNS-SD service name, defaults to "Dire Wolf on <hostname>"
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing integer value for DNSSD command.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n == 0 || n == 1 {
-				p_misc_config.dns_sd_enabled = n != 0
-			} else {
-				p_misc_config.dns_sd_enabled = false
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid integer value for DNSSD. Disabling dns-sd.\n", line)
-			}
-		} else if strings.EqualFold(t, "DNSSDNAME") {
-			t = split("", true)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing service name for DNSSDNAME.\n", line)
-
-				continue
-			} else {
-				p_misc_config.dns_sd_name = t
-			}
-		} else if strings.EqualFold(t, "gpsnmea") {
-			/*
-			 * GPSNMEA  serial-device  [ speed ]		- Direct connection to GPS receiver.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: Missing serial port name for GPS receiver.\n", line)
-
-				continue
-			}
-
-			p_misc_config.gpsnmea_port = t
-
-			t = split("", false)
-			if t != "" {
-				var n, _ = strconv.Atoi(t)
-				p_misc_config.gpsnmea_speed = n
-			} else {
-				p_misc_config.gpsnmea_speed = 4800 // The standard at one time.
-			}
-		} else if strings.EqualFold(t, "gpsd") {
-			/*
-			 * GPSD		- Use GPSD server.
-			 *
-			 * GPSD [ host [ port ] ]
-			 */
-
-			/* TODO KG
-			   #if __WIN32__
-
-			   	    text_color_set(DW_COLOR_ERROR);
-			   	    dw_printf ("Config file, line %d: The GPSD interface is not available for Windows.\n", line);
-			   	    continue;
-
-			   #elif ENABLE_GPSD
-			*/
-			dw_printf("Warning: GPSD support currently disabled pending a rewrite of the integration.\n")
-
-			p_misc_config.gpsd_host = "localhost"
-			p_misc_config.gpsd_port = DEFAULT_GPSD_PORT
-
-			t = split("", false)
-			if t != "" {
-				p_misc_config.gpsd_host = t
-
-				t = split("", false)
-				if t != "" {
-					var n, _ = strconv.Atoi(t)
-					if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
-						p_misc_config.gpsd_port = n
-					} else {
-						p_misc_config.gpsd_port = DEFAULT_GPSD_PORT
-
-						text_color_set(DW_COLOR_ERROR)
-						dw_printf("Line %d: Invalid port number for GPSD Socket Interface. Using default of %d.\n",
-							line, p_misc_config.gpsd_port)
-					}
-				}
-			}
-			/* TODO KG
-			#else
-				    text_color_set(DW_COLOR_ERROR);
-				    dw_printf ("Config file, line %d: The GPSD interface has not been enabled.\n", line);
-				    dw_printf ("Install gpsd and libgps-dev packages then rebuild direwolf.\n");
-				    continue;
-			#endif
-			*/
-		} else if strings.EqualFold(t, "waypoint") {
-			/*
-			 * WAYPOINT		- Generate WPL and AIS NMEA sentences for display on map.
-			 *
-			 * WAYPOINT  serial-device [ formats ]
-			 * WAYPOINT  host:udpport [ formats ]
-			 *
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing output device for WAYPOINT on line %d.\n", line)
-
-				continue
-			}
-
-			/* If there is a ':' in the name, split it into hostname:udpportnum. */
-			/* Otherwise assume it is serial port name. */
-
-			if strings.Contains(t, ":") {
-				var hostname, portStr, _ = strings.Cut(t, ":")
-
-				var port, _ = strconv.Atoi(portStr)
-				if port >= MIN_IP_PORT_NUMBER && port <= MAX_IP_PORT_NUMBER {
-					p_misc_config.waypoint_udp_hostname = hostname
-					if p_misc_config.waypoint_udp_hostname == "" {
-						p_misc_config.waypoint_udp_hostname = "localhost"
-					}
-
-					p_misc_config.waypoint_udp_portnum = port
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Invalid UDP port number %d for sending waypoints.\n", line, port)
-				}
-			} else {
-				p_misc_config.waypoint_serial_port = t
-			}
-
-			/* Anything remaining is the formats to enable. */
-
-			t = split("", true)
-			for _, c := range t {
-				switch unicode.ToUpper(c) {
-				case 'N':
-					p_misc_config.waypoint_formats |= WPL_FORMAT_NMEA_GENERIC
-				case 'G':
-					p_misc_config.waypoint_formats |= WPL_FORMAT_GARMIN
-				case 'M':
-					p_misc_config.waypoint_formats |= WPL_FORMAT_MAGELLAN
-				case 'K':
-					p_misc_config.waypoint_formats |= WPL_FORMAT_KENWOOD
-				case 'A':
-					p_misc_config.waypoint_formats |= WPL_FORMAT_AIS
-				case ' ', ',':
-				default:
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: Invalid output format '%c' for WAYPOINT on line %d.\n", c, line)
-				}
-			}
-		} else if strings.EqualFold(t, "logdir") {
-			/*
-			 * LOGDIR	- Directory name for automatically named daily log files.  Use "." for current working directory.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing directory name for LOGDIR on line %d.\n", line)
-
+		} else if strings.HasPrefix(keyword, "PAIDEVICE") {
+			if handlePAIDEVICE(ps) {
 				continue
-			} else {
-				if p_misc_config.log_path != "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: LOGDIR on line %d is replacing an earlier LOGDIR or LOGFILE.\n", line)
-				}
-
-				p_misc_config.log_daily_names = true
-				p_misc_config.log_path = t
 			}
-
-			t = split("", false)
-			if t != "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: LOGDIR on line %d should have directory path and nothing more.\n", line)
-			}
-		} else if strings.EqualFold(t, "logfile") {
-			/*
-			 * LOGFILE	- Log file name, including any directory part.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Missing file name for LOGFILE on line %d.\n", line)
-
-				continue
-			} else {
-				if p_misc_config.log_path != "" {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Config file: LOGFILE on line %d is replacing an earlier LOGDIR or LOGFILE.\n", line)
-				}
-
-				p_misc_config.log_daily_names = false
-				p_misc_config.log_path = t
-			}
-
-			t = split("", false)
-			if t != "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: LOGFILE on line %d should have file name and nothing more.\n", line)
-			}
-		} else if strings.EqualFold(t, "BEACON") {
-			/*
-			 * BEACON channel delay every message
-			 *
-			 * Original handcrafted style.  Removed in version 1.0.
-			 */
-			text_color_set(DW_COLOR_ERROR)
-			dw_printf("Config file, line %d: Old style 'BEACON' has been replaced with new commands.\n", line)
-			dw_printf("Use PBEACON, OBEACON, TBEACON, or CBEACON instead.\n")
-		} else if strings.EqualFold(t, "PBEACON") ||
-			strings.EqualFold(t, "OBEACON") ||
-			strings.EqualFold(t, "TBEACON") ||
-			strings.EqualFold(t, "CBEACON") ||
-			strings.EqualFold(t, "IBEACON") {
-			/*
-			 * PBEACON keyword=value ...
-			 * OBEACON keyword=value ...
-			 * TBEACON keyword=value ...
-			 * CBEACON keyword=value ...
-			 * IBEACON keyword=value ...
-			 *
-			 * New style with keywords for options.
-			 */
-
-			// TODO: maybe add proportional pathing so multiple beacon timing does not need to be manually constructed?
-			// http://www.aprs.org/newN/ProportionalPathing.txt
-			if p_misc_config.num_beacons < MAX_BEACONS {
-				if strings.EqualFold(t, "PBEACON") {
-					p_misc_config.beacon[p_misc_config.num_beacons].btype = BEACON_POSITION
-				} else if strings.EqualFold(t, "OBEACON") {
-					p_misc_config.beacon[p_misc_config.num_beacons].btype = BEACON_OBJECT
-				} else if strings.EqualFold(t, "TBEACON") {
-					p_misc_config.beacon[p_misc_config.num_beacons].btype = BEACON_TRACKER
-				} else if strings.EqualFold(t, "IBEACON") {
-					p_misc_config.beacon[p_misc_config.num_beacons].btype = BEACON_IGATE
-				} else {
-					p_misc_config.beacon[p_misc_config.num_beacons].btype = BEACON_CUSTOM
-				}
-
-				/* Save line number because some errors will be reported later. */
-				p_misc_config.beacon[p_misc_config.num_beacons].lineno = line
-
-				if beacon_options(text[len("xBEACON")+1:], &(p_misc_config.beacon[p_misc_config.num_beacons]), line, p_audio_config) == nil {
-					p_misc_config.num_beacons++
-				}
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Maximum number of beacons exceeded on line %d.\n", line)
-
-				continue
-			}
-		} else if strings.EqualFold(t, "SMARTBEACON") || strings.EqualFold(t, "SMARTBEACONING") {
-			/*
-			 * SMARTBEACONING [ fast_speed fast_rate slow_speed slow_rate turn_time turn_angle turn_slope ]
-			 *
-			 * Parameters must be all or nothing.
-			 */
-			dw_printf("SMARTBEACONING support currently disabled due to mid-stage porting complexity - line %d skipped.\n", line)
-
-			/* TODO KG
-			#define SB_NUM(name,sbvar,minn,maxx,unit)  							\
-				    t = split("", false);									\
-				    if (t == "") {									\
-				      if (strcmp(name, "fast speed") == 0) {						\
-				        p_misc_config.sb_configured = 1;						\
-				        continue;									\
-				      }											\
-				      text_color_set(DW_COLOR_ERROR);							\
-				      dw_printf ("Line %d: Missing %s for SmartBeaconing.\n", line, name);		\
-				      continue;										\
-				    }											\
-				    var n, _ = strconv.Atoi(t);									\
-			            if (n >= minn && n <= maxx) {							\
-				      p_misc_config.sbvar = n;								\
-				    }											\
-				    else {										\
-				      text_color_set(DW_COLOR_ERROR);							\
-			              dw_printf ("Line %d: Invalid %s for SmartBeaconing. Using default %d %s.\n",	\
-						line, name, p_misc_config.sbvar, unit);				\
-			   	    }
-			*/
-
-			/* TODO KG
-			#define SB_TIME(name,sbvar,minn,maxx,unit)  							\
-				    t = split("", false);									\
-				    if (t == "") {									\
-				      text_color_set(DW_COLOR_ERROR);							\
-				      dw_printf ("Line %d: Missing %s for SmartBeaconing.\n", line, name);		\
-				      continue;										\
-				    }											\
-				    n = parse_interval(t,line);								\
-			            if (n >= minn && n <= maxx) {							\
-				      p_misc_config.sbvar = n;								\
-				    }											\
-				    else {										\
-				      text_color_set(DW_COLOR_ERROR);							\
-			              dw_printf ("Line %d: Invalid %s for SmartBeaconing. Using default %d %s.\n",	\
-						line, name, p_misc_config.sbvar, unit);				\
-			   	    }
-			*/
-
-			/* TODO KG
-			SB_NUM("fast speed", sb_fast_speed, 2, 90, "MPH")
-			SB_TIME("fast rate", sb_fast_rate, 10, 300, "seconds")
-
-			SB_NUM("slow speed", sb_slow_speed, 1, 30, "MPH")
-			SB_TIME("slow rate", sb_slow_rate, 30, 3600, "seconds")
-
-			SB_TIME("turn time", sb_turn_time, 5, 180, "seconds")
-			SB_NUM("turn angle", sb_turn_angle, 5, 90, "degrees")
-			SB_NUM("turn slope", sb_turn_slope, 1, 255, "deg*mph")
-
-			p_misc_config.sb_configured = 1
-			*/
-
-			/* If I was ambitious, I might allow optional */
-			/* unit at end for miles or km / hour. */
-		} else if strings.EqualFold(t, "FRACK") {
-			/*
-			 * ==================== AX.25 connected mode ====================
-			 */
-
-			/*
-			 * FRACK  n 		- Number of seconds to wait for ack to transmission.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing value for FRACK.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= AX25_T1V_FRACK_MIN && n <= AX25_T1V_FRACK_MAX {
-				p_misc_config.frack = n
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid FRACK time. Using default %d.\n", line, p_misc_config.frack)
-			}
-		} else if strings.EqualFold(t, "RETRY") {
-			/*
-			 * RETRY  n 		- Number of times to retry before giving up.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing value for RETRY.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= AX25_N2_RETRY_MIN && n <= AX25_N2_RETRY_MAX {
-				p_misc_config.retry = n
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid RETRY number. Using default %d.\n", line, p_misc_config.retry)
-			}
-		} else if strings.EqualFold(t, "PACLEN") {
-			/*
-			 * PACLEN  n 		- Maximum number of bytes in information part.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing value for PACLEN.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= AX25_N1_PACLEN_MIN && n <= AX25_N1_PACLEN_MAX {
-				p_misc_config.paclen = n
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid PACLEN value. Using default %d.\n", line, p_misc_config.paclen)
-			}
-		} else if strings.EqualFold(t, "MAXFRAME") {
-			/*
-			 * MAXFRAME  n 		- Max frames to send before ACK.  mod 8 "Window" size.
-			 *
-			 * Window size would make more sense but everyone else calls it MAXFRAME.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing value for MAXFRAME.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= AX25_K_MAXFRAME_BASIC_MIN && n <= AX25_K_MAXFRAME_BASIC_MAX {
-				p_misc_config.maxframe_basic = n
-			} else {
-				p_misc_config.maxframe_basic = AX25_K_MAXFRAME_BASIC_DEFAULT
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid MAXFRAME value outside range of %d to %d. Using default %d.\n",
-					line, AX25_K_MAXFRAME_BASIC_MIN, AX25_K_MAXFRAME_BASIC_MAX, p_misc_config.maxframe_basic)
-			}
-		} else if strings.EqualFold(t, "EMAXFRAME") {
-			/*
-			 * EMAXFRAME  n 		- Max frames to send before ACK.  mod 128 "Window" size.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing value for EMAXFRAME.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= AX25_K_MAXFRAME_EXTENDED_MIN && n <= AX25_K_MAXFRAME_EXTENDED_MAX {
-				p_misc_config.maxframe_extended = n
-			} else {
-				p_misc_config.maxframe_extended = AX25_K_MAXFRAME_EXTENDED_DEFAULT
-
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid EMAXFRAME value outside of range %d to %d. Using default %d.\n",
-					line, AX25_K_MAXFRAME_EXTENDED_MIN, AX25_K_MAXFRAME_EXTENDED_MAX, p_misc_config.maxframe_extended)
-			}
-		} else if strings.EqualFold(t, "MAXV22") {
-			/*
-			 * MAXV22  n 		- Max number of SABME sent before trying SABM.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing value for MAXV22.\n", line)
-
-				continue
-			}
-
-			var n, _ = strconv.Atoi(t)
-			if n >= 0 && n <= AX25_N2_RETRY_MAX {
-				p_misc_config.maxv22 = n
-			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Invalid MAXV22 number. Will use half of RETRY.\n", line)
-			}
-		} else if strings.EqualFold(t, "V20") {
-			/*
-			 * V20  address [ address ... ] 	- Stations known to support only AX.25 v2.0.
-			 *					  When connecting to these, skip SABME and go right to SABM.
-			 *					  Possible to have multiple and they are cumulative.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing address(es) for V20.\n", line)
-
+		} else if strings.HasPrefix(keyword, "PAODEVICE") {
+			if handlePAODEVICE(ps) {
 				continue
 			}
-
-			for t != "" {
-				var strictness = 2
-				var _, _, _, ok = ax25_parse_addr(AX25_DESTINATION, t, strictness)
-
-				if ok {
-					p_misc_config.v20_addrs = append(p_misc_config.v20_addrs, t)
-					p_misc_config.v20_count++
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Invalid station address for V20 command.\n", line)
-
-					// continue processing any others following.
-				}
-
-				t = split("", false)
-			}
-		} else if strings.EqualFold(t, "NOXID") {
-			/*
-			 * NOXID  address [ address ... ] 	- Stations known not to understand XID.
-			 *					  After connecting to these (with v2.2 obviously), don't try using XID command.
-			 *					  AX.25 for Linux is the one known case so far.
-			 *					  Possible to have multiple and they are cumulative.
-			 */
-			t = split("", false)
-			if t == "" {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Line %d: Missing address(es) for NOXID.\n", line)
-
+		} else if handler, ok := configHandlers[keyword]; ok {
+			if handler(ps) {
 				continue
-			}
-
-			for t != "" {
-				var strictness = 2
-				var _, _, _, ok = ax25_parse_addr(AX25_DESTINATION, t, strictness)
-
-				if ok {
-					p_misc_config.noxid_addrs = append(p_misc_config.noxid_addrs, t)
-					p_misc_config.noxid_count++
-				} else {
-					text_color_set(DW_COLOR_ERROR)
-					dw_printf("Line %d: Invalid station address for NOXID command.\n", line)
-
-					// continue processing any others following.
-				}
-
-				t = split("", false)
 			}
 		} else {
 			/*
 			 * Invalid command.
 			 */
 			text_color_set(DW_COLOR_ERROR)
-			dw_printf("Config file: Unrecognized command '%s' on line %d.\n", t, line)
+			dw_printf("Config file: Unrecognized command '%s' on line %d.\n", t, ps.line)
 		}
 	}
 
@@ -5280,23 +1222,23 @@ func config_init(fname string, p_audio_config *audio_s,
 	for i := range MAX_TOTAL_CHANS {
 		for j := range MAX_TOTAL_CHANS {
 			/* APRS digipeating. */
-			if p_digi_config.enabled[i][j] {
-				if IsNoCall(p_audio_config.mycall[i]) {
+			if ps.digi.enabled[i][j] {
+				if IsNoCall(ps.audio.mycall[i]) {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file: MYCALL must be set for receive channel %d before digipeating is allowed.\n", i)
-					p_digi_config.enabled[i][j] = false
+					ps.digi.enabled[i][j] = false
 				}
 
-				if IsNoCall(p_audio_config.mycall[j]) {
+				if IsNoCall(ps.audio.mycall[j]) {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file: MYCALL must be set for transmit channel %d before digipeating is allowed.\n", j)
-					p_digi_config.enabled[i][j] = false
+					ps.digi.enabled[i][j] = false
 				}
 
 				var b = 0
 
-				for k := 0; k < p_misc_config.num_beacons; k++ {
-					if p_misc_config.beacon[k].sendto_chan == j {
+				for k := 0; k < ps.misc.num_beacons; k++ {
+					if ps.misc.beacon[k].sendto_chan == j {
 						b++
 					}
 				}
@@ -5306,29 +1248,29 @@ func config_init(fname string, p_audio_config *audio_s,
 					dw_printf("Config file: Beaconing should be configured for channel %d when digipeating is enabled.\n", j)
 					// It's a recommendation, not a requirement.
 					// Was there some good reason to turn it off in earlier version?
-					//p_digi_config.enabled[i][j] = 0;
+					//ps.digi.enabled[i][j] = 0;
 				}
 			}
 
 			/* Connected mode digipeating. */
 
-			if i < MAX_RADIO_CHANS && j < MAX_RADIO_CHANS && p_cdigi_config.enabled[i][j] {
-				if IsNoCall(p_audio_config.mycall[i]) {
+			if i < MAX_RADIO_CHANS && j < MAX_RADIO_CHANS && ps.cdigi.enabled[i][j] {
+				if IsNoCall(ps.audio.mycall[i]) {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file: MYCALL must be set for receive channel %d before digipeating is allowed.\n", i)
-					p_cdigi_config.enabled[i][j] = false
+					ps.cdigi.enabled[i][j] = false
 				}
 
-				if IsNoCall(p_audio_config.mycall[j]) {
+				if IsNoCall(ps.audio.mycall[j]) {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file: MYCALL must be set for transmit channel %d before digipeating is allowed.\n", j)
-					p_cdigi_config.enabled[i][j] = false
+					ps.cdigi.enabled[i][j] = false
 				}
 
 				var b = 0
 
-				for k := 0; k < p_misc_config.num_beacons; k++ {
-					if p_misc_config.beacon[k].sendto_chan == j {
+				for k := 0; k < ps.misc.num_beacons; k++ {
+					if ps.misc.beacon[k].sendto_chan == j {
 						b++
 					}
 				}
@@ -5343,21 +1285,21 @@ func config_init(fname string, p_audio_config *audio_s,
 
 		/* When IGate is enabled, all radio channels must have a callsign associated. */
 
-		if len(p_igate_config.t2_login) > 0 &&
-			(p_audio_config.chan_medium[i] == MEDIUM_RADIO || p_audio_config.chan_medium[i] == MEDIUM_NETTNC) {
-			if IsNoCall(p_audio_config.mycall[i]) {
+		if len(ps.igate.t2_login) > 0 &&
+			(ps.audio.chan_medium[i] == MEDIUM_RADIO || ps.audio.chan_medium[i] == MEDIUM_NETTNC) {
+			if IsNoCall(ps.audio.mycall[i]) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Config file: MYCALL must be set for receive channel %d before Rx IGate is allowed.\n", i)
 
-				p_igate_config.t2_login = ""
+				ps.igate.t2_login = ""
 			}
 			// Currently we can have only one transmit channel.
 			// This might be generalized someday to allow more.
-			if p_igate_config.tx_chan >= 0 && IsNoCall(p_audio_config.mycall[p_igate_config.tx_chan]) {
+			if ps.igate.tx_chan >= 0 && IsNoCall(ps.audio.mycall[ps.igate.tx_chan]) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Config file: MYCALL must be set for transmit channel %d before Tx IGate is allowed.\n", i)
 
-				p_igate_config.tx_chan = -1
+				ps.igate.tx_chan = -1
 			}
 		}
 	}
@@ -5365,11 +1307,11 @@ func config_init(fname string, p_audio_config *audio_s,
 	// Apply default IS>RF IGate filter if none specified.  New in 1.4.
 	// This will handle eventual case of multiple transmit channels.
 
-	if len(p_igate_config.t2_login) > 0 {
+	if len(ps.igate.t2_login) > 0 {
 		for j := range MAX_TOTAL_CHANS {
-			if p_audio_config.chan_medium[j] == MEDIUM_RADIO || p_audio_config.chan_medium[j] == MEDIUM_NETTNC {
-				if p_digi_config.filter_str[MAX_TOTAL_CHANS][j] == "" {
-					p_digi_config.filter_str[MAX_TOTAL_CHANS][j] = "i/180"
+			if ps.audio.chan_medium[j] == MEDIUM_RADIO || ps.audio.chan_medium[j] == MEDIUM_NETTNC {
+				if ps.digi.filter_str[MAX_TOTAL_CHANS][j] == "" {
+					ps.digi.filter_str[MAX_TOTAL_CHANS][j] = "i/180"
 				}
 			}
 		}
@@ -5377,10 +1319,4482 @@ func config_init(fname string, p_audio_config *audio_s,
 
 	// Terrible hack.  But what can we do?
 
-	if p_misc_config.maxv22 < 0 {
-		p_misc_config.maxv22 = p_misc_config.retry / 3
+	if ps.misc.maxv22 < 0 {
+		ps.misc.maxv22 = ps.misc.retry / 3
 	}
 } /* end config_init */
+
+// handleADEVICE handles the ADEVICE[n] keyword.
+func handleADEVICE(ps *parseState) bool {
+	/*
+	 * ADEVICE[n] 		- Name of input sound device, and optionally output, if different.
+	 *
+	 *			ADEVICE    plughw:1,0				-- same for in and out.
+	 *			ADEVICE	   plughw:2,0  plughw:3,0		-- different in/out for a channel or channel pair.
+	 *			ADEVICE1   udp:7355  default			-- input from SDR via UDP; output to soundcard.
+	 *			ADEVICE    default   udp:localhost:7355		-- input from soundcard; output via UDP.
+	 *
+	 *	New in 1.8: Ability to map to another audio device.
+	 *	This allows multiple modems (i.e. data speeds) on the same audio interface.
+	 *
+	 *			ADEVICEn   = n				-- Copy from different already defined channel.
+	 */
+	/* Note that ALSA name can contain comma such as hw:1,0 */
+	/* "ADEVICE" is equivalent to "ADEVICE0". */
+	ps.adevice = 0
+
+	// ps.keyword holds the original token e.g. "ADEVICE" or "ADEVICE1".
+	if len(ps.keyword) >= 8 {
+		var i, iErr = strconv.Atoi(string(ps.keyword[7]))
+		if iErr != nil {
+			dw_printf("Config file: Could not parse ADEVICE number on line %d: %s.\n", ps.line, iErr)
+			return true
+		}
+
+		if i < 0 || i >= MAX_ADEVS {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Device number %d out of range for ADEVICE command on line %d.\n", i, ps.line)
+			dw_printf("If you really need more than %d audio devices, increase MAX_ADEVS and recompile.\n", MAX_ADEVS)
+
+			ps.adevice = 0
+
+			return true
+		}
+
+		ps.adevice = i
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing name of audio device for ADEVICE command on line %d.\n", ps.line)
+		rtfm()
+		exit(1)
+	}
+
+	// Do not allow same adevice to be defined more than once.
+	// Overriding the default for adevice 0 is ok.
+	// In that case defined was 2.  That's why we check for 1, not just non-zero.
+
+	if ps.audio.adev[ps.adevice].defined == 1 { // 1 means defined by user.
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: ADEVICE%d can't be defined more than once. Line %d.\n", ps.adevice, ps.line)
+
+		return true
+	}
+
+	ps.audio.adev[ps.adevice].defined = 1
+
+	// New case for release 1.8.
+
+	if t == "=" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: ADEVICE = n (copy-from) is not yet implemented. Line %d.\n", ps.line)
+
+		return true
+	} else {
+		/* First channel of device is valid. */
+		// This might be changed to UDP or STDIN when the device name is examined.
+		ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)] = MEDIUM_RADIO
+
+		ps.audio.adev[ps.adevice].adevice_in = t
+		ps.audio.adev[ps.adevice].adevice_out = t
+
+		t = split("", false)
+		if t != "" {
+			// Different audio devices for receive and transmit.
+			ps.audio.adev[ps.adevice].adevice_out = t
+		}
+	}
+	return false
+}
+
+// handlePAIDEVICE handles PAIDEVICE[n].
+func handlePAIDEVICE(ps *parseState) bool {
+	// ps.keyword holds the original token e.g. "PAIDEVICE" or "PAIDEVICE1".
+	ps.adevice = 0
+	if len(ps.keyword) > 9 && unicode.IsDigit(rune(ps.keyword[9])) {
+		ps.adevice = int(ps.keyword[9] - '0')
+	}
+
+	if ps.adevice < 0 || ps.adevice >= MAX_ADEVS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Device number %d out of range for PAIDEVICE command on line %d.\n", ps.adevice, ps.line)
+		ps.adevice = 0
+
+		return true
+	}
+
+	var t = split("", true)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing name of audio device for PAIDEVICE command on line %d.\n", ps.line)
+
+		return true
+	}
+
+	ps.audio.adev[ps.adevice].defined = 1
+
+	/* First channel of device is valid. */
+	ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)] = MEDIUM_RADIO
+
+	ps.audio.adev[ps.adevice].adevice_in = t
+	return false
+}
+
+// handlePAODEVICE handles PAODEVICE[n].
+func handlePAODEVICE(ps *parseState) bool {
+	// ps.keyword holds the original token e.g. "PAODEVICE" or "PAODEVICE1".
+	ps.adevice = 0
+	if len(ps.keyword) > 9 && unicode.IsDigit(rune(ps.keyword[9])) {
+		ps.adevice = int(ps.keyword[9] - '0')
+	}
+
+	if ps.adevice < 0 || ps.adevice >= MAX_ADEVS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Device number %d out of range for PAODEVICE command on line %d.\n", ps.adevice, ps.line)
+		ps.adevice = 0
+
+		return true
+	}
+
+	var t = split("", true)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing name of audio device for PAODEVICE command on line %d.\n", ps.line)
+
+		return true
+	}
+
+	ps.audio.adev[ps.adevice].defined = 1
+
+	/* First channel of device is valid. */
+	ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)] = MEDIUM_RADIO
+
+	ps.audio.adev[ps.adevice].adevice_out = t
+	return false
+}
+
+// handleARATE handles the ARATE keyword.
+func handleARATE(ps *parseState) bool {
+	/*
+	 * ARATE 		- Audio samples per second, 11025, 22050, 44100, etc.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing audio sample rate for ARATE command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= MIN_SAMPLES_PER_SEC && n <= MAX_SAMPLES_PER_SEC {
+		ps.audio.adev[ps.adevice].samples_per_sec = n
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Use a more reasonable audio sample rate in range of %d - %d.\n",
+			ps.line, MIN_SAMPLES_PER_SEC, MAX_SAMPLES_PER_SEC)
+	}
+	return false
+}
+
+// handleACHANNELS handles the ACHANNELS keyword.
+func handleACHANNELS(ps *parseState) bool {
+	/*
+	 * ACHANNELS 		- Number of audio channels for current device: 1 or 2
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing number of audio channels for ACHANNELS command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n == 1 || n == 2 {
+		ps.audio.adev[ps.adevice].num_channels = n
+
+		/* Set valid channels depending on mono or stereo. */
+
+		ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)] = MEDIUM_RADIO
+		if n == 2 {
+			ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)+1] = MEDIUM_RADIO
+		}
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Number of audio channels must be 1 or 2.\n", ps.line)
+	}
+	return false
+}
+
+// handleCHANNEL handles the CHANNEL keyword.
+func handleCHANNEL(ps *parseState) bool {
+	/*
+	 * ==================== Radio channel parameters ====================
+	 */
+
+	/*
+	 * CHANNEL n		- Set channel for channel-specific commands.  Only for modem/radio channels.
+	 */
+
+	// TODO: allow full range so mycall can be set for network channels.
+	// Watch out for achan[] out of bounds.
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing channel number for CHANNEL command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 0 && n < MAX_RADIO_CHANS {
+		ps.channel = n
+
+		if ps.audio.chan_medium[n] != MEDIUM_RADIO {
+			if ps.audio.adev[ACHAN2ADEV(n)].defined == 0 {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Channel number %d is not valid because audio device %d is not defined.\n",
+					ps.line, n, ACHAN2ADEV(n))
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Channel number %d is not valid because audio device %d is not in stereo.\n",
+					ps.line, n, ACHAN2ADEV(n))
+			}
+		}
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Channel number must in range of 0 to %d.\n", ps.line, MAX_RADIO_CHANS-1)
+	}
+	return false
+}
+
+// handleICHANNEL handles the ICHANNEL keyword.
+func handleICHANNEL(ps *parseState) bool {
+	/*
+	 * ICHANNEL n			- Define IGate virtual channel.
+	 *
+	 *	This allows a client application to talk to to APRS-IS
+	 *	by using a channel number outside the normal range for modems.
+	 *	In the future there might be other typs of virtual channels.
+	 *	This does not change the current channel number used by MODEM, PTT, etc.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing virtual channel number for ICHANNEL command.\n", ps.line)
+
+		return true
+	}
+
+	var ichan, _ = strconv.Atoi(t)
+	if ichan >= MAX_RADIO_CHANS && ichan < MAX_TOTAL_CHANS {
+		if ps.audio.chan_medium[ichan] == MEDIUM_NONE {
+			ps.audio.chan_medium[ichan] = MEDIUM_IGATE
+
+			// This is redundant but saves the time of searching through all
+			// the channels for each packet.
+			ps.audio.igate_vchannel = ichan
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: ICHANNEL can't use channel %d because it is already in use.\n", ps.line, ichan)
+		}
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: ICHANNEL number must in range of %d to %d.\n", ps.line, MAX_RADIO_CHANS, MAX_TOTAL_CHANS-1)
+	}
+	return false
+}
+
+// handleNCHANNEL handles the NCHANNEL keyword.
+func handleNCHANNEL(ps *parseState) bool {
+	/*
+	 * NCHANNEL chan addr port			- Define Network TNC virtual channel.
+	 *
+	 *	This allows a client application to talk to to an external TNC over TCP KISS
+	 *	by using a channel number outside the normal range for modems.
+	 *	This does not change the current channel number used by MODEM, PTT, etc.
+	 *
+	 *	chan = direwolf channel.
+	 *	addr = hostname or IP address of network TNC.
+	 *	port = KISS TCP port on network TNC.
+	 *
+	 *	Future: Might allow selection of channel on the network TNC.
+	 *	For now, ignore incoming and set to 0 for outgoing.
+	 *
+	 * FIXME: Can't set mycall for nchannel.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing virtual channel number for NCHANNEL command.\n", ps.line)
+
+		return true
+	}
+
+	var nchan, _ = strconv.Atoi(t)
+	if nchan >= MAX_RADIO_CHANS && nchan < MAX_TOTAL_CHANS {
+		if ps.audio.chan_medium[nchan] == MEDIUM_NONE {
+			ps.audio.chan_medium[nchan] = MEDIUM_NETTNC
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: NCHANNEL can't use channel %d because it is already in use.\n", ps.line, nchan)
+		}
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: NCHANNEL number must in range of %d to %d.\n", ps.line, MAX_RADIO_CHANS, MAX_TOTAL_CHANS-1)
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing network TNC address for NCHANNEL command.\n", ps.line)
+
+		return true
+	}
+
+	ps.audio.nettnc_addr[nchan] = t
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing network TNC TCP port for NCHANNEL command.\n", ps.line)
+
+		return true
+	}
+	var n, _ = strconv.Atoi(t)
+	ps.audio.nettnc_port[nchan] = n
+	return false
+}
+
+// handleMYCALL handles the MYCALL keyword.
+func handleMYCALL(ps *parseState) bool {
+	/*
+	 * MYCALL station
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing value for MYCALL command on line %d.\n", ps.line)
+
+		return true
+	} else {
+		var strictness = 2
+
+		/* Silently force upper case. */
+		/* Might change to warning someday. */
+		t = strings.ToUpper(t)
+
+		var _, _, _, ok = ax25_parse_addr(-1, t, strictness)
+
+		if !ok {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Invalid value for MYCALL command on line %d.\n", ps.line)
+
+			return true
+		}
+
+		// Definitely set for current channel.
+		// Set for other channels which have not been set yet.
+
+		for c := range MAX_TOTAL_CHANS {
+			if c == ps.channel || IsNoCall(ps.audio.mycall[c]) {
+				ps.audio.mycall[c] = t
+			}
+		}
+	}
+	return false
+}
+
+// handleMODEM handles the MODEM keyword.
+func handleMODEM(ps *parseState) bool {
+	/*
+	 * MODEM	- Set modem properties for current channel.
+	 *
+	 *
+	 * Old style:
+	 * 	MODEM  baud [ mark  space  [A][B][C][+]  [  num-decoders spacing ] ]
+	 *
+	 * New style, version 1.2:
+	 *	MODEM  speed [ option ] ...
+	 *
+	 * Options:
+	 *	mark:space	- AFSK tones.  Defaults based on speed.
+	 *	num@offset	- Multiple decoders on different frequencies.
+	 *	/9		- Divide sample rate by specified number.
+	 *	*9		- Upsample ratio for G3RUH.
+	 *	[A-Z+-]+	- Letters, plus, minus for the demodulator "profile."
+	 *	g3ruh		- This modem type regardless of default for speed.
+	 *	v26a or v26b	- V.26 alternative.  a=original, b=MFJ compatible
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: MODEM can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing data transmission speed for MODEM command.\n", ps.line)
+
+		return true
+	}
+
+	var n int
+	if strings.EqualFold(t, "AIS") {
+		n = MAX_BAUD - 1 // Hack - See special case later.
+	} else if strings.EqualFold(t, "EAS") {
+		n = MAX_BAUD - 2 // Hack - See special case later.
+	} else {
+		n, _ = strconv.Atoi(t)
+	}
+
+	if n >= MIN_BAUD && n <= MAX_BAUD {
+		ps.audio.achan[ps.channel].baud = n
+		if n != 300 && n != 1200 && n != 2400 && n != 4800 && n != 9600 && n != 19200 && n != MAX_BAUD-1 && n != MAX_BAUD-2 {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Warning: Non-standard data rate of %d bits per second.  Are you sure?\n", ps.line, n)
+		}
+	} else {
+		ps.audio.achan[ps.channel].baud = DEFAULT_BAUD
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Unreasonable data rate. Using %d bits per second.\n",
+			ps.line, ps.audio.achan[ps.channel].baud)
+	}
+
+	/* Set defaults based on speed. */
+	/* Should be same as -B command line option in direwolf.c. */
+
+	/* We have similar logic in direwolf.c, config.c, gen_packets.c, and atest.c, */
+	/* that need to be kept in sync.  Maybe it could be a common function someday. */
+
+	if ps.audio.achan[ps.channel].baud < 600 {
+		ps.audio.achan[ps.channel].modem_type = MODEM_AFSK
+		ps.audio.achan[ps.channel].mark_freq = 1600
+		ps.audio.achan[ps.channel].space_freq = 1800
+	} else if ps.audio.achan[ps.channel].baud < 1800 {
+		ps.audio.achan[ps.channel].modem_type = MODEM_AFSK
+		ps.audio.achan[ps.channel].mark_freq = DEFAULT_MARK_FREQ
+		ps.audio.achan[ps.channel].space_freq = DEFAULT_SPACE_FREQ
+	} else if ps.audio.achan[ps.channel].baud < 3600 {
+		ps.audio.achan[ps.channel].modem_type = MODEM_QPSK
+		ps.audio.achan[ps.channel].mark_freq = 0
+		ps.audio.achan[ps.channel].space_freq = 0
+	} else if ps.audio.achan[ps.channel].baud < 7200 {
+		ps.audio.achan[ps.channel].modem_type = MODEM_8PSK
+		ps.audio.achan[ps.channel].mark_freq = 0
+		ps.audio.achan[ps.channel].space_freq = 0
+	} else if ps.audio.achan[ps.channel].baud == MAX_BAUD-1 {
+		ps.audio.achan[ps.channel].modem_type = MODEM_AIS
+		ps.audio.achan[ps.channel].mark_freq = 0
+		ps.audio.achan[ps.channel].space_freq = 0
+	} else if ps.audio.achan[ps.channel].baud == MAX_BAUD-2 {
+		ps.audio.achan[ps.channel].modem_type = MODEM_EAS
+		ps.audio.achan[ps.channel].baud = 521 // Actually 520.83 but we have an integer field here.
+		// Will make more precise in afsk demod init.
+		ps.audio.achan[ps.channel].mark_freq = 2083  // Actually 2083.3 - logic 1.
+		ps.audio.achan[ps.channel].space_freq = 1563 // Actually 1562.5 - logic 0.
+		// ? strlcpy (p_audio_config.achan[channel].profiles, "A", sizeof(p_audio_config.achan[channel].profiles));
+	} else {
+		ps.audio.achan[ps.channel].modem_type = MODEM_SCRAMBLE
+		ps.audio.achan[ps.channel].mark_freq = 0
+		ps.audio.achan[ps.channel].space_freq = 0
+	}
+
+	/* Get any options. */
+
+	t = split("", false)
+	if t == "" {
+		/* all done. */
+		return true
+	}
+
+	if alldigits(t) {
+		/* old style */
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Old style (pre version 1.2) format will no longer be supported in next version.\n", ps.line)
+
+		n, _ = strconv.Atoi(t)
+		/* Originally the upper limit was 3000. */
+		/* Version 1.0 increased to 5000 because someone */
+		/* wanted to use 2400/4800 Hz AFSK. */
+		/* Of course the MIC and SPKR connections won't */
+		/* have enough bandwidth so radios must be modified. */
+		if n >= 300 && n <= 5000 {
+			ps.audio.achan[ps.channel].mark_freq = n
+		} else {
+			ps.audio.achan[ps.channel].mark_freq = DEFAULT_MARK_FREQ
+
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Unreasonable mark tone frequency. Using %d.\n",
+				ps.line, ps.audio.achan[ps.channel].mark_freq)
+		}
+
+		/* Get space frequency */
+
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Missing tone frequency for space.\n", ps.line)
+
+			return true
+		}
+
+		n, _ = strconv.Atoi(t)
+		if n >= 300 && n <= 5000 {
+			ps.audio.achan[ps.channel].space_freq = n
+		} else {
+			ps.audio.achan[ps.channel].space_freq = DEFAULT_SPACE_FREQ
+
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Unreasonable space tone frequency. Using %d.\n",
+				ps.line, ps.audio.achan[ps.channel].space_freq)
+		}
+
+		/* Gently guide users toward new format. */
+
+		if ps.audio.achan[ps.channel].baud == 1200 &&
+			ps.audio.achan[ps.channel].mark_freq == 1200 &&
+			ps.audio.achan[ps.channel].space_freq == 2200 {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: The AFSK frequencies can be omitted when using the 1200 baud default 1200:2200.\n", ps.line)
+		}
+
+		if ps.audio.achan[ps.channel].baud == 300 &&
+			ps.audio.achan[ps.channel].mark_freq == 1600 &&
+			ps.audio.achan[ps.channel].space_freq == 1800 {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: The AFSK frequencies can be omitted when using the 300 baud default 1600:1800.\n", ps.line)
+		}
+
+		/* New feature in 0.9 - Optional filter profile(s). */
+
+		t = split("", false)
+		if t != "" {
+			/* Look for some combination of letter(s) and + */
+			if unicode.IsLetter(rune(t[0])) || t[0] == '+' {
+				/* Here we only catch something other than letters and + mixed in. */
+				/* Later, we check for valid letters and no more than one letter if + specified. */
+				if strings.ContainsFunc(t, func(r rune) bool {
+					return !(unicode.IsLetter(r) || r == '+' || r == '-')
+				}) {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Demodulator type can only contain letters and + character.\n", ps.line)
+				}
+
+				ps.audio.achan[ps.channel].profiles = t
+
+				t = split("", false)
+				if len(ps.audio.achan[ps.channel].profiles) > 1 && t != "" {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Can't combine multiple demodulator types and multiple frequencies.\n", ps.line)
+
+					return true
+				}
+			}
+		}
+
+		/* New feature in 0.9 - optional number of decoders and frequency offset between. */
+
+		if t != "" {
+			n, _ = strconv.Atoi(t)
+			if n < 1 || n > MAX_SUBCHANS {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Number of demodulators is out of range. Using 3.\n", ps.line)
+
+				n = 3
+			}
+
+			ps.audio.achan[ps.channel].num_freq = n
+
+			t = split("", false)
+			if t != "" {
+				n, _ = strconv.Atoi(t)
+				if n < 5 || n > int(math.Abs(float64(ps.audio.achan[ps.channel].mark_freq-ps.audio.achan[ps.channel].space_freq))/2) {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Unreasonable value for offset between modems.  Using 50 Hz.\n", ps.line)
+
+					n = 50
+				}
+
+				ps.audio.achan[ps.channel].offset = n
+
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: New style for multiple demodulators is %d@%d\n", ps.line,
+					ps.audio.achan[ps.channel].num_freq, ps.audio.achan[ps.channel].offset)
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Missing frequency offset between modems.  Using 50 Hz.\n", ps.line)
+
+				ps.audio.achan[ps.channel].offset = 50
+			}
+		}
+	} else {
+		/* New style in version 1.2. */
+		for t != "" {
+			if strings.Contains(t, ":") { /* mark:space */
+				var markStr, spaceStr, _ = strings.Cut(t, ":")
+				var mark, _ = strconv.Atoi(markStr)
+				var space, _ = strconv.Atoi(spaceStr)
+
+				ps.audio.achan[ps.channel].mark_freq = mark
+				ps.audio.achan[ps.channel].space_freq = space
+
+				if ps.audio.achan[ps.channel].mark_freq == 0 && ps.audio.achan[ps.channel].space_freq == 0 {
+					ps.audio.achan[ps.channel].modem_type = MODEM_SCRAMBLE
+				} else {
+					ps.audio.achan[ps.channel].modem_type = MODEM_AFSK
+
+					if ps.audio.achan[ps.channel].mark_freq < 300 || ps.audio.achan[ps.channel].mark_freq > 5000 {
+						ps.audio.achan[ps.channel].mark_freq = DEFAULT_MARK_FREQ
+
+						text_color_set(DW_COLOR_ERROR)
+						dw_printf("Line %d: Unreasonable mark tone frequency. Using %d instead.\n",
+							ps.line, ps.audio.achan[ps.channel].mark_freq)
+					}
+
+					if ps.audio.achan[ps.channel].space_freq < 300 || ps.audio.achan[ps.channel].space_freq > 5000 {
+						ps.audio.achan[ps.channel].space_freq = DEFAULT_SPACE_FREQ
+
+						text_color_set(DW_COLOR_ERROR)
+						dw_printf("Line %d: Unreasonable space tone frequency. Using %d instead.\n",
+							ps.line, ps.audio.achan[ps.channel].space_freq)
+					}
+				}
+			} else if strings.Contains(t, "@") { /* num@offset */
+				var numStr, offsetStr, _ = strings.Cut(t, "@")
+				var num, _ = strconv.Atoi(numStr)
+				var offset, _ = strconv.Atoi(offsetStr)
+
+				ps.audio.achan[ps.channel].num_freq = num
+				ps.audio.achan[ps.channel].offset = offset
+
+				if ps.audio.achan[ps.channel].num_freq < 1 || ps.audio.achan[ps.channel].num_freq > MAX_SUBCHANS {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Number of demodulators is out of range. Using 3.\n", ps.line)
+
+					ps.audio.achan[ps.channel].num_freq = 3
+				}
+
+				if ps.audio.achan[ps.channel].offset < 5 ||
+					float64(ps.audio.achan[ps.channel].offset) > math.Abs(float64(ps.audio.achan[ps.channel].mark_freq-ps.audio.achan[ps.channel].space_freq))/2 {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Offset between demodulators is unreasonable. Using 50 Hz.\n", ps.line)
+
+					ps.audio.achan[ps.channel].offset = 50
+				}
+			} else if strings.EqualFold(t, "BPSK") { /* Force BPSK modem (1 bit/symbol, carrier 1800 Hz). */
+				ps.audio.achan[ps.channel].modem_type = MODEM_BPSK
+				ps.audio.achan[ps.channel].mark_freq = 0
+				ps.audio.achan[ps.channel].space_freq = 0
+			} else if strings.EqualFold(t, "G3RUH") { /* Force G3RUH modem regardless of default for speed. New in 1.6. */
+				ps.audio.achan[ps.channel].modem_type = MODEM_SCRAMBLE
+				ps.audio.achan[ps.channel].mark_freq = 0
+				ps.audio.achan[ps.channel].space_freq = 0
+			} else if strings.EqualFold(t, "V26A") || /* Compatible with direwolf versions <= 1.5.  New in 1.6. */
+				strings.EqualFold(t, "V26B") { /* Compatible with MFJ-2400.  New in 1.6. */
+				if ps.audio.achan[ps.channel].modem_type != MODEM_QPSK ||
+					ps.audio.achan[ps.channel].baud != 2400 {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: %s option can only be used with 2400 bps PSK.\n", ps.line, t)
+
+					return true
+				}
+
+				ps.audio.achan[ps.channel].v26_alternative = IfThenElse((strings.EqualFold(t, "V26A")), V26_A, V26_B)
+			} else if t[0] == '/' { /* /div */
+				var n, _ = strconv.Atoi(t[1:])
+
+				if n >= 1 && n <= 8 {
+					ps.audio.achan[ps.channel].decimate = n
+				} else {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Ignoring unreasonable sample rate division factor of %d.\n", ps.line, n)
+				}
+			} else if t[0] == '*' { /* *upsample */
+				var n, _ = strconv.Atoi(t[1:])
+
+				if n >= 1 && n <= 4 {
+					ps.audio.achan[ps.channel].upsample = n
+				} else {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Ignoring unreasonable upsample ratio of %d.\n", ps.line, n)
+				}
+			} else if alllettersorpm(t) { /* profile of letter(s) + - */
+				// Will be validated later.
+				ps.audio.achan[ps.channel].profiles = t
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Unrecognized option for MODEM: %s\n", ps.line, t)
+			}
+
+			t = split("", false)
+		}
+
+		/* A later place catches disallowed combination of + and @. */
+		/* A later place sets /n for 300 baud if not specified by user. */
+
+		//dw_printf ("debug: div = %d\n", p_audio_config.achan[channel].decimate);
+	}
+	return false
+}
+
+// handleDTMF handles the DTMF keyword.
+func handleDTMF(ps *parseState) bool {
+	/*
+	 * DTMF  		- Enable DTMF decoder.
+	 *
+	 * Future possibilities:
+	 *	Option to determine if it goes to APRStt gateway and/or application.
+	 *	Disable normal demodulator to reduce CPU requirements.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: DTMF can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	ps.audio.achan[ps.channel].dtmf_decode = DTMF_DECODE_ON
+	return false
+}
+
+// handleFIX_BITS handles the FIX_BITS keyword.
+func handleFIX_BITS(ps *parseState) bool {
+	/*
+	 * FIX_BITS  n  [ APRS | AX25 | NONE ] [ PASSALL ]
+	 *
+	 *	- Attempt to fix frames with bad FCS.
+	 *	- n is maximum number of bits to attempt fixing.
+	 *	- Optional sanity check & allow everything even with bad FCS.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: FIX_BITS can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing value for FIX_BITS command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if BitFixLevel(n) >= RETRY_NONE && BitFixLevel(n) < RETRY_MAX { // MAX is actually last valid +1
+		ps.audio.achan[ps.channel].fix_bits = BitFixLevel(n)
+	} else {
+		ps.audio.achan[ps.channel].fix_bits = DEFAULT_FIX_BITS
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid value %d for FIX_BITS. Using default of %d.\n",
+			ps.line, n, ps.audio.achan[ps.channel].fix_bits)
+	}
+
+	if ps.audio.achan[ps.channel].fix_bits > DEFAULT_FIX_BITS {
+		text_color_set(DW_COLOR_INFO)
+		dw_printf("Line %d: Using a FIX_BITS value greater than %d is not recommended for normal operation.\n",
+			ps.line, DEFAULT_FIX_BITS)
+		dw_printf("FIX_BITS > 1 was an interesting experiment but turned out to be a bad idea.\n")
+		dw_printf("Don't be surprised if it takes 100%% CPU, direwolf can't keep up with the audio stream,\n")
+		dw_printf("and you see messages like \"Audio input device 0 error code -32: Broken pipe\"\n")
+	}
+
+	t = split("", false)
+	for t != "" {
+		// If more than one sanity test, we silently take the last one.
+		if strings.EqualFold(t, "APRS") {
+			ps.audio.achan[ps.channel].sanity_test = SANITY_APRS
+		} else if strings.EqualFold(t, "AX25") || strings.EqualFold(t, "AX.25") {
+			ps.audio.achan[ps.channel].sanity_test = SANITY_AX25
+		} else if strings.EqualFold(t, "NONE") {
+			ps.audio.achan[ps.channel].sanity_test = SANITY_NONE
+		} else if strings.EqualFold(t, "PASSALL") {
+			ps.audio.achan[ps.channel].passall = true
+
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: There is an old saying, \"Be careful what you ask for because you might get it.\"\n", ps.line)
+			dw_printf("The PASSALL option means allow all frames even when they are invalid.\n")
+			dw_printf("You are asking to receive random trash and you WILL get your wish.\n")
+			dw_printf("Don't complain when you see all sorts of random garbage.  That's what you asked for.\n")
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Invalid option '%s' for FIX_BITS.\n", ps.line, t)
+		}
+
+		t = split("", false)
+	}
+	return false
+}
+
+// handlePTTDCDCON handles the PTTDCDCON keyword.
+func handlePTTDCDCON(ps *parseState) bool {
+	/*
+	 * PTT 		- Push To Talk signal line.
+	 * DCD		- Data Carrier Detect indicator.
+	 * CON		- Connected to another station indicator.
+	 *
+	 * xxx  serial-port [-]rts-or-dtr [ [-]rts-or-dtr ]
+	 * xxx  GPIO  [-]gpio-num
+	 * xxx  LPT  [-]bit-num
+	 * PTT  RIG  model  port [ rate ]
+	 * PTT  RIG  AUTO  port [ rate ]
+	 * PTT  CM108 [ [-]bit-num ] [ hid-device ]
+	 *
+	 * 		When model is 2, port would host:port like 127.0.0.1:4532
+	 *		Otherwise, port would be a serial port like /dev/ttyS0
+	 *
+	 *
+	 * Applies to most recent CHANNEL command.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: PTT can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+	var ot int
+	var otname string
+
+	if strings.EqualFold(ps.keyword, "PTT") {
+		ot = OCTYPE_PTT
+		otname = "PTT"
+	} else if strings.EqualFold(ps.keyword, "DCD") {
+		ot = OCTYPE_DCD
+		otname = "DCD"
+	} else {
+		ot = OCTYPE_CON
+		otname = "CON"
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file line %d: Missing output control device for %s command.\n",
+			ps.line, otname)
+
+		return true
+	}
+
+	if strings.EqualFold(t, "GPIO") {
+		/* GPIO case, Linux only. */
+
+		/* TODO KG
+		   #if __WIN32__
+		   	      text_color_set(DW_COLOR_ERROR);
+		   	      dw_printf ("Config file line %d: %s with GPIO is only available on Linux.\n", ps.line, otname);
+		   #else
+		*/
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Missing GPIO number for %s.\n", ps.line, otname)
+
+			return true
+		}
+
+		var gpio, _ = strconv.Atoi(t)
+		if gpio < 0 {
+			ps.audio.achan[ps.channel].octrl[ot].out_gpio_num = -1 * gpio
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = true
+		} else {
+			ps.audio.achan[ps.channel].octrl[ot].out_gpio_num = gpio
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = false
+		}
+
+		ps.audio.achan[ps.channel].octrl[ot].ptt_method = PTT_METHOD_GPIO
+		// #endif
+	} else if strings.EqualFold(t, "GPIOD") {
+		/*
+			#if __WIN32__
+				      text_color_set(DW_COLOR_ERROR);
+				      dw_printf ("Config file line %d: %s with GPIOD is only available on Linux.\n", ps.line, otname);
+			#else
+		*/
+		// #if defined(USE_GPIOD)
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Missing GPIO chip name for %s.\n", ps.line, otname)
+			dw_printf("Use the \"gpioinfo\" command to get a list of gpio chip names and corresponding I/O lines.\n")
+
+			return true
+		}
+
+		// Issue 590.  Originally we used the chip name, like gpiochip3, and fed it into
+		// gpiod_chip_open_by_name.   This function has disappeared in Debian 13 Trixie.
+		// We must now specify the full device path, like /dev/gpiochip3, for the only
+		// remaining open function gpiod_chip_open.
+		// We will allow the user to specify either the name or full device path.
+		// While we are here, also allow only the number as used by the gpiod utilities.
+
+		if t[0] == '/' { // Looks like device path.  Use as given.
+			ps.audio.achan[ps.channel].octrl[ot].out_gpio_name = t
+		} else if unicode.IsDigit(rune(t[0])) { // or if digit, prepend "/dev/gpiochip"
+			ps.audio.achan[ps.channel].octrl[ot].out_gpio_name = "/dev/gpiochip" + t
+		} else { // otherwise, prepend "/dev/" to the name
+			ps.audio.achan[ps.channel].octrl[ot].out_gpio_name = "/dev/" + t
+		}
+
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Missing GPIO number for %s.\n", ps.line, otname)
+
+			return true
+		}
+
+		var gpio, _ = strconv.Atoi(t)
+		if gpio < 0 {
+			ps.audio.achan[ps.channel].octrl[ot].out_gpio_num = -1 * gpio
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = true
+		} else {
+			ps.audio.achan[ps.channel].octrl[ot].out_gpio_num = gpio
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = false
+		}
+
+		ps.audio.achan[ps.channel].octrl[ot].ptt_method = PTT_METHOD_GPIOD
+		/* TODO KG
+		#else
+			      text_color_set(DW_COLOR_ERROR);
+			      dw_printf ("Application was not built with optional support for GPIOD.\n");
+			      dw_printf ("Install packages gpiod and libgpiod-dev, remove 'build' subdirectory, then rebuild.\n");
+		#endif // USE_GPIOD
+		*/
+		//#endif /* __WIN32__ */
+	} else if strings.EqualFold(t, "LPT") {
+		/* Parallel printer case, x86 Linux only. */
+
+		//#if  ( defined(__i386__) || defined(__x86_64__) ) && ( defined(__linux__) || defined(__unix__) )
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Missing LPT bit number for %s.\n", ps.line, otname)
+
+			return true
+		}
+
+		var lpt, _ = strconv.Atoi(t)
+		if lpt < 0 {
+			ps.audio.achan[ps.channel].octrl[ot].ptt_lpt_bit = -1 * lpt
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = true
+		} else {
+			ps.audio.achan[ps.channel].octrl[ot].ptt_lpt_bit = lpt
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = false
+		}
+
+		ps.audio.achan[ps.channel].octrl[ot].ptt_method = PTT_METHOD_LPT
+		/*
+			#else
+				      text_color_set(DW_COLOR_ERROR);
+				      dw_printf ("Config file line %d: %s with LPT is only available on x86 Linux.\n", ps.line, otname);
+			#endif
+		*/
+	} else if strings.EqualFold(t, "RIG") {
+		// TODO KG #ifdef USE_HAMLIB
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Missing model number for hamlib.\n", ps.line)
+
+			return true
+		}
+
+		if strings.EqualFold(t, "AUTO") {
+			ps.audio.achan[ps.channel].octrl[ot].ptt_model = -1
+		} else {
+			if !alldigits(t) {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file line %d: A rig number, not a name, is required here.\n", ps.line)
+				dw_printf("For example, if you have a Yaesu FT-847, specify 101.\n")
+				dw_printf("See https://github.com/Hamlib/Hamlib/wiki/Supported-Radios for more details.\n")
+
+				return true
+			}
+
+			var n, _ = strconv.Atoi(t)
+			if n < 1 || n > 9999 {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file line %d: Unreasonable model number %d for hamlib.\n", ps.line, n)
+
+				return true
+			}
+
+			ps.audio.achan[ps.channel].octrl[ot].ptt_model = n
+		}
+
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Missing port for hamlib.\n", ps.line)
+
+			return true
+		}
+
+		ps.audio.achan[ps.channel].octrl[ot].ptt_device = t
+
+		// Optional serial port rate for CAT control PTT.
+
+		t = split("", false)
+		if t != "" {
+			if !alldigits(t) {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file line %d: An optional number is required here for CAT serial port speed: %s\n", ps.line, t)
+
+				return true
+			}
+			var n, _ = strconv.Atoi(t)
+			ps.audio.achan[ps.channel].octrl[ot].ptt_rate = n
+		}
+
+		t = split("", false)
+		if t != "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: %s was not expected after model & port for hamlib.\n", ps.line, t)
+		}
+
+		ps.audio.achan[ps.channel].octrl[ot].ptt_method = PTT_METHOD_HAMLIB
+
+		// #else
+		/* TODO KG
+		   #if __WIN32__
+		   	      text_color_set(DW_COLOR_ERROR);
+		   	      dw_printf ("Config file line %d: Windows version of direwolf does not support HAMLIB.\n", ps.line);
+		   	      exit (EXIT_FAILURE);
+		   #else
+		*/
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file line %d: %s with RIG is only available when hamlib support is enabled.\n", ps.line, otname)
+		dw_printf("You must rebuild direwolf with hamlib support.\n")
+		dw_printf("See User Guide for details.\n")
+		// #endif
+
+		//#endif
+	} else if strings.EqualFold(t, "CM108") {
+		/* CM108 - GPIO of USB sound card. case, Linux and Windows only. */
+
+		// TODO KG #if USE_CM108
+		if ot != OCTYPE_PTT {
+			// Future project:  Allow DCD and CON via the same device.
+			// This gets more complicated because we can't selectively change a single GPIO bit.
+			// We would need to keep track of what is currently there, change one bit, in our local
+			// copy of the status and then write out the byte for all of the pins.
+			// Let's keep it simple with just PTT for the first stab at this.
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: PTT CM108 option is only valid for PTT, not %s.\n", ps.line, otname)
+
+			return true
+		}
+
+		ps.audio.achan[ps.channel].octrl[ot].out_gpio_num = 3 // All known designs use GPIO 3.
+		// User can override for special cases.
+		ps.audio.achan[ps.channel].octrl[ot].ptt_invert = false // High for transmit.
+		ps.audio.achan[ps.channel].octrl[ot].ptt_device = ""
+
+		// Try to find PTT device for audio output device.
+		// Simplifiying assumption is that we have one radio per USB Audio Adapter.
+		// Failure at this point is not an error.
+		// See if config file sets it explicitly before complaining.
+
+		ps.audio.achan[ps.channel].octrl[ot].ptt_device = cm108_find_ptt(ps.audio.adev[ACHAN2ADEV(ps.channel)].adevice_out)
+
+		for {
+			t = split("", false)
+			if t == "" {
+				break
+			}
+
+			if t[0] == '-' {
+				var gpio, _ = strconv.Atoi(t[1:])
+				ps.audio.achan[ps.channel].octrl[ot].out_gpio_num = -1 * gpio
+				ps.audio.achan[ps.channel].octrl[ot].ptt_invert = true
+			} else if unicode.IsDigit(rune(t[0])) {
+				var gpio, _ = strconv.Atoi(t)
+				ps.audio.achan[ps.channel].octrl[ot].out_gpio_num = gpio
+				ps.audio.achan[ps.channel].octrl[ot].ptt_invert = false
+			} else if t[0] == '/' {
+				ps.audio.achan[ps.channel].octrl[ot].ptt_device = t
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file line %d: Found \"%s\" when expecting GPIO number or device name like /dev/hidraw1.\n", ps.line, t)
+
+				return true
+			}
+		}
+
+		if ps.audio.achan[ps.channel].octrl[ot].out_gpio_num < 1 || ps.audio.achan[ps.channel].octrl[ot].out_gpio_num > 8 {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: CM108 GPIO number %d is not in range of 1 thru 8.\n", ps.line,
+				ps.audio.achan[ps.channel].octrl[ot].out_gpio_num)
+
+			return true
+		}
+
+		if ps.audio.achan[ps.channel].octrl[ot].ptt_device == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Could not determine USB Audio GPIO PTT device for audio output %s.\n", ps.line,
+				ps.audio.adev[ACHAN2ADEV(ps.channel)].adevice_out)
+			/* TODO KG
+			#if __WIN32__
+				        dw_printf ("You must explicitly mention a HID path.\n");
+			#else
+			*/
+			dw_printf("You must explicitly mention a device name such as /dev/hidraw1.\n")
+			dw_printf("Run \"cm108\" utility to get a list.\n")
+			dw_printf("See Interface Guide for details.\n")
+
+			return true
+		}
+
+		ps.audio.achan[ps.channel].octrl[ot].ptt_method = PTT_METHOD_CM108
+
+		/* TODO KG
+		#else
+			      text_color_set(DW_COLOR_ERROR);
+			      dw_printf ("Config file line %d: %s with CM108 is only available when USB Audio GPIO support is enabled.\n", ps.line, otname);
+			      dw_printf ("You must rebuild direwolf with CM108 Audio Adapter GPIO PTT support.\n");
+			      dw_printf ("See Interface Guide for details.\n");
+			      rtfm();
+			      exit (EXIT_FAILURE);
+		#endif
+		*/
+	} else {
+		/* serial port case. */
+		ps.audio.achan[ps.channel].octrl[ot].ptt_device = t
+
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Missing RTS or DTR after %s device name.\n",
+				ps.line, otname)
+
+			return true
+		}
+
+		if strings.EqualFold(t, "rts") {
+			ps.audio.achan[ps.channel].octrl[ot].ptt_line = PTT_LINE_RTS
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = false
+		} else if strings.EqualFold(t, "dtr") {
+			ps.audio.achan[ps.channel].octrl[ot].ptt_line = PTT_LINE_DTR
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = false
+		} else if strings.EqualFold(t, "-rts") {
+			ps.audio.achan[ps.channel].octrl[ot].ptt_line = PTT_LINE_RTS
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = true
+		} else if strings.EqualFold(t, "-dtr") {
+			ps.audio.achan[ps.channel].octrl[ot].ptt_line = PTT_LINE_DTR
+			ps.audio.achan[ps.channel].octrl[ot].ptt_invert = true
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Expected RTS or DTR after %s device name.\n",
+				ps.line, otname)
+
+			return true
+		}
+
+		ps.audio.achan[ps.channel].octrl[ot].ptt_method = PTT_METHOD_SERIAL
+
+		/* In version 1.2, we allow a second one for same serial port. */
+		/* Some interfaces want the two control lines driven with opposite polarity. */
+		/* e.g.   PTT COM1 RTS -DTR  */
+
+		t = split("", false)
+		if t != "" {
+			if strings.EqualFold(t, "rts") {
+				ps.audio.achan[ps.channel].octrl[ot].ptt_line2 = PTT_LINE_RTS
+				ps.audio.achan[ps.channel].octrl[ot].ptt_invert2 = false
+			} else if strings.EqualFold(t, "dtr") {
+				ps.audio.achan[ps.channel].octrl[ot].ptt_line2 = PTT_LINE_DTR
+				ps.audio.achan[ps.channel].octrl[ot].ptt_invert2 = false
+			} else if strings.EqualFold(t, "-rts") {
+				ps.audio.achan[ps.channel].octrl[ot].ptt_line2 = PTT_LINE_RTS
+				ps.audio.achan[ps.channel].octrl[ot].ptt_invert2 = true
+			} else if strings.EqualFold(t, "-dtr") {
+				ps.audio.achan[ps.channel].octrl[ot].ptt_line2 = PTT_LINE_DTR
+				ps.audio.achan[ps.channel].octrl[ot].ptt_invert2 = true
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file line %d: Expected RTS or DTR after first RTS or DTR.\n",
+					ps.line)
+
+				return true
+			}
+
+			/* Would not make sense to specify the same one twice. */
+
+			if ps.audio.achan[ps.channel].octrl[ot].ptt_line == ps.audio.achan[ps.channel].octrl[ot].ptt_line2 {
+				dw_printf("Config file line %d: Doesn't make sense to specify the some control line twice.\n",
+					ps.line)
+			}
+		} /* end of second serial port control ps.line. */
+	} /* end of serial port case. */
+	/* end of PTT, DCD, CON */
+	return false
+}
+
+// handleTXINH handles the TXINH keyword.
+func handleTXINH(ps *parseState) bool {
+	/*
+	 * INPUTS
+	 *
+	 * TXINH - TX holdoff input
+	 *
+	 * TXINH GPIO [-]gpio-num (only type supported so far)
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TXINH can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+	var itname = "TXINH"
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file line %d: Missing input type name for %s command.\n", ps.line, itname)
+
+		return true
+	}
+
+	if strings.EqualFold(t, "GPIO") {
+		/* TODO KG
+		#if __WIN32__
+			      text_color_set(DW_COLOR_ERROR);
+			      dw_printf ("Config file line %d: %s with GPIO is only available on Linux.\n", ps.line, itname);
+		#else
+		*/
+		t = split("", false)
+		if t == "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file line %d: Missing GPIO number for %s.\n", ps.line, itname)
+
+			return true
+		}
+
+		var gpio, _ = strconv.Atoi(t)
+		if gpio < 0 {
+			ps.audio.achan[ps.channel].ictrl[ICTYPE_TXINH].in_gpio_num = -1 * gpio
+			ps.audio.achan[ps.channel].ictrl[ICTYPE_TXINH].invert = true
+		} else {
+			ps.audio.achan[ps.channel].ictrl[ICTYPE_TXINH].in_gpio_num = gpio
+			ps.audio.achan[ps.channel].ictrl[ICTYPE_TXINH].invert = false
+		}
+
+		ps.audio.achan[ps.channel].ictrl[ICTYPE_TXINH].method = PTT_METHOD_GPIO
+		// #endif
+	}
+	return false
+}
+
+// handleDWAIT handles the DWAIT keyword.
+func handleDWAIT(ps *parseState) bool {
+	/*
+	 * DWAIT n		- Extra delay for receiver squelch. n = 10 mS units.
+	 *
+	 * Why did I do this?  Just add more to TXDELAY.
+	 * Now undocumented in User Guide.  Might disappear someday.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: DWAIT can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing delay time for DWAIT command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 0 && n <= 255 {
+		ps.audio.achan[ps.channel].dwait = n
+	} else {
+		ps.audio.achan[ps.channel].dwait = DEFAULT_DWAIT
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid delay time for DWAIT. Using %d.\n",
+			ps.line, ps.audio.achan[ps.channel].dwait)
+	}
+	return false
+}
+
+// handleSLOTTIME handles the SLOTTIME keyword.
+func handleSLOTTIME(ps *parseState) bool {
+	/*
+	 * SLOTTIME n		- For non-digipeat transmit delay timing. n = 10 mS units.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: SLOTTIME can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing delay time for SLOTTIME command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 5 && n < 50 {
+		// 0 = User has no clue.  This would be no delay.
+		// 10 = Default.
+		// 50 = Half second.  User might think it is mSec and use 100.
+		ps.audio.achan[ps.channel].slottime = n
+	} else {
+		ps.audio.achan[ps.channel].slottime = DEFAULT_SLOTTIME
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid delay time for persist algorithm. Using default %d.\n",
+			ps.line, ps.audio.achan[ps.channel].slottime)
+		dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
+		dw_printf("section, to understand what this means.\n")
+		dw_printf("Why don't you just use the default?\n")
+	}
+	return false
+}
+
+// handlePERSIST handles the PERSIST keyword.
+func handlePERSIST(ps *parseState) bool {
+	/*
+	 * PERSIST 		- For non-digipeat transmit delay timing.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: PERSIST can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing probability for PERSIST command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 5 && n <= 250 {
+		ps.audio.achan[ps.channel].persist = n
+	} else {
+		ps.audio.achan[ps.channel].persist = DEFAULT_PERSIST
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid probability for persist algorithm. Using default %d.\n",
+			ps.line, ps.audio.achan[ps.channel].persist)
+		dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
+		dw_printf("section, to understand what this means.\n")
+		dw_printf("Why don't you just use the default?\n")
+	}
+	return false
+}
+
+// handleTXDELAY handles the TXDELAY keyword.
+func handleTXDELAY(ps *parseState) bool {
+	/*
+	 * TXDELAY n		- For transmit delay timing. n = 10 mS units.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TXDELAY can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing time for TXDELAY command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 0 && n <= 255 {
+		text_color_set(DW_COLOR_ERROR)
+
+		if n < 10 {
+			dw_printf("Line %d: Setting TXDELAY this small is a REALLY BAD idea if you want other stations to hear you.\n",
+				ps.line)
+			dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
+			dw_printf("section, to understand what this means.\n")
+			dw_printf("Why don't you just use the default rather than reducing reliability?\n")
+		} else if n >= 100 {
+			dw_printf("Line %d: Keeping with tradition, going back to the 1980s, TXDELAY is in 10 millisecond units.\n",
+				ps.line)
+			dw_printf("Line %d: The value %d would be %.3f seconds which seems rather excessive.  Are you sure you want that?\n",
+				ps.line, n, float64(n)*10./1000.)
+			dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
+			dw_printf("section, to understand what this means.\n")
+			dw_printf("Why don't you just use the default?\n")
+		}
+
+		ps.audio.achan[ps.channel].txdelay = n
+	} else {
+		ps.audio.achan[ps.channel].txdelay = DEFAULT_TXDELAY
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid time for transmit delay. Using %d.\n",
+			ps.line, ps.audio.achan[ps.channel].txdelay)
+	}
+	return false
+}
+
+// handleTXTAIL handles the TXTAIL keyword.
+func handleTXTAIL(ps *parseState) bool {
+	/*
+	 * TXTAIL n		- For transmit timing. n = 10 mS units.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TXTAIL can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing time for TXTAIL command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 0 && n <= 255 {
+		if n < 5 {
+			dw_printf("Line %d: Setting TXTAIL that small is a REALLY BAD idea if you want other stations to hear you.\n",
+				ps.line)
+			dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
+			dw_printf("section, to understand what this means.\n")
+			dw_printf("Why don't you just use the default rather than reducing reliability?\n")
+		} else if n >= 50 {
+			dw_printf("Line %d: Keeping with tradition, going back to the 1980s, TXTAIL is in 10 millisecond units.\n",
+				ps.line)
+			dw_printf("Line %d: The value %d would be %.3f seconds which seems rather excessive.  Are you sure you want that?\n",
+				ps.line, n, float64(n)*10./1000.)
+			dw_printf("Read the Dire Wolf User Guide, \"Radio Channel - Transmit Timing\"\n")
+			dw_printf("section, to understand what this means.\n")
+			dw_printf("Why don't you just use the default?\n")
+		}
+
+		ps.audio.achan[ps.channel].txtail = n
+	} else {
+		ps.audio.achan[ps.channel].txtail = DEFAULT_TXTAIL
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid time for transmit timing. Using %d.\n",
+			ps.line, ps.audio.achan[ps.channel].txtail)
+	}
+	return false
+}
+
+// handleFULLDUP handles the FULLDUP keyword.
+func handleFULLDUP(ps *parseState) bool {
+	/*
+	 * FULLDUP  {on|off} 		- Full Duplex
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: FULLDUP can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing parameter for FULLDUP command.  Expecting ON or OFF.\n", ps.line)
+
+		return true
+	}
+
+	if strings.EqualFold(t, "ON") {
+		ps.audio.achan[ps.channel].fulldup = true
+	} else if strings.EqualFold(t, "OFF") {
+		ps.audio.achan[ps.channel].fulldup = false
+	} else {
+		ps.audio.achan[ps.channel].fulldup = false
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Expected ON or OFF for FULLDUP.\n", ps.line)
+	}
+	return false
+}
+
+// handleSPEECH handles the SPEECH keyword.
+func handleSPEECH(ps *parseState) bool {
+	/*
+	 * SPEECH  script
+	 *
+	 * Specify script for text-to-speech function.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: SPEECH can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing script for Text-to-Speech function.\n", ps.line)
+
+		return true
+	}
+
+	/* See if we can run it. */
+
+	/*
+	   TODO KG Do we *actually* want to do this...? If so, let's do it when we've ported this to Go...
+
+	   	 if (xmit_speak_it(t, -1, " ") == 0) {
+	   	   if (strlcpy (ps.audio.tts_script, t, sizeof(ps.audio.tts_script)) >= sizeof(ps.audio.tts_script)) {
+	   	     text_color_set(DW_COLOR_ERROR);
+	   	     dw_printf ("Line %d: Script for text-to-speech function is too long.\n", ps.line);
+	   	   }
+	   	 } else {
+	   	   text_color_set(DW_COLOR_ERROR);
+	   	   dw_printf ("Line %d: Error trying to run Text-to-Speech function.\n", ps.line);
+	   	   continue;
+	   	}
+	*/
+	return false
+}
+
+// handleFX25TX handles the FX25TX keyword.
+func handleFX25TX(ps *parseState) bool {
+	/*
+	 * FX25TX n		- Enable FX.25 transmission.  Default off.
+	 *				0 = off, 1 = auto mode, others are suggestions for testing
+	 *				or special cases.  16, 32, 64 is number of parity bytes to add.
+	 *				Also set by "-X n" command line option.
+	 *				V1.7 changed from global to per-channel setting.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: FX25TX can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing FEC mode for FX25TX command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 0 && n < 200 {
+		ps.audio.achan[ps.channel].fx25_strength = n
+		ps.audio.achan[ps.channel].layer2_xmit = LAYER2_FX25
+	} else {
+		ps.audio.achan[ps.channel].fx25_strength = 1
+		ps.audio.achan[ps.channel].layer2_xmit = LAYER2_FX25
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Unreasonable value for FX.25 transmission mode. Using %d.\n",
+			ps.line, ps.audio.achan[ps.channel].fx25_strength)
+	}
+	return false
+}
+
+// handleFX25AUTO handles the FX25AUTO keyword.
+func handleFX25AUTO(ps *parseState) bool {
+	/*
+	 * FX25AUTO n		- Enable Automatic use of FX.25 for connected mode.  *** Not Implemented ***
+	 *				Automatically enable, for that session only, when an identical
+	 *				frame is sent more than this number of times.
+	 *				Default 5 based on half of default RETRY.
+	 *				0 to disable feature.
+	 *				Current a global setting.  Could be per channel someday.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: FX25AUTO can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing count for FX25AUTO command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 0 && n < 20 {
+		ps.audio.fx25_auto_enable = n
+	} else {
+		ps.audio.fx25_auto_enable = AX25_N2_RETRY_DEFAULT / 2
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Unreasonable count for connected mode automatic FX.25. Using %d.\n",
+			ps.line, ps.audio.fx25_auto_enable)
+	}
+	return false
+}
+
+// handleIL2PTX handles the IL2PTX keyword.
+func handleIL2PTX(ps *parseState) bool {
+	/*
+	 * IL2PTX  [ + - ] [ 0 1 ]	- Enable IL2P transmission.  Default off.
+	 *				"+" means normal polarity. Redundant since it is the default.
+	 *					(command line -I for first channel)
+	 *				"-" means inverted polarity. Do not use for 1200 bps.
+	 *					(command line -i for first channel)
+	 *				"0" means weak FEC.  Not recommended.
+	 *				"1" means stronger FEC.  "Max FEC."  Default if not specified.
+	 */
+	if ps.channel < 0 || ps.channel >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: IL2PTX can only be used with radio channel 0 - %d.\n", ps.line, MAX_RADIO_CHANS-1)
+
+		return true
+	}
+
+	ps.audio.achan[ps.channel].layer2_xmit = LAYER2_IL2P
+	ps.audio.achan[ps.channel].il2p_max_fec = 1
+	ps.audio.achan[ps.channel].il2p_invert_polarity = 0
+
+	for {
+		var t = split("", false)
+		if t == "" {
+			break
+		}
+
+		for _, c := range t {
+			switch c {
+			case '+':
+				ps.audio.achan[ps.channel].il2p_invert_polarity = 0
+			case '-':
+				ps.audio.achan[ps.channel].il2p_invert_polarity = 1
+			case '0':
+				ps.audio.achan[ps.channel].il2p_max_fec = 0
+			case '1':
+				ps.audio.achan[ps.channel].il2p_max_fec = 1
+			default:
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Invalid parameter '%c' for IL2PTX command.\n", ps.line, c)
+
+				continue
+			}
+		}
+	}
+	return false
+}
+
+// handleDIGIPEAT handles the DIGIPEAT keyword.
+func handleDIGIPEAT(ps *parseState) bool {
+	/*
+	 * ==================== APRS Digipeater parameters ====================
+	 */
+
+	/*
+	 * DIGIPEAT  from-chan  to-chan  alias-pattern  wide-pattern  [ OFF|DROP|MARK|TRACE | ATGP=alias ]
+	 *
+	 * ATGP is an ugly hack for the specific need of ATGP which needs more that 8 digipeaters.
+	 * DO NOT put this in the User Guide.  On a need to know basis.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing FROM-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	if !alldigits(t) {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: '%s' is not allowed for FROM-channel.  It must be a number.\n",
+			ps.line, t)
+
+		return true
+	}
+
+	var from_chan, _ = strconv.Atoi(t)
+	if from_chan < 0 || from_chan >= MAX_TOTAL_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: FROM-channel must be in range of 0 to %d on line %d.\n",
+			MAX_TOTAL_CHANS-1, ps.line)
+
+		return true
+	}
+
+	// Channels specified must be radio channels or network TNCs.
+
+	if ps.audio.chan_medium[from_chan] != MEDIUM_RADIO &&
+		ps.audio.chan_medium[from_chan] != MEDIUM_NETTNC {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
+			ps.line, from_chan)
+
+		return true
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing TO-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	if !alldigits(t) {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: '%s' is not allowed for TO-channel.  It must be a number.\n",
+			ps.line, t)
+
+		return true
+	}
+
+	var to_chan, _ = strconv.Atoi(t)
+	if to_chan < 0 || to_chan >= MAX_TOTAL_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: TO-channel must be in range of 0 to %d on line %d.\n",
+			MAX_TOTAL_CHANS-1, ps.line)
+
+		return true
+	}
+
+	if ps.audio.chan_medium[to_chan] != MEDIUM_RADIO &&
+		ps.audio.chan_medium[to_chan] != MEDIUM_NETTNC {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
+			ps.line, to_chan)
+
+		return true
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing alias pattern on line %d.\n", ps.line)
+
+		return true
+	}
+
+	var r, err = regexp.Compile(t)
+	if err != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Invalid alias matching pattern on line %d:\n%s\n", ps.line, err)
+
+		return true
+	}
+
+	ps.digi.alias[from_chan][to_chan] = r
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing wide pattern on line %d.\n", ps.line)
+
+		return true
+	}
+
+	r, err = regexp.Compile(t)
+	if err != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Invalid wide matching pattern on line %d:\n%s\n", ps.line, err)
+
+		return true
+	}
+
+	ps.digi.wide[from_chan][to_chan] = r
+
+	ps.digi.enabled[from_chan][to_chan] = true
+	ps.digi.preempt[from_chan][to_chan] = PREEMPT_OFF
+
+	t = split("", false)
+	if t != "" {
+		if strings.EqualFold(t, "OFF") {
+			ps.digi.preempt[from_chan][to_chan] = PREEMPT_OFF
+			t = split("", false)
+		} else if strings.EqualFold(t, "DROP") {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: Preemptive digipeating DROP option is discouraged.\n", ps.line)
+			dw_printf("It can create a via path which is misleading about the actual path taken.\n")
+			dw_printf("PREEMPT is the best choice for this feature.\n")
+
+			ps.digi.preempt[from_chan][to_chan] = PREEMPT_DROP
+			t = split("", false)
+		} else if strings.EqualFold(t, "MARK") {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: Preemptive digipeating MARK option is discouraged.\n", ps.line)
+			dw_printf("It can create a via path which is misleading about the actual path taken.\n")
+			dw_printf("PREEMPT is the best choice for this feature.\n")
+
+			ps.digi.preempt[from_chan][to_chan] = PREEMPT_MARK
+			t = split("", false)
+		} else if (strings.EqualFold(t, "TRACE")) || (strings.HasPrefix(strings.ToUpper(t), "PREEMPT")) {
+			ps.digi.preempt[from_chan][to_chan] = PREEMPT_TRACE
+			t = split("", false)
+		} else if strings.HasPrefix(strings.ToUpper(t), "ATGP=") {
+			ps.digi.atgp[from_chan][to_chan] = t[5:]
+			t = split("", false)
+		}
+	}
+
+	if t != "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: Found \"%s\" where end of line was expected.\n", ps.line, t)
+	}
+	return false
+}
+
+// handleDEDUPE handles the DEDUPE keyword.
+func handleDEDUPE(ps *parseState) bool {
+	/*
+	 * DEDUPE 		- Time to suppress digipeating of duplicate APRS packets.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing time for DEDUPE command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 0 && n < 600 {
+		ps.digi.dedupe_time = n
+	} else {
+		ps.digi.dedupe_time = DEFAULT_DEDUPE
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Unreasonable value for dedupe time. Using %d.\n",
+			ps.line, ps.digi.dedupe_time)
+	}
+	return false
+}
+
+// handleREGEN handles the REGEN keyword.
+func handleREGEN(ps *parseState) bool {
+	/*
+	 * REGEN 		- Signal regeneration.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing FROM-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	if !alldigits(t) {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: '%s' is not allowed for FROM-channel.  It must be a number.\n",
+			ps.line, t)
+
+		return true
+	}
+
+	var from_chan, _ = strconv.Atoi(t)
+	if from_chan < 0 || from_chan >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: FROM-channel must be in range of 0 to %d on line %d.\n",
+			MAX_RADIO_CHANS-1, ps.line)
+
+		return true
+	}
+
+	// Only radio channels are valid for regenerate.
+
+	if ps.audio.chan_medium[from_chan] != MEDIUM_RADIO {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
+			ps.line, from_chan)
+
+		return true
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing TO-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	if !alldigits(t) {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: '%s' is not allowed for TO-channel.  It must be a number.\n",
+			ps.line, t)
+
+		return true
+	}
+
+	var to_chan, _ = strconv.Atoi(t)
+	if to_chan < 0 || to_chan >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: TO-channel must be in range of 0 to %d on line %d.\n",
+			MAX_RADIO_CHANS-1, ps.line)
+
+		return true
+	}
+
+	if ps.audio.chan_medium[to_chan] != MEDIUM_RADIO {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
+			ps.line, to_chan)
+
+		return true
+	}
+
+	ps.digi.regen[from_chan][to_chan] = true
+	return false
+}
+
+// handleCDIGIPEAT handles the CDIGIPEAT keyword.
+func handleCDIGIPEAT(ps *parseState) bool {
+	/*
+	 * ==================== Connected Digipeater parameters ====================
+	 */
+
+	/*
+	 * CDIGIPEAT  from-chan  to-chan [ alias-pattern ]
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing FROM-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	if !alldigits(t) {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: '%s' is not allowed for FROM-channel.  It must be a number.\n",
+			ps.line, t)
+
+		return true
+	}
+
+	var from_chan, _ = strconv.Atoi(t)
+	if from_chan < 0 || from_chan >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: FROM-channel must be in range of 0 to %d on line %d.\n",
+			MAX_RADIO_CHANS-1, ps.line)
+
+		return true
+	}
+
+	// For connected mode Link layer, only internal modems should be allowed.
+	// A network TNC probably would not provide information about channel status.
+	// There is discussion about this in the document called
+	// Why-is-9600-only-twice-as-fast-as-1200.pdf
+
+	if ps.audio.chan_medium[from_chan] != MEDIUM_RADIO {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
+			ps.line, from_chan)
+		dw_printf("Only internal modems can be used for connected mode packet.\n")
+
+		return true
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing TO-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	if !alldigits(t) {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: '%s' is not allowed for TO-channel.  It must be a number.\n",
+			ps.line, t)
+
+		return true
+	}
+
+	var to_chan, _ = strconv.Atoi(t)
+	if to_chan < 0 || to_chan >= MAX_RADIO_CHANS {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: TO-channel must be in range of 0 to %d on line %d.\n",
+			MAX_RADIO_CHANS-1, ps.line)
+
+		return true
+	}
+
+	if ps.audio.chan_medium[to_chan] != MEDIUM_RADIO {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
+			ps.line, to_chan)
+		dw_printf("Only internal modems can be used for connected mode packet.\n")
+
+		return true
+	}
+
+	t = split("", false)
+	if t != "" {
+		var r, err = regexp.Compile(t)
+		if err == nil {
+			ps.cdigi.alias[from_chan][to_chan] = r
+			ps.cdigi.has_alias[from_chan][to_chan] = true
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Invalid alias matching pattern on line %d:\n%s\n", ps.line, err)
+
+			return true
+		}
+
+		t = split("", false)
+	}
+
+	ps.cdigi.enabled[from_chan][to_chan] = true
+
+	if t != "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: Found \"%s\" where end of line was expected.\n", ps.line, t)
+	}
+	return false
+}
+
+// handleFILTER handles the FILTER keyword.
+func handleFILTER(ps *parseState) bool {
+	/*
+	 * ==================== Packet Filtering for APRS digipeater or IGate ====================
+	 */
+
+	/*
+	 * FILTER  from-chan  to-chan  filter_specification_expression
+	 * FILTER  from-chan  IG       filter_specification_expression
+	 * FILTER  IG         to-chan  filter_specification_expression
+	 *
+	 *
+	 * Note that we have three different config file filter commands:
+	 *
+	 *	FILTER		- Originally for APRS digipeating but later enhanced
+	 *			  to include IGate client side.  Maybe it should be
+	 *			  renamed AFILTER to make it clearer after adding CFILTER.
+	 *
+	 *			  Both internal modem and NET TNC channels allowed here.
+	 *			  "IG" should be used for the IGate, NOT a virtual channel
+	 *			  assigned to it.
+	 *
+	 *	CFILTER		- Similar for connected moded digipeater.
+	 *
+	 *			  Only internal modems can be used because they provide
+	 *			  information about radio channel status.
+	 *			  A remote network TNC might not provide the necessary
+	 *			  status for correct operation.
+	 *			  There is discussion about this in the document called
+	 *			  Why-is-9600-only-twice-as-fast-as-1200.pdf
+	 *
+	 *	IGFILTER	- APRS-IS (IGate) server side - completely different.
+	 *			  I'm not happy with this name because IG sounds like IGate
+	 *			  which is really the client side.  More comments later.
+	 *			  Maybe it should be called subscribe or something like that
+	 *			  because the subscriptions are cumulative.
+	 */
+	var from_chan int
+	var to_chan int
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing FROM-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	if t[0] == 'i' || t[0] == 'I' {
+		from_chan = MAX_TOTAL_CHANS
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: FILTER IG ... on line %d.\n", ps.line)
+		dw_printf("Warning! Don't mess with IS>RF filtering unless you are an expert and have an unusual situation.\n")
+		dw_printf("Warning! The default is fine for nearly all situations.\n")
+		dw_printf("Warning! Be sure to read carefully and understand  \"Successful-APRS-Gateway-Operation.pdf\" .\n")
+		dw_printf("Warning! If you insist, be sure to add \" | i/180 \" so you don't break messaging.\n")
+	} else {
+		var fromChanErr error
+
+		from_chan, fromChanErr = strconv.Atoi(t)
+		if from_chan < 0 || from_chan >= MAX_TOTAL_CHANS || fromChanErr != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Filter FROM-channel must be in range of 0 to %d or \"IG\" on line %d.\n",
+				MAX_TOTAL_CHANS-1, ps.line)
+
+			return true
+		}
+
+		if ps.audio.chan_medium[from_chan] != MEDIUM_RADIO &&
+			ps.audio.chan_medium[from_chan] != MEDIUM_NETTNC {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
+				ps.line, from_chan)
+
+			return true
+		}
+
+		if ps.audio.chan_medium[from_chan] == MEDIUM_IGATE {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: Use 'IG' rather than %d for FROM-channel.\n",
+				ps.line, from_chan)
+
+			return true
+		}
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing TO-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	if t[0] == 'i' || t[0] == 'I' {
+		to_chan = MAX_TOTAL_CHANS
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: FILTER ... IG ... on line %d.\n", ps.line)
+		dw_printf("Warning! Don't mess with RF>IS filtering unless you are an expert and have an unusual situation.\n")
+		dw_printf("Warning! Expected behavior is for everything to go from RF to IS.\n")
+		dw_printf("Warning! The default is fine for nearly all situations.\n")
+		dw_printf("Warning! Be sure to read carefully and understand  \"Successful-APRS-Gateway-Operation.pdf\" .\n")
+	} else {
+		var toChanErr error
+
+		to_chan, toChanErr = strconv.Atoi(t)
+		if to_chan < 0 || to_chan >= MAX_TOTAL_CHANS || toChanErr != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Filter TO-channel must be in range of 0 to %d or \"IG\" on line %d.\n",
+				MAX_TOTAL_CHANS-1, ps.line)
+
+			return true
+		}
+
+		if ps.audio.chan_medium[to_chan] != MEDIUM_RADIO &&
+			ps.audio.chan_medium[to_chan] != MEDIUM_NETTNC {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
+				ps.line, to_chan)
+
+			return true
+		}
+
+		if ps.audio.chan_medium[to_chan] == MEDIUM_IGATE {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: Use 'IG' rather than %d for TO-channel.\n",
+				ps.line, to_chan)
+
+			return true
+		}
+	}
+
+	t = split("", true) /* Take rest of ps.line including spaces. */
+
+	if t == "" {
+		t = " " /* Empty means permit nothing. */
+	}
+
+	if ps.digi.filter_str[from_chan][to_chan] != "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: Replacing previous filter for same from/to pair:\n        %s\n", ps.line, ps.digi.filter_str[from_chan][to_chan])
+		ps.digi.filter_str[from_chan][to_chan] = ""
+	}
+
+	ps.digi.filter_str[from_chan][to_chan] = t
+
+	// TODO:  Do a test run to see errors now instead of waiting.
+	return false
+}
+
+// handleCFILTER handles the CFILTER keyword.
+func handleCFILTER(ps *parseState) bool {
+	/*
+	 * ==================== Packet Filtering for connected digipeater ====================
+	 */
+
+	/*
+	 * CFILTER  from-chan  to-chan  filter_specification_expression
+	 *
+	 * Why did I put this here?
+	 * What would be a useful use case?  Perhaps block by source or destination?
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing FROM-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	var from_chan, fromChanErr = strconv.Atoi(t)
+	if from_chan < 0 || from_chan >= MAX_RADIO_CHANS || fromChanErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Filter FROM-channel must be in range of 0 to %d on line %d.\n",
+			MAX_RADIO_CHANS-1, ps.line)
+
+		return true
+	}
+
+	// DO NOT allow a network TNC here.
+	// Must be internal modem to have necessary knowledge about channel status.
+
+	if ps.audio.chan_medium[from_chan] != MEDIUM_RADIO {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: FROM-channel %d is not valid.\n",
+			ps.line, from_chan)
+
+		return true
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing TO-channel on line %d.\n", ps.line)
+
+		return true
+	}
+
+	var to_chan, toChanErr = strconv.Atoi(t)
+	if to_chan < 0 || to_chan >= MAX_RADIO_CHANS || toChanErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Filter TO-channel must be in range of 0 to %d on line %d.\n",
+			MAX_RADIO_CHANS-1, ps.line)
+
+		return true
+	}
+
+	if ps.audio.chan_medium[to_chan] != MEDIUM_RADIO {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: TO-channel %d is not valid.\n",
+			ps.line, to_chan)
+
+		return true
+	}
+
+	t = split("", true) /* Take rest of ps.line including spaces. */
+
+	if t == "" {
+		t = " " /* Empty means permit nothing. */
+	}
+
+	ps.cdigi.cfilter_str[from_chan][to_chan] = t
+
+	// TODO1.2:  Do a test run to see errors now instead of waiting.
+	return false
+}
+
+// handleTTCORRAL handles the TTCORRAL keyword.
+func handleTTCORRAL(ps *parseState) bool {
+	/*
+	 * ==================== APRStt gateway ====================
+	 */
+
+	/*
+	 * TTCORRAL 		- How to handle unknown positions
+	 *
+	 * TTCORRAL  latitude  longitude  offset-or-ambiguity
+	 */
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing latitude for TTCORRAL command.\n", ps.line)
+		return true
+	}
+	ps.tt.corral_lat = parse_ll(t, LAT, ps.line)
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing longitude for TTCORRAL command.\n", ps.line)
+		return true
+	}
+	ps.tt.corral_lon = parse_ll(t, LON, ps.line)
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing longitude for TTCORRAL command.\n", ps.line)
+		return true
+	}
+	ps.tt.corral_offset = parse_ll(t, LAT, ps.line)
+	if ps.tt.corral_offset == 1 ||
+		ps.tt.corral_offset == 2 ||
+		ps.tt.corral_offset == 3 {
+		ps.tt.corral_ambiguity = int(ps.tt.corral_offset)
+		ps.tt.corral_offset = 0
+	}
+
+	// dw_printf ("DEBUG: corral %f %f %f %d\n", p_tt_config.corral_lat,
+	//
+	//	p_tt_config.corral_lon, p_tt_config.corral_offset, p_tt_config.corral_ambiguity);
+	return false
+}
+
+// handleTTPOINT handles the TTPOINT keyword.
+func handleTTPOINT(ps *parseState) bool {
+	/*
+	 * TTPOINT 		- Define a point represented by touch tone sequence.
+	 *
+	 * TTPOINT   pattern  latitude  longitude
+	 */
+
+	var tl = new(ttloc_s)
+	tl.ttlocType = TTLOC_POINT
+
+	// Pattern: B and digits
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTPOINT command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	if t[0] != 'B' {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTPOINT pattern must begin with upper case 'B'.\n", ps.line)
+	}
+
+	for _, j := range t[1:] {
+		if !unicode.IsDigit(j) {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTPOINT pattern must be B and digits only.\n", ps.line)
+		}
+	}
+
+	// Latitude
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing latitude for TTPOINT command.\n", ps.line)
+		return true
+	}
+	tl.point.lat = parse_ll(t, LAT, ps.line)
+
+	// Longitude
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing longitude for TTPOINT command.\n", ps.line)
+		return true
+	}
+	tl.point.lon = parse_ll(t, LON, ps.line)
+
+	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	return false
+}
+
+// handleTTVECTOR handles the TTVECTOR keyword.
+func handleTTVECTOR(ps *parseState) bool {
+	/*
+	 * TTVECTOR 		- Touch tone location with bearing and distance.
+	 *
+	 * TTVECTOR   pattern  latitude  longitude  scale  unit
+	 */
+
+	var tl = new(ttloc_s)
+	tl.ttlocType = TTLOC_VECTOR
+	tl.pattern = ""
+	tl.vector.lat = 0
+	tl.vector.lon = 0
+	tl.vector.scale = 1
+
+	// Pattern: B5bbbd...
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTVECTOR command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	if t[0] != 'B' {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTVECTOR pattern must begin with upper case 'B'.\n", ps.line)
+	}
+	if !strings.HasPrefix(t[1:], "5bbb") {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTVECTOR pattern would normally contain \"5bbb\".\n", ps.line)
+	}
+	for j := 1; j < len(t); j++ {
+		if !unicode.IsDigit(rune(t[j])) && t[j] != 'b' && t[j] != 'd' {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTVECTOR pattern must contain only B, digits, b, and d.\n", ps.line)
+		}
+	}
+
+	// Latitude
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing latitude for TTVECTOR command.\n", ps.line)
+		return true
+	}
+	tl.vector.lat = parse_ll(t, LAT, ps.line)
+
+	// Longitude
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing longitude for TTVECTOR command.\n", ps.line)
+		return true
+	}
+	tl.vector.lon = parse_ll(t, LON, ps.line)
+
+	// Longitude
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing scale for TTVECTOR command.\n", ps.line)
+		return true
+	}
+	var scale, _ = strconv.ParseFloat(t, 64)
+
+	// Unit.
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing unit for TTVECTOR command.\n", ps.line)
+		return true
+	}
+
+	var meters float64
+	for j := 0; j < len(units) && meters == 0; j++ {
+		if strings.EqualFold(units[j].name, t) {
+			meters = units[j].meters
+		}
+	}
+	if meters == 0 {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Unrecognized unit for TTVECTOR command.  Using miles.\n", ps.line)
+		meters = 1609.344
+	}
+	tl.vector.scale = scale * meters
+
+	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	return false
+}
+
+// handleTTGRID handles the TTGRID keyword.
+func handleTTGRID(ps *parseState) bool {
+	/*
+	 * TTGRID 		- Define a grid for touch tone locations.
+	 *
+	 * TTGRID   pattern  min-latitude  min-longitude  max-latitude  max-longitude
+	 */
+
+	var tl = new(ttloc_s)
+	tl.ttlocType = TTLOC_GRID
+
+	// Pattern: B [digit] x... y...
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTGRID command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	if t[0] != 'B' {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTGRID pattern must begin with upper case 'B'.\n", ps.line)
+	}
+	for j := 1; j < len(t); j++ {
+		if !unicode.IsDigit(rune(t[j])) && t[j] != 'x' && t[j] != 'y' {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTGRID pattern must be B, optional digit, xxx, yyy.\n", ps.line)
+		}
+	}
+
+	// Minimum Latitude - all zeros in received data
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing minimum latitude for TTGRID command.\n", ps.line)
+		return true
+	}
+	tl.grid.lat0 = parse_ll(t, LAT, ps.line)
+
+	// Minimum Longitude - all zeros in received data
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing minimum longitude for TTGRID command.\n", ps.line)
+		return true
+	}
+	tl.grid.lon0 = parse_ll(t, LON, ps.line)
+
+	// Maximum Latitude - all nines in received data
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing maximum latitude for TTGRID command.\n", ps.line)
+		return true
+	}
+	tl.grid.lat9 = parse_ll(t, LAT, ps.line)
+
+	// Maximum Longitude - all nines in received data
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing maximum longitude for TTGRID command.\n", ps.line)
+		return true
+	}
+	tl.grid.lon9 = parse_ll(t, LON, ps.line)
+
+	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	return false
+}
+
+// handleTTUTM handles the TTUTM keyword.
+func handleTTUTM(ps *parseState) bool {
+	/*
+	 * TTUTM 		- Specify UTM zone for touch tone locations.
+	 *
+	 * TTUTM   pattern  zone [ scale [ x-offset y-offset ] ]
+	 */
+
+	var tl = new(ttloc_s)
+	tl.ttlocType = TTLOC_UTM
+	tl.utm.scale = 1
+
+	// Pattern: B [digit] x... y...
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTUTM command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	if t[0] != 'B' {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTUTM pattern must begin with upper case 'B'.\n", ps.line)
+		return true
+	}
+	for j := 1; j < len(t); j++ {
+		if !unicode.IsDigit(rune(t[j])) && t[j] != 'x' && t[j] != 'y' {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTUTM pattern must be B, optional digit, xxx, yyy.\n", ps.line)
+			// Bail out somehow.  continue would match inner for.
+		}
+	}
+
+	// Zone 1 - 60 and optional latitudinal letter.
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing zone for TTUTM command.\n", ps.line)
+		return true
+	}
+
+	tl.utm.latband, tl.utm.hemi, tl.utm.lzone = parse_utm_zone(t)
+
+	// Optional scale.
+
+	t = split("", false)
+	if t != "" {
+
+		tl.utm.scale, _ = strconv.ParseFloat(t, 64)
+
+		// Optional x offset.
+
+		t = split("", false)
+		if t != "" {
+
+			tl.utm.x_offset, _ = strconv.ParseFloat(t, 64)
+
+			// Optional y offset.
+
+			t = split("", false)
+			if t != "" {
+
+				tl.utm.y_offset, _ = strconv.ParseFloat(t, 64)
+			}
+		}
+	}
+
+	// Practice run to see if conversion might fail later with actual location.
+
+	var utm = coordconv.UTMCoord{
+		Zone:       tl.utm.lzone,
+		Hemisphere: HemisphereRuneToCoordconvHemisphere(tl.utm.hemi),
+		Easting:    tl.utm.x_offset + 5*tl.utm.scale,
+		Northing:   tl.utm.y_offset + 5*tl.utm.scale,
+	}
+	var _, geoErr = coordconv.DefaultUTMConverter.ConvertToGeodetic(utm)
+
+	if geoErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid UTM location: \n%s\n", ps.line, geoErr)
+		return true
+	}
+
+	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	return false
+}
+
+// handleTTUSNGMGRS handles the TTUSNGMGRS keyword.
+func handleTTUSNGMGRS(ps *parseState) bool {
+	/*
+	 * TTUSNG, TTMGRS 		- Specify zone/square for touch tone locations.
+	 *
+	 * TTUSNG   pattern  zone_square
+	 * TTMGRS   pattern  zone_square
+	 */
+
+	var tl = new(ttloc_s)
+
+	// TODO1.2: in progress...
+	if strings.EqualFold(ps.keyword, "TTMGRS") {
+		tl.ttlocType = TTLOC_MGRS
+	} else {
+		tl.ttlocType = TTLOC_USNG
+	}
+
+	// Pattern: B [digit] x... y...
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTUSNG/TTMGRS command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	if t[0] != 'B' {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTUSNG/TTMGRS pattern must begin with upper case 'B'.\n", ps.line)
+		return true
+	}
+	var num_x = 0
+	var num_y = 0
+	for j := 1; j < len(t); j++ {
+		if !unicode.IsDigit(rune(t[j])) && t[j] != 'x' && t[j] != 'y' {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTUSNG/TTMGRS pattern must be B, optional digit, xxx, yyy.\n", ps.line)
+			// Bail out somehow.  continue would match inner for.
+		}
+		if t[j] == 'x' {
+			num_x++
+		}
+		if t[j] == 'y' {
+			num_y++
+		}
+	}
+	if num_x < 1 || num_x > 5 || num_x != num_y {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTUSNG/TTMGRS must have 1 to 5 x and same number y.\n", ps.line)
+		return true
+	}
+
+	// Zone 1 - 60 and optional latitudinal letter.
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing zone & square for TTUSNG/TTMGRS command.\n", ps.line)
+		return true
+	}
+	tl.mgrs.zone = t
+
+	// Try converting it rather do our own error checking.
+
+	var _, convertErr = coordconv.DefaultMGRSConverter.ConvertToGeodetic(tl.mgrs.zone)
+	if convertErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid USNG/MGRS zone & square:  %s\n%s\n", ps.line, tl.mgrs.zone, convertErr)
+		return true
+	}
+
+	// Should be the end.
+
+	t = split("", false)
+	if t != "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Unexpected stuff at end ignored:  %s\n", ps.line, t)
+	}
+
+	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	return false
+}
+
+// handleTTMHEAD handles the TTMHEAD keyword.
+func handleTTMHEAD(ps *parseState) bool {
+	/*
+	 * TTMHEAD 		- Define pattern to be used for Maidenhead Locator.
+	 *
+	 * TTMHEAD   pattern   [ prefix ]
+	 *
+	 *			Pattern would be  B[0-9A-D]xxxx...
+	 *			Optional prefix is 10, 6, or 4 digits.
+	 *
+	 *			The total number of digts in both must be 4, 6, 10, or 12.
+	 */
+
+	// TODO1.3:  TTMHEAD needs testing.
+
+	var tl = new(ttloc_s)
+	tl.ttlocType = TTLOC_MHEAD
+
+	// Pattern: B, optional additional button, some number of xxxx... for matching
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTMHEAD command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	if t[0] != 'B' {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTMHEAD pattern must begin with upper case 'B'.\n", ps.line)
+		return true
+	}
+
+	// Optionally one of 0-9ABCD
+
+	var j int
+	if len(t) > 1 && (strings.ContainsRune("ABCD", rune(t[1])) || unicode.IsDigit(rune(t[1]))) {
+		j = 2
+	} else {
+		j = 1
+	}
+
+	var count_x = 0
+	var count_other = 0
+	for k := j; k < len(t); k++ {
+		if t[k] == 'x' {
+			count_x++
+		} else {
+			count_other++
+		}
+	}
+
+	if count_other != 0 {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTMHEAD must have only lower case x to match received data.\n", ps.line)
+		return true
+	}
+
+	// optional prefix
+
+	t = split("", false)
+	if t != "" {
+		tl.mhead.prefix = t
+
+		if !alldigits(t) || (len(t) != 4 && len(t) != 6 && len(t) != 10) {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTMHEAD prefix must be 4, 6, or 10 digits.\n", ps.line)
+			return true
+		}
+
+		var _, mhErrors = tt_mhead_to_text(t, false)
+		if mhErrors != 0 {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTMHEAD prefix not a valid DTMF sequence.\n", ps.line)
+			return true
+		}
+	}
+
+	var k = len(tl.mhead.prefix) + count_x
+
+	if k != 4 && k != 6 && k != 10 && k != 12 {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTMHEAD prefix and user data must have a total of 4, 6, 10, or 12 digits.\n", ps.line)
+		return true
+	}
+
+	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	return false
+}
+
+// handleTTSATSQ handles the TTSATSQ keyword.
+func handleTTSATSQ(ps *parseState) bool {
+	/*
+	 * TTSATSQ 		- Define pattern to be used for Satellite square.
+	 *
+	 * TTSATSQ   pattern
+	 *
+	 *			Pattern would be  B[0-9A-D]xxxx
+	 *
+	 *			Must have exactly 4 x.
+	 */
+
+	// TODO1.2:  TTSATSQ To be continued...
+
+	var tl = new(ttloc_s)
+	tl.ttlocType = TTLOC_SATSQ
+
+	// Pattern: B, optional additional button, exactly xxxx for matching
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTSATSQ command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	if t[0] != 'B' {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTSATSQ pattern must begin with upper case 'B'.\n", ps.line)
+		return true
+	}
+
+	// Optionally one of 0-9ABCD
+
+	var j int
+	if len(t) > 1 && (strings.ContainsRune("ABCD", rune(t[1])) || unicode.IsDigit(rune(t[1]))) {
+		j = 2
+	} else {
+		j = 1
+	}
+
+	if t[j:] != "xxxx" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTSATSQ pattern must end with exactly xxxx in lower case.\n", ps.line)
+		return true
+	}
+
+	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	return false
+}
+
+// handleTTAMBIG handles the TTAMBIG keyword.
+func handleTTAMBIG(ps *parseState) bool {
+	/*
+	 * TTAMBIG 		- Define pattern to be used for Object Location Ambiguity.
+	 *
+	 * TTAMBIG   pattern
+	 *
+	 *			Pattern would be  B[0-9A-D]x
+	 *
+	 *			Must have exactly one x.
+	 */
+
+	// TODO1.3:  TTAMBIG To be continued...
+
+	var tl = new(ttloc_s)
+	tl.ttlocType = TTLOC_AMBIG
+
+	// Pattern: B, optional additional button, exactly x for matching
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTAMBIG command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	if t[0] != 'B' {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTAMBIG pattern must begin with upper case 'B'.\n", ps.line)
+		return true
+	}
+
+	// Optionally one of 0-9ABCD
+
+	var j int
+	if len(t) > 1 && (strings.ContainsRune("ABCD", rune(t[1])) || unicode.IsDigit(rune(t[1]))) {
+		j = 2
+	} else {
+		j = 1
+	}
+
+	if t[j:] != "x" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: TTAMBIG pattern must end with exactly one x in lower case.\n", ps.line)
+		return true
+	}
+
+	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	return false
+}
+
+// handleTTMACRO handles the TTMACRO keyword.
+func handleTTMACRO(ps *parseState) bool {
+	/*
+	 * TTMACRO 		- Define compact message format with full expansion
+	 *
+	 * TTMACRO   pattern  definition
+	 *
+	 *		pattern can contain:
+	 *			0-9 which must match exactly.
+	 *				In version 1.2, also allow A,B,C,D for exact match.
+	 *			x, y, z which are used for matching of variable fields.
+	 *
+	 *		definition can contain:
+	 *			0-9, A, B, C, D, *, #, x, y, z.
+	 *			Not sure why # was included in there.
+	 *
+	 *	    new for version 1.3 - in progress
+	 *
+	 *			AA{objname}
+	 *			AB{symbol}
+	 *			AC{call}
+	 *
+	 *		These provide automatic conversion from plain text to the TT encoding.
+	 *
+	 */
+
+	var tl = new(ttloc_s)
+	tl.ttlocType = TTLOC_MACRO
+
+	// Pattern: Any combination of digits, x, y, and z.
+	// Also make note of which letters are used in pattern and definition.
+	// Version 1.2: also allow A,B,C,D in the pattern.
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing pattern for TTMACRO command.\n", ps.line)
+		return true
+	}
+	tl.pattern = t
+
+	var p_count [3]int
+	var tt_error = 0
+
+	for j := 0; j < len(t); j++ {
+		if !strings.ContainsRune("0123456789ABCDxyz", rune(t[j])) {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTMACRO pattern can contain only digits, A, B, C, D, and lower case x, y, or z.\n", ps.line)
+			tt_error++
+			break
+		}
+		// Count how many x, y, z in the pattern.
+		if t[j] >= 'x' && t[j] <= 'z' {
+			p_count[t[j]-'x']++
+		}
+	}
+
+	//text_color_set(DW_COLOR_DEBUG);
+	//dw_printf ("Line %d: TTMACRO pattern \"%s\" p_count = %d %d %d.\n", line, t, p_count[0], p_count[1], p_count[2]);
+
+	// Next we should find the definition.
+	// It can contain touch tone characters and lower case x, y, z for substitutions.
+
+	t = split("", true)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing definition for TTMACRO command.\n", ps.line)
+		tl.macro.definition = "" // Don't die on null pointer later.
+		return true
+	}
+
+	// Make a pass over the definition, looking for the xx{...} substitutions.
+	// These are done just once when reading the configuration file.
+
+	var tmp = t               // Chomp through this
+	var otemp strings.Builder // Result after any substitution
+
+	tmp = strings.TrimSpace(tmp)
+
+	for len(tmp) != 0 {
+
+		if strings.HasPrefix(tmp, "AC{") {
+			// Convert to fixed length 10 digit callsign.
+			tmp = tmp[3:]
+			var stemp strings.Builder
+			for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
+				stemp.WriteString(string(tmp[0]))
+				tmp = tmp[1:]
+			}
+			if len(tmp) > 0 && tmp[0] == '}' {
+				var ttemp, errs = tt_text_to_call10(stemp.String(), false)
+				if errs == 0 {
+					//text_color_set(DW_COLOR_DEBUG);
+					//dw_printf ("DEBUG Line %d: AC{%s} -> AC%s\n", line, stemp, ttemp);
+					otemp.WriteString("AC" + ttemp)
+				} else {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: AC{%s} could not be converted to tones for callsign.\n", ps.line, stemp.String())
+					tt_error++
+				}
+				tmp = tmp[1:]
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: AC{... is missing matching } in TTMACRO definition.\n", ps.line)
+				tt_error++
+			}
+		} else if strings.HasPrefix(tmp, "AA{") {
+
+			// Convert to object name.
+
+			tmp = tmp[3:]
+			var stemp string
+			for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
+				stemp += string(tmp[0])
+				tmp = tmp[1:]
+			}
+			if len(tmp) > 0 && tmp[0] == '}' {
+				if len(stemp) > 9 {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Object name %s has been truncated to 9 characters.\n", ps.line, stemp)
+					stemp = stemp[:9]
+				}
+				var ttemp, errs = tt_text_to_two_key(stemp, false)
+				if errs == 0 {
+					//text_color_set(DW_COLOR_DEBUG);
+					//dw_printf ("DEBUG Line %d: AA{%s} -> AA%s\n", line, stemp, ttemp);
+					otemp.WriteString("AA" + ttemp)
+				} else {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: AA{%s} could not be converted to tones for object name.\n", ps.line, stemp)
+					tt_error++
+				}
+				tmp = tmp[1:]
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: AA{... is missing matching } in TTMACRO definition.\n", ps.line)
+				tt_error++
+			}
+		} else if strings.HasPrefix(tmp, "AB{") {
+
+			// Attempt conversion from description to symbol code.
+
+			tmp = tmp[3:]
+			var stemp strings.Builder
+			for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
+				stemp.WriteString(string(tmp[0]))
+				tmp = tmp[1:]
+			}
+			if len(tmp) > 0 && tmp[0] == '}' {
+				// First try to find something matching the description.
+
+				var symtab, symbol, ok = aprsSymbolData.symbols_code_from_description(' ', stemp.String())
+
+				if !ok {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Couldn't convert \"%s\" to APRS symbol code.  Using default.\n", ps.line, stemp.String())
+					symtab = '\\' // Alternate
+					symbol = 'A'  // Box
+				}
+
+				// Convert symtab(overlay) & symbol to tone sequence.
+
+				var ttemp = aprsSymbolData.symbols_to_tones(symtab, symbol)
+
+				//text_color_set(DW_COLOR_DEBUG);
+				//dw_printf ("DEBUG config file Line %d: AB{%s} -> %s\n", line, stemp, ttemp);
+
+				otemp.WriteString(ttemp)
+				tmp = tmp[1:]
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: AB{... is missing matching } in TTMACRO definition.\n", ps.line)
+				tt_error++
+			}
+		} else if strings.HasPrefix(tmp, "CA{") {
+
+			// Convert to enhanced comment that can contain any ASCII character.
+
+			tmp = tmp[3:]
+			var stemp strings.Builder
+			for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
+				stemp.WriteString(string(tmp[0]))
+				tmp = tmp[1:]
+			}
+			if len(tmp) > 0 && tmp[0] == '}' {
+				var ttemp, errs = tt_text_to_ascii2d(stemp.String(), false)
+				if errs == 0 {
+					//text_color_set(DW_COLOR_DEBUG);
+					//dw_printf ("DEBUG Line %d: CA{%s} -> CA%s\n", line, stemp, ttemp);
+					otemp.WriteString("CA" + ttemp)
+				} else {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: CA{%s} could not be converted to tones for enhanced comment.\n", ps.line, stemp.String())
+					tt_error++
+				}
+				tmp = tmp[1:]
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: CA{... is missing matching } in TTMACRO definition.\n", ps.line)
+				tt_error++
+			}
+		} else if strings.ContainsRune("0123456789ABCD*#xyz", rune(tmp[0])) {
+			otemp.WriteString(string(tmp[0]))
+			tmp = tmp[1:]
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: TTMACRO definition can contain only 0-9, A, B, C, D, *, #, x, y, z.\n", ps.line)
+			tt_error++
+			tmp = tmp[1:]
+		}
+	}
+
+	// Make sure that number of x, y, z, in pattern and definition match.
+
+	var d_count [3]int
+
+	for j := 0; j < len(otemp.String()); j++ {
+		if otemp.String()[j] >= 'x' && otemp.String()[j] <= 'z' {
+			d_count[otemp.String()[j]-'x']++
+		}
+	}
+
+	// A little validity checking.
+
+	for j := range 3 {
+		if p_count[j] > 0 && d_count[j] == 0 {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: '%c' is in TTMACRO pattern but is not used in definition.\n", ps.line, 'x'+j)
+		}
+		if d_count[j] > 0 && p_count[j] == 0 {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: '%c' is referenced in TTMACRO definition but does not appear in the pattern.\n", ps.line, 'x'+j)
+		}
+	}
+
+	//text_color_set(DW_COLOR_DEBUG);
+	//dw_printf ("DEBUG Config Line %d: %s -> %s\n", line, t, otemp);
+
+	if tt_error == 0 {
+		tl.macro.definition = otemp.String()
+	}
+
+	if tt_error == 0 {
+		ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+	} else {
+		dw_printf("Line %d: Errors found in TTMACRO, skipping.\n", ps.line)
+	}
+	return false
+}
+
+// handleTTOBJ handles the TTOBJ keyword.
+func handleTTOBJ(ps *parseState) bool {
+	/*
+	 * TTOBJ 		- TT Object Report options.
+	 *
+	 * TTOBJ  recv-chan  where-to  [ via-path ]
+	 *
+	 *	whereto is any combination of transmit channel, APP, IG.
+	 */
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing DTMF receive channel for TTOBJ command.\n", ps.line)
+		return true
+	}
+
+	var r, rErr = strconv.Atoi(t)
+	if r < 0 || r > MAX_RADIO_CHANS-1 || rErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: DTMF receive channel must be in range of 0 to %d on line %d.\n",
+			MAX_RADIO_CHANS-1, ps.line)
+		return true
+	}
+
+	// I suppose we need internal modem channel here.
+	// otherwise a DTMF decoder would not be available.
+
+	if ps.audio.chan_medium[r] != MEDIUM_RADIO {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: TTOBJ DTMF receive channel %d is not valid.\n",
+			ps.line, r)
+		return true
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing transmit channel for TTOBJ command.\n", ps.line)
+		return true
+	}
+
+	// Can have any combination of number, APP, IG.
+	// Would it be easier with strtok?
+
+	var x = -1
+	var app = 0
+	var ig = 0
+
+	for _, p := range t {
+		if unicode.IsDigit(p) {
+			x = int(p - '0')
+			if x < 0 || x > MAX_TOTAL_CHANS-1 {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n", MAX_TOTAL_CHANS-1, ps.line)
+				x = -1
+			} else if ps.audio.chan_medium[x] != MEDIUM_RADIO &&
+				ps.audio.chan_medium[x] != MEDIUM_NETTNC {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file, line %d: TTOBJ transmit channel %d is not valid.\n", ps.line, x)
+				x = -1
+			}
+		} else if p == 'a' || p == 'A' {
+			app = 1
+		} else if p == 'i' || p == 'I' {
+			ig = 1
+		} else if strings.ContainsRune("pPgG,", p) {
+			// Skip?
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: Expected comma separated list with some combination of transmit channel, APP, and IG.\n", ps.line)
+		}
+	}
+
+	// This enables the DTMF decoder on the specified channel.
+	// Additional channels can be enabled with the DTMF command.
+	// Note that DTMF command does not enable the APRStt gateway.
+
+	//text_color_set(DW_COLOR_DEBUG);
+	//dw_printf ("Debug TTOBJ r=%d, x=%d, app=%d, ig=%d\n", r, x, app, ig);
+
+	ps.audio.achan[r].dtmf_decode = DTMF_DECODE_ON
+	ps.tt.gateway_enabled = 1
+	ps.tt.obj_recv_chan = r
+	ps.tt.obj_xmit_chan = x
+	ps.tt.obj_send_to_app = app
+	ps.tt.obj_send_to_ig = ig
+
+	t = split("", false)
+	if t != "" {
+
+		if check_via_path(t) >= 0 {
+			ps.tt.obj_xmit_via = t
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: invalid via path.\n", ps.line)
+		}
+	}
+	return false
+}
+
+// handleTTERR handles the TTERR keyword.
+func handleTTERR(ps *parseState) bool {
+	/*
+	 * TTERR 		- TT responses for success or errors.
+	 *
+	 * TTERR  msg_id  method  text...
+	 */
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing message identifier for TTERR command.\n", ps.line)
+		return true
+	}
+
+	var msg_num = -1
+	for n := range TT_ERROR_MAXP1 {
+		if strings.EqualFold(t, ttErrorString(n)) {
+			msg_num = n
+			break
+		}
+	}
+	if msg_num < 0 {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid message identifier for TTERR command.\n", ps.line)
+		// pick one of ...
+		return true
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing method (SPEECH, MORSE) for TTERR command.\n", ps.line)
+		return true
+	}
+
+	t = strings.ToUpper(t)
+
+	var method, _, _, ok = ax25_parse_addr(-1, t, 1)
+	if !ok {
+		return true // function above prints any error message
+	}
+
+	if method != "MORSE" && method != "SPEECH" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Response method of %s must be SPEECH or MORSE for TTERR command.\n", ps.line, method)
+		return true
+	}
+
+	t = split("", true)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing response text for TTERR command.\n", ps.line)
+		return true
+	}
+
+	//text_color_set(DW_COLOR_DEBUG);
+	//dw_printf ("Line %d: TTERR debug %d %s-%d \"%s\"\n", line, msg_num, method, ssid, t);
+
+	Assert(msg_num >= 0 && msg_num < TT_ERROR_MAXP1)
+
+	ps.tt.response[msg_num].method = method
+
+	// TODO1.3: Need SSID too!
+
+	ps.tt.response[msg_num].mtext = t
+	return false
+}
+
+// handleTTSTATUS handles the TTSTATUS keyword.
+func handleTTSTATUS(ps *parseState) bool {
+	/*
+	 * TTSTATUS 		- TT custom status messages.
+	 *
+	 * TTSTATUS  status_id  text...
+	 */
+
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing status number for TTSTATUS command.\n", ps.line)
+		return true
+	}
+
+	var status_num, _ = strconv.Atoi(t)
+
+	if status_num < 1 || status_num > 9 {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Status number for TTSTATUS command must be in range of 1 to 9.\n", ps.line)
+		return true
+	}
+
+	t = split("", true)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing status text for TTSTATUS command.\n", ps.line)
+		return true
+	}
+
+	//text_color_set(DW_COLOR_DEBUG);
+	//dw_printf ("Line %d: TTSTATUS debug %d \"%s\"\n", line, status_num, t);
+
+	t = strings.TrimSpace(t)
+
+	ps.tt.status[status_num] = t
+	return false
+}
+
+// handleTTCMD handles the TTCMD keyword.
+func handleTTCMD(ps *parseState) bool {
+	/*
+	 * TTCMD 		- Command to run when valid sequence is received.
+	 *			  Any text generated will be sent back to user.
+	 *
+	 * TTCMD ...
+	 */
+	var t = split("", true)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing command for TTCMD command.\n", ps.line)
+		return true
+	}
+
+	ps.tt.ttcmd = t
+	return false
+}
+
+// handleIGSERVER handles the IGSERVER keyword.
+func handleIGSERVER(ps *parseState) bool {
+	/*
+	 * ==================== Internet gateway ====================
+	 */
+
+	/*
+	 * IGSERVER 		- Name of IGate server.
+	 *
+	 * IGSERVER  hostname [ port ] 				-- original implementation.
+	 *
+	 * IGSERVER  hostname:port				-- more in line with usual conventions.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing IGate server name for IGSERVER command.\n", ps.line)
+
+		return true
+	}
+
+	ps.igate.t2_server_name = t
+
+	/* If there is a : in the name, split it out as the port number. */
+
+	if strings.Contains(t, ":") {
+		var hostname, portStr, _ = strings.Cut(t, ":")
+		ps.igate.t2_server_name = hostname
+
+		var port, portErr = strconv.Atoi(portStr)
+		if port >= MIN_IP_PORT_NUMBER && port <= MAX_IP_PORT_NUMBER && portErr == nil {
+			ps.igate.t2_server_port = port
+		} else {
+			ps.igate.t2_server_port = DEFAULT_IGATE_PORT
+
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Invalid port number for IGate server. Using default %d.\n",
+				ps.line, ps.igate.t2_server_port)
+		}
+	}
+
+	/* Alternatively, the port number could be separated by white space. */
+
+	t = split("", false)
+	if t != "" {
+		var n, _ = strconv.Atoi(t)
+		if n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER {
+			ps.igate.t2_server_port = n
+		} else {
+			ps.igate.t2_server_port = DEFAULT_IGATE_PORT
+
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Invalid port number for IGate server. Using default %d.\n",
+				ps.line, ps.igate.t2_server_port)
+		}
+	}
+	// dw_printf ("DEBUG  server=%s   port=%d\n", p_igate_config.t2_server_name, p_igate_config.t2_server_port);
+	// exit (0);
+	return false
+}
+
+// handleIGLOGIN handles the IGLOGIN keyword.
+func handleIGLOGIN(ps *parseState) bool {
+	/*
+	 * IGLOGIN 		- Login callsign and passcode for IGate server
+	 *
+	 * IGLOGIN  callsign  passcode
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing login callsign for IGLOGIN command.\n", ps.line)
+
+		return true
+	}
+	// TODO: Wouldn't hurt to do validity checking of format.
+	ps.igate.t2_login = t
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing passcode for IGLOGIN command.\n", ps.line)
+
+		return true
+	}
+
+	ps.igate.t2_passcode = t
+	return false
+}
+
+// handleIGTXVIA handles the IGTXVIA keyword.
+func handleIGTXVIA(ps *parseState) bool {
+	/*
+	 * IGTXVIA 		- Transmit channel and VIA path for messages from IGate server
+	 *
+	 * IGTXVIA  channel  [ path ]
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing transmit channel for IGTXVIA command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n < 0 || n > MAX_TOTAL_CHANS-1 {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n",
+			MAX_TOTAL_CHANS-1, ps.line)
+
+		return true
+	}
+
+	ps.igate.tx_chan = n
+
+	t = split("", false)
+	if t != "" {
+		// TODO KG#if 1	// proper checking
+		n = check_via_path(t)
+		if n >= 0 {
+			ps.igate.max_digi_hops = n
+			ps.igate.tx_via = "," + t
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: invalid via path.\n", ps.line)
+		}
+
+		/* TODO KG #else	// previously
+
+		   	      char *p;
+		   	      ps.igate.tx_via[0] = ',';
+		   	      strlcpy (ps.igate.tx_via + 1, t, sizeof(ps.igate.tx_via)-1);
+		   	      for (p = ps.igate.tx_via; *p != 0; p++) {
+		   	        if (islower(*p)) {
+		   		  *p = toupper(*p);	// silently force upper case.
+		   	        }
+		   	      }
+		   #endif
+		*/
+	}
+	return false
+}
+
+// handleIGFILTER handles the IGFILTER keyword.
+func handleIGFILTER(ps *parseState) bool {
+	/*
+	 * IGFILTER 		- IGate Server side filters.
+	 *			  Is this name too confusing.  Too similar to FILTER IG 0 ...
+	 *			  Maybe SSFILTER suggesting Server Side.
+	 *			  SUBSCRIBE might be better because it's not a filter that limits.
+	 *
+	 * IGFILTER  filter-spec ...
+	 */
+	var t = split("", true) /* Take rest of ps.line as one string. */
+
+	if ps.igate.t2_filter != "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Warning - IGFILTER already configured (%s), this one (%s) will be ignored.\n", ps.line, ps.igate.t2_filter, t)
+
+		return true
+	}
+
+	if t != "" {
+		ps.igate.t2_filter = t
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Warning - IGFILTER is a rarely needed expert level feature.\n", ps.line)
+		dw_printf("If you don't have a special situation and a good understanding of\n")
+		dw_printf("how this works, you probably should not be messing with it.\n")
+		dw_printf("The default behavior is appropriate for most situations.\n")
+		dw_printf("Please read \"Successful-APRS-IGate-Operation.pdf\".\n")
+	}
+	return false
+}
+
+// handleIGTXLIMIT handles the IGTXLIMIT keyword.
+func handleIGTXLIMIT(ps *parseState) bool {
+	/*
+	 * IGTXLIMIT 		- Limit transmissions during 1 and 5 minute intervals.
+	 *
+	 * IGTXLIMIT  one-minute-limit  five-minute-limit
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing one minute limit for IGTXLIMIT command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n < 1 {
+		ps.igate.tx_limit_1 = 1
+	} else if n <= IGATE_TX_LIMIT_1_MAX {
+		ps.igate.tx_limit_1 = n
+	} else {
+		ps.igate.tx_limit_1 = IGATE_TX_LIMIT_1_MAX
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: One minute transmit limit has been reduced to %d.\n",
+			ps.line, ps.igate.tx_limit_1)
+		dw_printf("You won't make friends by setting a limit this high.\n")
+	}
+
+	t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing five minute limit for IGTXLIMIT command.\n", ps.line)
+
+		return true
+	}
+
+	n, _ = strconv.Atoi(t)
+	if n < 1 {
+		ps.igate.tx_limit_5 = 1
+	} else if n <= IGATE_TX_LIMIT_5_MAX {
+		ps.igate.tx_limit_5 = n
+	} else {
+		ps.igate.tx_limit_5 = IGATE_TX_LIMIT_5_MAX
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Five minute transmit limit has been reduced to %d.\n",
+			ps.line, ps.igate.tx_limit_5)
+		dw_printf("You won't make friends by setting a limit this high.\n")
+	}
+	return false
+}
+
+// handleIGMSP handles the IGMSP keyword.
+func handleIGMSP(ps *parseState) bool {
+	/*
+	 * IGMSP 		- Number of times to send position of message sender.
+	 *
+	 * IGMSP  n
+	 */
+	var t = split("", false)
+	if t != "" {
+		var n, _ = strconv.Atoi(t)
+		if n >= 0 && n <= 10 {
+			ps.igate.igmsp = n
+		} else {
+			ps.igate.igmsp = 1
+
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Unreasonable number of times for message sender position.  Using default 1.\n", ps.line)
+		}
+	} else {
+		ps.igate.igmsp = 1
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing number of times for message sender position.  Using default 1.\n", ps.line)
+	}
+	return false
+}
+
+// handleSATGATE handles the SATGATE keyword.
+func handleSATGATE(ps *parseState) bool {
+	/*
+	 * SATGATE 		- Special SATgate mode to delay packets heard directly.
+	 *
+	 * SATGATE [ n ]
+	 */
+	text_color_set(DW_COLOR_INFO)
+	dw_printf("Line %d: SATGATE is pretty useless and will be removed in a future version.\n", ps.line)
+
+	var t = split("", false)
+	if t != "" {
+		var n, _ = strconv.Atoi(t)
+		if n >= MIN_SATGATE_DELAY && n <= MAX_SATGATE_DELAY {
+			ps.igate.satgate_delay = n
+		} else {
+			ps.igate.satgate_delay = DEFAULT_SATGATE_DELAY
+
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Unreasonable SATgate delay.  Using default.\n", ps.line)
+		}
+	} else {
+		ps.igate.satgate_delay = DEFAULT_SATGATE_DELAY
+	}
+	return false
+}
+
+// handleAGWPORT handles the AGWPORT keyword.
+func handleAGWPORT(ps *parseState) bool {
+	/*
+	 * ==================== All the left overs ====================
+	 */
+
+	/*
+	 * AGWPORT 		- Port number for "AGW TCPIP Socket Interface"
+	 *
+	 * In version 1.2 we allow 0 to disable listening.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing port number for AGWPORT command.\n", ps.line)
+
+		return true
+	}
+	var n, _ = strconv.Atoi(t)
+
+	t = split("", false)
+	if t != "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Unexpected \"%s\" after the port number.\n", ps.line, t)
+		dw_printf("Perhaps you were trying to use feature available only with KISSPORT.\n")
+
+		return true
+	}
+
+	if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
+		ps.misc.agwpe_port = n
+	} else {
+		ps.misc.agwpe_port = DEFAULT_AGWPE_PORT
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid port number for AGW TCPIP Socket Interface. Using %d.\n",
+			ps.line, ps.misc.agwpe_port)
+	}
+	return false
+}
+
+// handleKISSPORT handles the KISSPORT keyword.
+func handleKISSPORT(ps *parseState) bool {
+	/*
+	 * KISSPORT port [ chan ]		- Port number for KISS over IP.
+	 */
+
+	// Previously we allowed only a single TCP port for KISS.
+	// An increasing number of people want to run multiple radios.
+	// Unfortunately, most applications don't know how to deal with multi-radio TNCs.
+	// They ignore the channel on receive and always transmit to channel 0.
+	// Running multiple instances of direwolf is a work-around but this leads to
+	// more complex configuration and we lose the cross-channel digipeating capability.
+	// In release 1.7 we add a new feature to assign a single radio channel to a TCP port.
+	// e.g.
+	//
+	//	KISSPORT 8001		# default, all channels.  Radio channel = KISS channel.
+	//
+	//	KISSPORT 7000 0		# Only radio channel 0 for receive.
+	//				# Transmit to radio channel 0, ignoring KISS channel.
+	//
+	//	KISSPORT 7001 1		# Only radio channel 1 for receive.  KISS channel set to 0.
+	//				# Transmit to radio channel 1, ignoring KISS channel.
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing TCP port number for KISSPORT command.\n", ps.line)
+
+		return true
+	}
+	var n, _ = strconv.Atoi(t)
+
+	var tcp_port int
+	if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
+		tcp_port = n
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid TCP port number for KISS TCPIP Socket Interface.\n", ps.line)
+		dw_printf("Use something in the range of %d to %d.\n", MIN_IP_PORT_NUMBER, MAX_IP_PORT_NUMBER)
+
+		return true
+	}
+
+	t = split("", false)
+	var kissChannel = -1 // optional.  default to all if not specified.
+
+	if t != "" {
+		var channelErr error
+
+		kissChannel, channelErr = strconv.Atoi(t)
+		if ps.channel < 0 || kissChannel >= MAX_TOTAL_CHANS || channelErr != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Invalid channel %d for KISSPORT command.  Must be in range 0 thru %d.\n", ps.line, kissChannel, MAX_TOTAL_CHANS-1)
+
+			return true
+		}
+	}
+
+	// "KISSPORT 0" is used to remove the default entry.
+
+	if tcp_port == 0 {
+		ps.misc.kiss_port[0] = 0 // Should all be wiped out?
+	} else {
+		// Try to find an empty slot.
+		// A duplicate TCP port number will overwrite the previous value.
+		var slot = -1
+		for i := 0; i < MAX_KISS_TCP_PORTS && slot == -1; i++ {
+			if ps.misc.kiss_port[i] == tcp_port { //nolint:staticcheck
+				slot = i
+				if !(slot == 0 && tcp_port == DEFAULT_KISS_PORT) {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Warning: Duplicate TCP port %d will overwrite previous value.\n", ps.line, tcp_port)
+				}
+			} else if ps.misc.kiss_port[i] == 0 {
+				slot = i
+			}
+		}
+
+		if slot >= 0 {
+			ps.misc.kiss_port[slot] = tcp_port
+			ps.misc.kiss_chan[slot] = kissChannel
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Too many KISSPORT commands.\n", ps.line)
+		}
+	}
+	return false
+}
+
+// handleNULLMODEM handles the NULLMODEM keyword.
+func handleNULLMODEM(ps *parseState) bool {
+	/*
+	 * NULLMODEM name [ speed ]	- Device name for serial port or our end of the virtual "null modem"
+	 * SERIALKISS name  [ speed ]
+	 *
+	 * Version 1.5:  Added SERIALKISS which is equivalent to NULLMODEM.
+	 * The original name sort of made sense when it was used only for one end of a virtual
+	 * null modem cable on Windows only.  Now it is also available for Linux.
+	 * TODO1.5: In retrospect, this doesn't seem like such a good name.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing serial port name on line %d.\n", ps.line)
+
+		return true
+	} else {
+		if ps.misc.kiss_serial_port != "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Warning serial port name on line %d replaces earlier value.\n", ps.line)
+		}
+
+		ps.misc.kiss_serial_port = t
+		ps.misc.kiss_serial_speed = 0
+		ps.misc.kiss_serial_poll = 0
+	}
+
+	t = split("", false)
+	if t != "" {
+		ps.misc.kiss_serial_speed, _ = strconv.Atoi(t)
+	}
+	return false
+}
+
+// handleSERIALKISSPOLL handles the SERIALKISSPOLL keyword.
+func handleSERIALKISSPOLL(ps *parseState) bool {
+	/*
+	 * SERIALKISSPOLL name		- Poll for serial port name that might come and go.
+	 *			  	  e.g. /dev/rfcomm0 for bluetooth.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing serial port name on line %d.\n", ps.line)
+
+		return true
+	} else {
+		if ps.misc.kiss_serial_port != "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Warning serial port name on line %d replaces earlier value.\n", ps.line)
+		}
+
+		ps.misc.kiss_serial_port = t
+		ps.misc.kiss_serial_speed = 0
+		ps.misc.kiss_serial_poll = 1 // set polling.
+	}
+	return false
+}
+
+// handleKISSCOPY handles the KISSCOPY keyword.
+func handleKISSCOPY(ps *parseState) bool {
+	/*
+	 * KISSCOPY 		- Data from network KISS client is copied to all others.
+	 *			  This does not apply to pseudo terminal KISS.
+	 */
+	ps.misc.kiss_copy = true
+	return false
+}
+
+// handleDNSSD handles the DNSSD keyword.
+func handleDNSSD(ps *parseState) bool {
+	/*
+	 * DNSSD 		- Enable or disable (1/0) dns-sd, DNS Service Discovery announcements
+	 * DNSSDNAME            - Set DNS-SD service name, defaults to "Dire Wolf on <hostname>"
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing integer value for DNSSD command.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n == 0 || n == 1 {
+		ps.misc.dns_sd_enabled = n != 0
+	} else {
+		ps.misc.dns_sd_enabled = false
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid integer value for DNSSD. Disabling dns-sd.\n", ps.line)
+	}
+	return false
+}
+
+// handleDNSSDNAME handles the DNSSDNAME keyword.
+func handleDNSSDNAME(ps *parseState) bool {
+	var t = split("", true)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing service name for DNSSDNAME.\n", ps.line)
+
+		return true
+	} else {
+		ps.misc.dns_sd_name = t
+	}
+	return false
+}
+
+// handleGPSNMEA handles the GPSNMEA keyword.
+func handleGPSNMEA(ps *parseState) bool {
+	/*
+	 * GPSNMEA  serial-device  [ speed ]		- Direct connection to GPS receiver.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: Missing serial port name for GPS receiver.\n", ps.line)
+
+		return true
+	}
+
+	ps.misc.gpsnmea_port = t
+
+	t = split("", false)
+	if t != "" {
+		var n, _ = strconv.Atoi(t)
+		ps.misc.gpsnmea_speed = n
+	} else {
+		ps.misc.gpsnmea_speed = 4800 // The standard at one time.
+	}
+	return false
+}
+
+// handleGPSD handles the GPSD keyword.
+func handleGPSD(ps *parseState) bool {
+	/*
+	 * GPSD		- Use GPSD server.
+	 *
+	 * GPSD [ host [ port ] ]
+	 */
+
+	/*
+	   TODO KG
+
+	   	#if __WIN32__
+
+	   		    text_color_set(DW_COLOR_ERROR);
+	   		    dw_printf ("Config file, line %d: The GPSD interface is not available for Windows.\n", ps.line);
+	   		    continue;
+
+	   	#elif ENABLE_GPSD
+	*/
+	dw_printf("Warning: GPSD support currently disabled pending a rewrite of the integration.\n")
+
+	ps.misc.gpsd_host = "localhost"
+	ps.misc.gpsd_port = DEFAULT_GPSD_PORT
+
+	var t = split("", false)
+	if t != "" {
+		ps.misc.gpsd_host = t
+
+		t = split("", false)
+		if t != "" {
+			var n, _ = strconv.Atoi(t)
+			if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
+				ps.misc.gpsd_port = n
+			} else {
+				ps.misc.gpsd_port = DEFAULT_GPSD_PORT
+
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Invalid port number for GPSD Socket Interface. Using default of %d.\n",
+					ps.line, ps.misc.gpsd_port)
+			}
+		}
+	}
+	/*
+	   	TODO KG
+
+	   #else
+
+	   	text_color_set(DW_COLOR_ERROR);
+	   	dw_printf ("Config file, line %d: The GPSD interface has not been enabled.\n", ps.line);
+	   	dw_printf ("Install gpsd and libgps-dev packages then rebuild direwolf.\n");
+	   	continue;
+
+	   #endif
+	*/
+	return false
+}
+
+// handleWAYPOINT handles the WAYPOINT keyword.
+func handleWAYPOINT(ps *parseState) bool {
+	/*
+	 * WAYPOINT		- Generate WPL and AIS NMEA sentences for display on map.
+	 *
+	 * WAYPOINT  serial-device [ formats ]
+	 * WAYPOINT  host:udpport [ formats ]
+	 *
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing output device for WAYPOINT on line %d.\n", ps.line)
+
+		return true
+	}
+
+	/* If there is a ':' in the name, split it into hostname:udpportnum. */
+	/* Otherwise assume it is serial port name. */
+
+	if strings.Contains(t, ":") {
+		var hostname, portStr, _ = strings.Cut(t, ":")
+
+		var port, _ = strconv.Atoi(portStr)
+		if port >= MIN_IP_PORT_NUMBER && port <= MAX_IP_PORT_NUMBER {
+			ps.misc.waypoint_udp_hostname = hostname
+			if ps.misc.waypoint_udp_hostname == "" {
+				ps.misc.waypoint_udp_hostname = "localhost"
+			}
+
+			ps.misc.waypoint_udp_portnum = port
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Invalid UDP port number %d for sending waypoints.\n", ps.line, port)
+		}
+	} else {
+		ps.misc.waypoint_serial_port = t
+	}
+
+	/* Anything remaining is the formats to enable. */
+
+	t = split("", true)
+	for _, c := range t {
+		switch unicode.ToUpper(c) {
+		case 'N':
+			ps.misc.waypoint_formats |= WPL_FORMAT_NMEA_GENERIC
+		case 'G':
+			ps.misc.waypoint_formats |= WPL_FORMAT_GARMIN
+		case 'M':
+			ps.misc.waypoint_formats |= WPL_FORMAT_MAGELLAN
+		case 'K':
+			ps.misc.waypoint_formats |= WPL_FORMAT_KENWOOD
+		case 'A':
+			ps.misc.waypoint_formats |= WPL_FORMAT_AIS
+		case ' ', ',':
+		default:
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Invalid output format '%c' for WAYPOINT on line %d.\n", c, ps.line)
+		}
+	}
+	return false
+}
+
+// handleLOGDIR handles the LOGDIR keyword.
+func handleLOGDIR(ps *parseState) bool {
+	/*
+	 * LOGDIR	- Directory name for automatically named daily log files.  Use "." for current working directory.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing directory name for LOGDIR on line %d.\n", ps.line)
+
+		return true
+	} else {
+		if ps.misc.log_path != "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: LOGDIR on line %d is replacing an earlier LOGDIR or LOGFILE.\n", ps.line)
+		}
+
+		ps.misc.log_daily_names = true
+		ps.misc.log_path = t
+	}
+
+	t = split("", false)
+	if t != "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: LOGDIR on line %d should have directory path and nothing more.\n", ps.line)
+	}
+	return false
+}
+
+// handleLOGFILE handles the LOGFILE keyword.
+func handleLOGFILE(ps *parseState) bool {
+	/*
+	 * LOGFILE	- Log file name, including any directory part.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Missing file name for LOGFILE on line %d.\n", ps.line)
+
+		return true
+	} else {
+		if ps.misc.log_path != "" {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: LOGFILE on line %d is replacing an earlier LOGDIR or LOGFILE.\n", ps.line)
+		}
+
+		ps.misc.log_daily_names = false
+		ps.misc.log_path = t
+	}
+
+	t = split("", false)
+	if t != "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: LOGFILE on line %d should have file name and nothing more.\n", ps.line)
+	}
+	return false
+}
+
+// handleBEACON handles the BEACON keyword.
+func handleBEACON(ps *parseState) bool {
+	/*
+	 * BEACON channel delay every message
+	 *
+	 * Original handcrafted style.  Removed in version 1.0.
+	 */
+	text_color_set(DW_COLOR_ERROR)
+	dw_printf("Config file, line %d: Old style 'BEACON' has been replaced with new commands.\n", ps.line)
+	dw_printf("Use PBEACON, OBEACON, TBEACON, or CBEACON instead.\n")
+	return false
+}
+
+// handleXBEACON handles the XBEACON keyword.
+func handleXBEACON(ps *parseState) bool {
+	/*
+	 * PBEACON keyword=value ...
+	 * OBEACON keyword=value ...
+	 * TBEACON keyword=value ...
+	 * CBEACON keyword=value ...
+	 * IBEACON keyword=value ...
+	 *
+	 * New style with keywords for options.
+	 */
+
+	// TODO: maybe add proportional pathing so multiple beacon timing does not need to be manually constructed?
+	// http://www.aprs.org/newN/ProportionalPathing.txt
+	if ps.misc.num_beacons < MAX_BEACONS {
+		if strings.EqualFold(ps.keyword, "PBEACON") {
+			ps.misc.beacon[ps.misc.num_beacons].btype = BEACON_POSITION
+		} else if strings.EqualFold(ps.keyword, "OBEACON") {
+			ps.misc.beacon[ps.misc.num_beacons].btype = BEACON_OBJECT
+		} else if strings.EqualFold(ps.keyword, "TBEACON") {
+			ps.misc.beacon[ps.misc.num_beacons].btype = BEACON_TRACKER
+		} else if strings.EqualFold(ps.keyword, "IBEACON") {
+			ps.misc.beacon[ps.misc.num_beacons].btype = BEACON_IGATE
+		} else {
+			ps.misc.beacon[ps.misc.num_beacons].btype = BEACON_CUSTOM
+		}
+
+		/* Save line number because some errors will be reported later. */
+		ps.misc.beacon[ps.misc.num_beacons].lineno = ps.line
+
+		if beacon_options(ps.text[len("xBEACON")+1:], &(ps.misc.beacon[ps.misc.num_beacons]), ps.line, ps.audio) == nil {
+			ps.misc.num_beacons++
+		}
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file: Maximum number of beacons exceeded on line %d.\n", ps.line)
+
+		return true
+	}
+	return false
+}
+
+// handleSMARTBEACON handles the SMARTBEACON keyword.
+func handleSMARTBEACON(ps *parseState) bool {
+	/*
+	 * SMARTBEACONING [ fast_speed fast_rate slow_speed slow_rate turn_time turn_angle turn_slope ]
+	 *
+	 * Parameters must be all or nothing.
+	 */
+	dw_printf("SMARTBEACONING support currently disabled due to mid-stage porting complexity - line %d skipped.\n", ps.line)
+
+	/* TODO KG
+	   #define SB_NUM(name,sbvar,minn,maxx,unit)  							\
+	   	var t = split("", false);									\
+	   	    if (t == "") {									\
+	   	      if (strcmp(name, "fast speed") == 0) {						\
+	   	        ps.misc.sb_configured = 1;						\
+	   	        continue;									\
+	   	      }											\
+	   	      text_color_set(DW_COLOR_ERROR);							\
+	   	      dw_printf ("Line %d: Missing %s for SmartBeaconing.\n", ps.line, name);		\
+	   	      continue;										\
+	   	    }											\
+	   	    var n, _ = strconv.Atoi(t);									\
+	               if (n >= minn && n <= maxx) {							\
+	   	      ps.misc.sbvar = n;								\
+	   	    }											\
+	   	    else {										\
+	   	      text_color_set(DW_COLOR_ERROR);							\
+	                 dw_printf ("Line %d: Invalid %s for SmartBeaconing. Using default %d %s.\n",	\
+	   			ps.line, name, ps.misc.sbvar, unit);				\
+	      	    }
+	*/
+
+	/* TODO KG
+	   #define SB_TIME(name,sbvar,minn,maxx,unit)  							\
+	   	    t = split("", false);									\
+	   	    if (t == "") {									\
+	   	      text_color_set(DW_COLOR_ERROR);							\
+	   	      dw_printf ("Line %d: Missing %s for SmartBeaconing.\n", ps.line, name);		\
+	   	      continue;										\
+	   	    }											\
+	   	    n = parse_interval(t,ps.line);								\
+	               if (n >= minn && n <= maxx) {							\
+	   	      ps.misc.sbvar = n;								\
+	   	    }											\
+	   	    else {										\
+	   	      text_color_set(DW_COLOR_ERROR);							\
+	                 dw_printf ("Line %d: Invalid %s for SmartBeaconing. Using default %d %s.\n",	\
+	   			ps.line, name, ps.misc.sbvar, unit);				\
+	      	    }
+	*/
+
+	/* TODO KG
+	   SB_NUM("fast speed", sb_fast_speed, 2, 90, "MPH")
+	   SB_TIME("fast rate", sb_fast_rate, 10, 300, "seconds")
+
+	   SB_NUM("slow speed", sb_slow_speed, 1, 30, "MPH")
+	   SB_TIME("slow rate", sb_slow_rate, 30, 3600, "seconds")
+
+	   SB_TIME("turn time", sb_turn_time, 5, 180, "seconds")
+	   SB_NUM("turn angle", sb_turn_angle, 5, 90, "degrees")
+	   SB_NUM("turn slope", sb_turn_slope, 1, 255, "deg*mph")
+
+	   ps.misc.sb_configured = 1
+	*/
+
+	/* If I was ambitious, I might allow optional */
+	/* unit at end for miles or km / hour. */
+	return false
+}
+
+// handleFRACK handles the FRACK keyword.
+func handleFRACK(ps *parseState) bool {
+	/*
+	 * ==================== AX.25 connected mode ====================
+	 */
+
+	/*
+	 * FRACK  n 		- Number of seconds to wait for ack to transmission.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing value for FRACK.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= AX25_T1V_FRACK_MIN && n <= AX25_T1V_FRACK_MAX {
+		ps.misc.frack = n
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid FRACK time. Using default %d.\n", ps.line, ps.misc.frack)
+	}
+	return false
+}
+
+// handleRETRY handles the RETRY keyword.
+func handleRETRY(ps *parseState) bool {
+	/*
+	 * RETRY  n 		- Number of times to retry before giving up.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing value for RETRY.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= AX25_N2_RETRY_MIN && n <= AX25_N2_RETRY_MAX {
+		ps.misc.retry = n
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid RETRY number. Using default %d.\n", ps.line, ps.misc.retry)
+	}
+	return false
+}
+
+// handlePACLEN handles the PACLEN keyword.
+func handlePACLEN(ps *parseState) bool {
+	/*
+	 * PACLEN  n 		- Maximum number of bytes in information part.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing value for PACLEN.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= AX25_N1_PACLEN_MIN && n <= AX25_N1_PACLEN_MAX {
+		ps.misc.paclen = n
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid PACLEN value. Using default %d.\n", ps.line, ps.misc.paclen)
+	}
+	return false
+}
+
+// handleMAXFRAME handles the MAXFRAME keyword.
+func handleMAXFRAME(ps *parseState) bool {
+	/*
+	 * MAXFRAME  n 		- Max frames to send before ACK.  mod 8 "Window" size.
+	 *
+	 * Window size would make more sense but everyone else calls it MAXFRAME.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing value for MAXFRAME.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= AX25_K_MAXFRAME_BASIC_MIN && n <= AX25_K_MAXFRAME_BASIC_MAX {
+		ps.misc.maxframe_basic = n
+	} else {
+		ps.misc.maxframe_basic = AX25_K_MAXFRAME_BASIC_DEFAULT
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid MAXFRAME value outside range of %d to %d. Using default %d.\n",
+			ps.line, AX25_K_MAXFRAME_BASIC_MIN, AX25_K_MAXFRAME_BASIC_MAX, ps.misc.maxframe_basic)
+	}
+	return false
+}
+
+// handleEMAXFRAME handles the EMAXFRAME keyword.
+func handleEMAXFRAME(ps *parseState) bool {
+	/*
+	 * EMAXFRAME  n 		- Max frames to send before ACK.  mod 128 "Window" size.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing value for EMAXFRAME.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= AX25_K_MAXFRAME_EXTENDED_MIN && n <= AX25_K_MAXFRAME_EXTENDED_MAX {
+		ps.misc.maxframe_extended = n
+	} else {
+		ps.misc.maxframe_extended = AX25_K_MAXFRAME_EXTENDED_DEFAULT
+
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid EMAXFRAME value outside of range %d to %d. Using default %d.\n",
+			ps.line, AX25_K_MAXFRAME_EXTENDED_MIN, AX25_K_MAXFRAME_EXTENDED_MAX, ps.misc.maxframe_extended)
+	}
+	return false
+}
+
+// handleMAXV22 handles the MAXV22 keyword.
+func handleMAXV22(ps *parseState) bool {
+	/*
+	 * MAXV22  n 		- Max number of SABME sent before trying SABM.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing value for MAXV22.\n", ps.line)
+
+		return true
+	}
+
+	var n, _ = strconv.Atoi(t)
+	if n >= 0 && n <= AX25_N2_RETRY_MAX {
+		ps.misc.maxv22 = n
+	} else {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid MAXV22 number. Will use half of RETRY.\n", ps.line)
+	}
+	return false
+}
+
+// handleV20 handles the V20 keyword.
+func handleV20(ps *parseState) bool {
+	/*
+	 * V20  address [ address ... ] 	- Stations known to support only AX.25 v2.0.
+	 *					  When connecting to these, skip SABME and go right to SABM.
+	 *					  Possible to have multiple and they are cumulative.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing address(es) for V20.\n", ps.line)
+
+		return true
+	}
+
+	for t != "" {
+		var strictness = 2
+		var _, _, _, ok = ax25_parse_addr(AX25_DESTINATION, t, strictness)
+
+		if ok {
+			ps.misc.v20_addrs = append(ps.misc.v20_addrs, t)
+			ps.misc.v20_count++
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Invalid station address for V20 command.\n", ps.line)
+
+			// continue processing any others following.
+		}
+
+		t = split("", false)
+	}
+	return false
+}
+
+// handleNOXID handles the NOXID keyword.
+func handleNOXID(ps *parseState) bool {
+	/*
+	 * NOXID  address [ address ... ] 	- Stations known not to understand XID.
+	 *					  After connecting to these (with v2.2 obviously), don't try using XID command.
+	 *					  AX.25 for Linux is the one known case so far.
+	 *					  Possible to have multiple and they are cumulative.
+	 */
+	var t = split("", false)
+	if t == "" {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Missing address(es) for NOXID.\n", ps.line)
+
+		return true
+	}
+
+	for t != "" {
+		var strictness = 2
+		var _, _, _, ok = ax25_parse_addr(AX25_DESTINATION, t, strictness)
+
+		if ok {
+			ps.misc.noxid_addrs = append(ps.misc.noxid_addrs, t)
+			ps.misc.noxid_count++
+		} else {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Invalid station address for NOXID command.\n", ps.line)
+
+			// continue processing any others following.
+		}
+
+		t = split("", false)
+	}
+	return false
+}
 
 /*
  * Parse the PBEACON or OBEACON options.

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -190,6 +190,175 @@ func Test_IsNoCall(t *testing.T) {
 	}
 }
 
+// --- config_init helpers ---
+
+// configFromString writes content to a temp config file, runs config_init, and
+// returns the resulting audio and misc config structs.
+func configFromString(t *testing.T, content string) (*audio_s, *misc_config_s) {
+	t.Helper()
+
+	var tmpFile, err = os.CreateTemp(t.TempDir(), "direwolf*.conf")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	var audioConfig = new(audio_s)
+	var digiConfig digi_config_s
+	var cdigiConfig cdigi_config_s
+	var ttConfig tt_config_s
+	var igateConfig igate_config_s
+	var miscConfig misc_config_s
+
+	config_init(tmpFile.Name(), audioConfig, &digiConfig, &cdigiConfig,
+		&ttConfig, &igateConfig, &miscConfig)
+
+	return audioConfig, &miscConfig
+}
+
+// --- config_init MYCALL directive ---
+
+func Test_config_init_mycall(t *testing.T) {
+	t.Run("basic callsign stored on channel 0", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "MYCALL Q1TEST\n")
+		assert.Equal(t, "Q1TEST", cfg.mycall[0])
+	})
+
+	t.Run("lowercase input is silently uppercased", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "MYCALL q1test\n")
+		assert.Equal(t, "Q1TEST", cfg.mycall[0])
+	})
+
+	t.Run("callsign with SSID", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "MYCALL Q1TEST-9\n")
+		assert.Equal(t, "Q1TEST-9", cfg.mycall[0])
+	})
+
+	t.Run("invalid callsign leaves all channels as NOCALL", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "MYCALL !INVALID!\n")
+		assert.True(t, IsNoCall(cfg.mycall[0]))
+	})
+
+	t.Run("MYCALL propagates to all unset channels", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "MYCALL Q1TEST\n")
+		// Channel 0 and all other channels that were not explicitly set should share it.
+		for c := range MAX_TOTAL_CHANS {
+			assert.Equal(t, "Q1TEST", cfg.mycall[c],
+				"expected Q1TEST on channel %d", c)
+		}
+	})
+
+	t.Run("per-channel MYCALL does not overwrite explicitly set channel", func(t *testing.T) {
+		// MYCALL Q1TEST sets all channels; then CHANNEL 1 + MYCALL Q2TEST
+		// should overwrite channel 1 but leave channel 0 as Q1TEST.
+		var cfg, _ = configFromString(t,
+			"ADEVICE hw:0,0\n"+
+				"ARATE 44100\n"+
+				"MYCALL Q1TEST\n"+
+				"CHANNEL 1\n"+
+				"MYCALL Q2TEST\n",
+		)
+		assert.Equal(t, "Q1TEST", cfg.mycall[0])
+		assert.Equal(t, "Q2TEST", cfg.mycall[1])
+	})
+}
+
+// --- config_init case-insensitive keyword dispatch ---
+
+func Test_config_init_keyword_case_insensitive(t *testing.T) {
+	t.Run("lowercase directive name works", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "mycall Q1TEST\n")
+		assert.Equal(t, "Q1TEST", cfg.mycall[0])
+	})
+
+	t.Run("mixed-case directive name works", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "MyCall Q1TEST\n")
+		assert.Equal(t, "Q1TEST", cfg.mycall[0])
+	})
+}
+
+// --- config_init TXDELAY directive ---
+
+func Test_config_init_txdelay(t *testing.T) {
+	t.Run("valid value stored", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "TXDELAY 50\n")
+		assert.Equal(t, 50, cfg.achan[0].txdelay)
+	})
+
+	t.Run("out-of-range value falls back to default", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "TXDELAY 999\n")
+		assert.Equal(t, DEFAULT_TXDELAY, cfg.achan[0].txdelay)
+	})
+}
+
+// --- config_init SLOTTIME directive ---
+
+func Test_config_init_slottime(t *testing.T) {
+	t.Run("valid value stored", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "SLOTTIME 20\n")
+		assert.Equal(t, 20, cfg.achan[0].slottime)
+	})
+
+	t.Run("out-of-range value falls back to default", func(t *testing.T) {
+		// 0 is outside the accepted range 5..49
+		var cfg, _ = configFromString(t, "SLOTTIME 0\n")
+		assert.Equal(t, DEFAULT_SLOTTIME, cfg.achan[0].slottime)
+	})
+}
+
+// --- config_init FRACK directive ---
+
+func Test_config_init_frack(t *testing.T) {
+	t.Run("valid value stored", func(t *testing.T) {
+		var _, misc = configFromString(t, "FRACK 5\n")
+		assert.Equal(t, 5, misc.frack)
+	})
+
+	t.Run("out-of-range value keeps default", func(t *testing.T) {
+		var _, misc = configFromString(t, "FRACK 999\n")
+		assert.Equal(t, AX25_T1V_FRACK_DEFAULT, misc.frack)
+	})
+}
+
+// --- config_init ADEVICE directive ---
+
+func Test_config_init_adevice(t *testing.T) {
+	t.Run("single arg sets both in and out to same device", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "ADEVICE hw:0,0\n")
+		assert.Equal(t, "hw:0,0", cfg.adev[0].adevice_in)
+		assert.Equal(t, "hw:0,0", cfg.adev[0].adevice_out)
+	})
+
+	t.Run("two args set in and out independently", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "ADEVICE hw:0,0 hw:1,0\n")
+		assert.Equal(t, "hw:0,0", cfg.adev[0].adevice_in)
+		assert.Equal(t, "hw:1,0", cfg.adev[0].adevice_out)
+	})
+
+	t.Run("ADEVICE1 numeric suffix sets device 1", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "ADEVICE hw:0,0\nADEVICE1 hw:1,0\n")
+		assert.Equal(t, "hw:1,0", cfg.adev[1].adevice_in)
+		assert.Equal(t, "hw:1,0", cfg.adev[1].adevice_out)
+	})
+}
+
+// --- config_init CHANNEL directive ---
+
+func Test_config_init_channel(t *testing.T) {
+	t.Run("CHANNEL 1 routes subsequent TXDELAY to channel 1", func(t *testing.T) {
+		// Need stereo ADEVICE so channel 1 is valid.
+		var cfg, _ = configFromString(t,
+			"ADEVICE hw:0,0\n"+
+				"ARATE 44100\n"+
+				"CHANNEL 1\n"+
+				"TXDELAY 42\n",
+		)
+		// Channel 0 should have the default; channel 1 should have 42.
+		assert.Equal(t, DEFAULT_TXDELAY, cfg.achan[0].txdelay)
+		assert.Equal(t, 42, cfg.achan[1].txdelay)
+	})
+}
+
 // --- config_init MODEM directive ---
 
 func Test_config_init_modem_directive(t *testing.T) {


### PR DESCRIPTION
Extract parseState struct, map-based keyword dispatcher, and 74
handler functions from the monolithic config_init() function.

- Extract parseState struct grouping channel, adevice, line, and all
  config struct pointers for clean handler signatures
- Replace ~96 else-if EqualFold chain with map[string]configHandler
  dispatch table and individual handleXxx functions
- Dispatch ADEVICE/PAIDEVICE/PAODEVICE separately via HasPrefix, as
  all three accept an optional numeric suffix (e.g. ADEVICE1)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
