### PR TITLE
fix: Remove debug null byte appended in cmd_listen_thread

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -975,10 +975,6 @@ func cmd_listen_thread(client int) {
 			}
 
 			cmd.Data = b
-
-			if n >= 0 {
-				cmd.Data = append(cmd.Data, 0) // Tidy if we print for debug.
-			}
 		}
 
 		/*


### PR DESCRIPTION
The null byte was appended to cmd.Data solely to make debug printing
tidier (C-style null-termination), not as part of the AGWPE protocol.
This is the null that caused the bug fixed in #487 — removing it
eliminates the divergence between cmd.Data and cmd.Header.DataLen
rather than working around it at each call site.

Other null bytes appended to outgoing frames ('C', 'd', monitor) are
retained: the AGWPE protocol spec hex dumps show DataLen counting a
trailing null in all those frame types.

Closes #488

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
