### PR TITLE
refactor: Allow NCHANNEL ports to support connected-mode operations

### DIFF
--- a/src/ax25_link.go
+++ b/src/ax25_link.go
@@ -1775,11 +1775,11 @@ func dl_data_indication(S *ax25_dlsm_t, pid int, dataBytes []byte) {
  *
  *------------------------------------------------------------------------------*/
 
-var dcd_status [MAX_RADIO_CHANS]int
-var ptt_status [MAX_RADIO_CHANS]int
+var dcd_status [MAX_TOTAL_CHANS]int
+var ptt_status [MAX_TOTAL_CHANS]int
 
 func lm_channel_busy(E *dlq_item_t) {
-	Assert(E._chan >= 0 && E._chan < MAX_RADIO_CHANS)
+	Assert(E._chan >= 0 && E._chan < MAX_TOTAL_CHANS)
 	Assert(E.activity == OCTYPE_PTT || E.activity == OCTYPE_DCD)
 	Assert(E.status == 1 || E.status == 0)
 
@@ -1847,7 +1847,7 @@ func lm_channel_busy(E *dlq_item_t) {
  *------------------------------------------------------------------------------*/
 
 func lm_seize_confirm(E *dlq_item_t) {
-	Assert(E._chan >= 0 && E._chan < MAX_RADIO_CHANS)
+	Assert(E._chan >= 0 && E._chan < MAX_TOTAL_CHANS)
 
 	for S := list_head; S != nil; S = S.next {
 		if E._chan == S.channel {

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -830,8 +830,9 @@ func app_process_rec_packet(channel int, subchan int, slice int, pp *packet_t, a
 	case fec_type_il2p:
 		display_retries = " IL2P "
 	default:
-		// Possible fix_bits indication.
-		if audio_config.achan[channel].fix_bits != RETRY_NONE || audio_config.achan[channel].passall {
+		// Possible fix_bits indication.  Only radio channels (< MAX_RADIO_CHANS) have achan entries;
+		// virtual channels such as NCHANNEL do not.
+		if channel < MAX_RADIO_CHANS && (audio_config.achan[channel].fix_bits != RETRY_NONE || audio_config.achan[channel].passall) {
 			Assert(retries >= RETRY_NONE && retries <= RETRY_MAX)
 			display_retries = fmt.Sprintf(" [%s] ", retries.String())
 		}

--- a/src/dlq.go
+++ b/src/dlq.go
@@ -437,7 +437,7 @@ func dlq_connect_request(addrs [AX25_MAX_ADDRS]string, num_addr int, channel int
 		dw_printf ("dlq_connect_request (...)\n");
 	#endif
 	*/
-	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
+	Assert(channel >= 0 && channel < MAX_TOTAL_CHANS)
 
 	/* Allocate a new queue item. */
 
@@ -486,7 +486,7 @@ func dlq_disconnect_request(addrs [AX25_MAX_ADDRS]string, num_addr int, channel 
 		dw_printf ("dlq_disconnect_request (...)\n");
 	#endif
 	*/
-	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
+	Assert(channel >= 0 && channel < MAX_TOTAL_CHANS)
 
 	/* Allocate a new queue item. */
 
@@ -540,7 +540,7 @@ func dlq_outstanding_frames_request(addrs [AX25_MAX_ADDRS]string, num_addr int, 
 		dw_printf ("dlq_outstanding_frames_request (...)\n");
 	#endif
 	*/
-	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
+	Assert(channel >= 0 && channel < MAX_TOTAL_CHANS)
 
 	/* Allocate a new queue item. */
 
@@ -597,7 +597,7 @@ func dlq_xmit_data_request(addrs [AX25_MAX_ADDRS]string, num_addr int, channel i
 		dw_printf ("dlq_xmit_data_request (...)\n");
 	#endif
 	*/
-	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
+	Assert(channel >= 0 && channel < MAX_TOTAL_CHANS)
 
 	/* Allocate a new queue item. */
 
@@ -652,7 +652,7 @@ func dlq_register_callsign(addr string, channel int, client int) {
 		dw_printf ("dlq_register_callsign (%s, chan=%d, client=%d)\n", addr, channel, client);
 	#endif
 	*/
-	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
+	Assert(channel >= 0 && channel < MAX_TOTAL_CHANS)
 
 	/* Allocate a new queue item. */
 
@@ -677,7 +677,7 @@ func dlq_unregister_callsign(addr string, channel int, client int) {
 		dw_printf ("dlq_unregister_callsign (%s, chan=%d, client=%d)\n", addr, channel, client);
 	#endif
 	*/
-	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
+	Assert(channel >= 0 && channel < MAX_TOTAL_CHANS)
 
 	/* Allocate a new queue item. */
 

--- a/src/ptt.go
+++ b/src/ptt.go
@@ -968,14 +968,18 @@ func ptt_set_real(ot int, channel int, ptt_signal int) {
 	var ptt2 = ptt_signal
 
 	Assert(ot >= 0 && ot < NUM_OCTYPES)
-	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
+	Assert(channel >= 0 && channel < MAX_TOTAL_CHANS)
+
+	if channel >= MAX_RADIO_CHANS {
+		return // NCHANNEL: no physical PTT hardware to drive
+	}
 
 	if ptt_debug_level >= 1 {
 		text_color_set(DW_COLOR_DEBUG)
 		dw_printf("%s %d = %d\n", otnames[ot], channel, ptt_signal)
 	}
 
-	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
+	Assert(channel >= 0 && channel < MAX_TOTAL_CHANS)
 
 	if save_audio_config_p.chan_medium[channel] != MEDIUM_RADIO {
 		text_color_set(DW_COLOR_ERROR)

--- a/src/server.go
+++ b/src/server.go
@@ -283,6 +283,21 @@ func debug_print(fromto fromto_t, client int, pmsg *AGWPEMessage) {
  *
  *--------------------------------------------------------------------*/
 
+// agwConnectedModeAllowed reports whether AX.25 connected mode is allowed on portx.
+// Connected mode is supported for MEDIUM_RADIO channels and MEDIUM_NETTNC channels.
+// When save_audio_config_p is nil (e.g. in unit tests), only channels < MAX_RADIO_CHANS
+// are permitted, preserving the previous behaviour.
+func agwConnectedModeAllowed(portx byte) bool {
+	if int(portx) >= MAX_TOTAL_CHANS {
+		return false
+	}
+	if save_audio_config_p == nil {
+		return int(portx) < MAX_RADIO_CHANS
+	}
+	var m = save_audio_config_p.chan_medium[portx]
+	return m == MEDIUM_RADIO || m == MEDIUM_NETTNC
+}
+
 func server_init(audio_config_p *audio_s, mc *misc_config_s) {
 	var server_port = mc.agwpe_port /* Usually 8000 but can be changed. */
 
@@ -1294,9 +1309,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 
 			var channel = int(cmd.Header.Portx)
 
-			// Connected mode can only be used with internal modems.
-
-			if channel < MAX_RADIO_CHANS && save_audio_config_p.chan_medium[channel] == MEDIUM_RADIO {
+			if agwConnectedModeAllowed(cmd.Header.Portx) {
 				ok = 1
 
 				dlq_register_callsign(ByteArrayToString(cmd.Header.CallFrom[:]), channel, client)
@@ -1320,9 +1333,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 	case 'x': /* Unregister CallSign  */
 		var channel = int(cmd.Header.Portx)
 
-		// Connected mode can only be used with internal modems.
-
-		if channel < MAX_RADIO_CHANS && save_audio_config_p.chan_medium[channel] == MEDIUM_RADIO {
+		if agwConnectedModeAllowed(cmd.Header.Portx) {
 			dlq_unregister_callsign(ByteArrayToString(cmd.Header.CallFrom[:]), channel, client)
 		} else {
 			text_color_set(DW_COLOR_ERROR)
@@ -1335,9 +1346,9 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 		/* v: Connect VIA, Start an AX.25 circuit thru digipeaters */
 		/* c: Connection with non-standard PID */
 		{
-			if int(cmd.Header.Portx) >= MAX_RADIO_CHANS {
+			if !agwConnectedModeAllowed(cmd.Header.Portx) {
 				text_color_set(DW_COLOR_ERROR)
-				dw_printf("AGW connect command on non-radio channel %d ignored.\n", cmd.Header.Portx)
+				dw_printf("AGW connect command on unsupported channel %d ignored.\n", cmd.Header.Portx)
 				break
 			}
 			/*
@@ -1399,9 +1410,9 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 
 	case 'D': /* Send Connected Data */
 		{
-			if int(cmd.Header.Portx) >= MAX_RADIO_CHANS {
+			if !agwConnectedModeAllowed(cmd.Header.Portx) {
 				text_color_set(DW_COLOR_ERROR)
-				dw_printf("AGW 'D' command on non-radio channel %d ignored.\n", cmd.Header.Portx)
+				dw_printf("AGW 'D' command on unsupported channel %d ignored.\n", cmd.Header.Portx)
 				break
 			}
 
@@ -1422,9 +1433,9 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 
 	case 'd': /* Disconnect, Terminate an AX.25 Connection */
 		{
-			if int(cmd.Header.Portx) >= MAX_RADIO_CHANS {
+			if !agwConnectedModeAllowed(cmd.Header.Portx) {
 				text_color_set(DW_COLOR_ERROR)
-				dw_printf("AGW 'd' command on non-radio channel %d ignored.\n", cmd.Header.Portx)
+				dw_printf("AGW 'd' command on unsupported channel %d ignored.\n", cmd.Header.Portx)
 				break
 			}
 
@@ -1558,9 +1569,9 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 		// We will send a request to it and the result coming out will be used to
 		// send the reply back to the client application.
 		{
-			if int(cmd.Header.Portx) >= MAX_RADIO_CHANS {
+			if !agwConnectedModeAllowed(cmd.Header.Portx) {
 				text_color_set(DW_COLOR_ERROR)
-				dw_printf("AGW 'Y' command on non-radio channel %d ignored.\n", cmd.Header.Portx)
+				dw_printf("AGW 'Y' command on unsupported channel %d ignored.\n", cmd.Header.Portx)
 				break
 			}
 

--- a/src/server_impl_test.go
+++ b/src/server_impl_test.go
@@ -410,3 +410,83 @@ func TestHandleClientCommand_v_PopulatesDigipeaters(t *testing.T) {
 	assert.Equal(t, "Q3TEST", item.addrs[AX25_REPEATER_1])
 	assert.Equal(t, "Q4TEST", item.addrs[AX25_REPEATER_1+1])
 }
+
+func TestAgwConnectedModeAllowed_OutOfRange(t *testing.T) {
+	var cfg audio_s
+	save_audio_config_p = &cfg
+	t.Cleanup(func() { save_audio_config_p = nil })
+
+	assert.False(t, agwConnectedModeAllowed(MAX_TOTAL_CHANS))
+	assert.False(t, agwConnectedModeAllowed(255))
+}
+
+func TestAgwConnectedModeAllowed_NilConfig_RadioRange(t *testing.T) {
+	save_audio_config_p = nil
+
+	assert.True(t, agwConnectedModeAllowed(0))
+	assert.True(t, agwConnectedModeAllowed(MAX_RADIO_CHANS-1))
+}
+
+func TestAgwConnectedModeAllowed_NilConfig_NCHANNELRange(t *testing.T) {
+	save_audio_config_p = nil
+
+	assert.False(t, agwConnectedModeAllowed(MAX_RADIO_CHANS))
+}
+
+func TestAgwConnectedModeAllowed_MediumRadio(t *testing.T) {
+	var cfg audio_s
+	cfg.chan_medium[0] = MEDIUM_RADIO
+	save_audio_config_p = &cfg
+	t.Cleanup(func() { save_audio_config_p = nil })
+
+	assert.True(t, agwConnectedModeAllowed(0))
+}
+
+func TestAgwConnectedModeAllowed_MediumNETTNC(t *testing.T) {
+	var cfg audio_s
+	cfg.chan_medium[MAX_RADIO_CHANS] = MEDIUM_NETTNC
+	save_audio_config_p = &cfg
+	t.Cleanup(func() { save_audio_config_p = nil })
+
+	assert.True(t, agwConnectedModeAllowed(MAX_RADIO_CHANS))
+}
+
+func TestAgwConnectedModeAllowed_MediumIGate(t *testing.T) {
+	var cfg audio_s
+	cfg.chan_medium[0] = MEDIUM_IGATE
+	save_audio_config_p = &cfg
+	t.Cleanup(func() { save_audio_config_p = nil })
+
+	assert.False(t, agwConnectedModeAllowed(0))
+}
+
+func TestAgwConnectedModeAllowed_MediumNone(t *testing.T) {
+	var cfg audio_s
+	// chan_medium[0] defaults to MEDIUM_NONE
+	save_audio_config_p = &cfg
+	t.Cleanup(func() { save_audio_config_p = nil })
+
+	assert.False(t, agwConnectedModeAllowed(0))
+}
+
+func TestHandleClientCommand_X_NETTNCChannelReportsSuccess(t *testing.T) {
+	var cfg audio_s
+	cfg.chan_medium[MAX_RADIO_CHANS] = MEDIUM_NETTNC
+	save_audio_config_p = &cfg
+	t.Cleanup(func() { save_audio_config_p = nil })
+
+	var client = setupClientPipe(t)
+	var replyCh = asyncReply(client)
+
+	var cmd = new(AGWPEMessage)
+	cmd.Header.DataKind = 'X'
+	cmd.Header.Portx = MAX_RADIO_CHANS
+	copy(cmd.Header.CallFrom[:], "Q1TEST")
+	handleClientCommand(0, cmd)
+
+	var reply = <-replyCh
+	require.NotNil(t, reply)
+	assert.Equal(t, byte('X'), reply.Header.DataKind)
+	require.Len(t, reply.Data, 1)
+	assert.Equal(t, byte(1), reply.Data[0]) // success
+}

--- a/src/tq.go
+++ b/src/tq.go
@@ -406,13 +406,16 @@ func lm_data_request(channel int, prio int, pp *packet_t) {
 	#endif
 	*/
 
+	if channel >= 0 && channel < MAX_TOTAL_CHANS && save_audio_config_p.chan_medium[channel] == MEDIUM_NETTNC {
+		// For NETTNC channels, just yeet out the packet and let the external TNC handle it - we don't have enough info to do much else
+		tq_append(channel, prio, pp)
+		return
+	}
+
 	if channel < 0 || channel >= MAX_RADIO_CHANS || save_audio_config_p.chan_medium[channel] != MEDIUM_RADIO {
-		// Connected mode is allowed only with internal modems.
 		text_color_set(DW_COLOR_ERROR)
-		dw_printf("ERROR - Request to transmit on invalid radio channel %d.\n", channel)
-		dw_printf("Connected packet mode is allowed only with internal modems.\n")
-		dw_printf("Why aren't external KISS modems allowed?  See\n")
-		dw_printf("Why-is-9600-only-twice-as-fast-as-1200.pdf for explanation.\n")
+		dw_printf("ERROR - Request to transmit on unsupported channel %d.\n", channel)
+		dw_printf("Connected packet mode requires MEDIUM_RADIO or MEDIUM_NETTNC.\n")
 		ax25_delete(pp)
 
 		return
@@ -548,13 +551,17 @@ func lm_seize_request(channel int) {
 	#endif
 	*/
 
+	if channel >= 0 && channel < MAX_TOTAL_CHANS && save_audio_config_p.chan_medium[channel] == MEDIUM_NETTNC {
+		// MEDIUM_NETTNC: no internal modem to seize; confirm the channel immediately.
+		// See lm_data_request for the rationale for allowing MEDIUM_NETTNC.
+		dlq_seize_confirm(channel)
+		return
+	}
+
 	if channel < 0 || channel >= MAX_RADIO_CHANS || save_audio_config_p.chan_medium[channel] != MEDIUM_RADIO {
-		// Connected mode is allowed only with internal modems.
 		text_color_set(DW_COLOR_ERROR)
-		dw_printf("ERROR - Request to transmit on invalid radio channel %d.\n", channel)
-		dw_printf("Connected packet mode is allowed only with internal modems.\n")
-		dw_printf("Why aren't external KISS modems allowed?  See\n")
-		dw_printf("Why-is-9600-only-twice-as-fast-as-1200.pdf for explanation.\n")
+		dw_printf("ERROR - Request to transmit on unsupported channel %d.\n", channel)
+		dw_printf("Connected packet mode requires MEDIUM_RADIO or MEDIUM_NETTNC.\n")
 
 		return
 	}


### PR DESCRIPTION
This enables pointing samoyed-direwolf at e.g. an AXUDP gateway that
acts as a simple KISS transport, then using Samoyed's AX.25 packet
engine to interact with a remote node.

The original restriction to MEDIUM_RADIO looks to have been deliberate,
on the basis that a KISS interface does not expose PTT state or DCD to
the AX.25 state machine, so collision avoidance cannot work correctly
over a real radio channel. See
Why-is-9600-only-twice-as-fast-as-1200.pdf for the full argument.

Now MEDIUM_NETTNC is deliberately allowed, despite also being a KISS
interface: the channel may not involve a real radio link at all (e.g.
an AXTCP gateway), and even when it does, I want to enable the user to
choose to accept the caveats.
