### PR TITLE
feat: Implement RHP2 (Remote Host Protocol) server

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters:
     exhaustive:
       default-signifies-exhaustive: true  # Soften the check for now...
     gocognit:
-      min-complexity: 1804  # I sure wish this could be lower
+      min-complexity: 1806  # I sure wish this could be lower
     goconst:
       min-occurrences: 10
     gocritic:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters:
     exhaustive:
       default-signifies-exhaustive: true  # Soften the check for now...
     gocognit:
-      min-complexity: 1800  # I sure wish this could be lower
+      min-complexity: 1804  # I sure wish this could be lower
     goconst:
       min-occurrences: 10
     gocritic:

--- a/src/config.go
+++ b/src/config.go
@@ -4699,8 +4699,11 @@ func config_init(fname string, p_audio_config *audio_s,
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Config file: Missing port number on line %d.\n", line)
 			} else {
-				var n, _ = strconv.Atoi(t)
-				if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
+				var n, nerr = strconv.Atoi(t)
+				if nerr != nil {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file: Invalid (non-numeric) port number for RHPPORT on line %d.\n", line)
+				} else if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
 					p_misc_config.rhp_port = n
 				} else {
 					text_color_set(DW_COLOR_ERROR)

--- a/src/config.go
+++ b/src/config.go
@@ -134,6 +134,7 @@ type beacon_s struct {
 
 type misc_config_s struct {
 	agwpe_port int /* TCP Port number for the "AGW TCPIP Socket Interface" */
+	rhp_port   int /* TCP Port number for the "Remote Host Protocol" interface. 0 = disabled. */
 
 	// Previously we allowed only a single TCP port for KISS.
 	// An increasing number of people want to run multiple radios.
@@ -249,6 +250,7 @@ const MAX_IP_PORT_NUMBER = 49151
 
 const DEFAULT_AGWPE_PORT = 8000 /* Like everyone else. */
 const DEFAULT_KISS_PORT = 8001  /* Above plus 1. */
+const DEFAULT_RHP_PORT = 9000   /* Remote Host Protocol. */
 
 const DEFAULT_NULLMODEM = "COM3" /* should be equiv. to /dev/ttyS2 on Cygwin */
 
@@ -4687,6 +4689,25 @@ func config_init(fname string, p_audio_config *audio_s,
 					dw_printf("Line %d: Too many KISSPORT commands.\n", line)
 				}
 			}
+		} else if strings.EqualFold(t, "RHPPORT") {
+			/*
+			 * RHPPORT n		- TCP port number for the Remote Host Protocol (RHP2) interface.
+			 *			  0 to disable.
+			 */
+			t = split("", false)
+			if t == "" {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file: Missing port number on line %d.\n", line)
+			} else {
+				var n, _ = strconv.Atoi(t)
+				if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {
+					p_misc_config.rhp_port = n
+				} else {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file: Invalid port number for RHPPORT on line %d.\n", line)
+				}
+			}
+
 		} else if strings.EqualFold(t, "NULLMODEM") || strings.EqualFold(t, "SERIALKISS") {
 			/*
 			 * NULLMODEM name [ speed ]	- Device name for serial port or our end of the virtual "null modem"

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -53,6 +53,7 @@ var waypointSender *WaypointSender
 var telemetryState = NewTelemetryState()
 var beaconService *BeaconService
 var kissNetSvc *KissNetService
+var rhpSvc *RHPService
 var mheardDB *MHeardDB
 var xmitSvc *XmitService
 var ttGateway *TTGateway
@@ -751,6 +752,7 @@ x = Silence FX.25 information.`)
 	server_init(audio_config, misc_config)
 	kissNetSvc = NewKissNetService(misc_config)
 	kissNetSvc.SetDebug(d_n_opt)
+	rhpSvc = NewRHPService(misc_config)
 
 	// TODO KG This checks `misc_config.kiss_port > 0` but `kiss_port` is now an array?
 	// Let's just check [0] for now...
@@ -1128,6 +1130,7 @@ func app_process_rec_packet(channel int, subchan int, slice int, pp *packet_t, a
 	kissNetSvc.SendRecPacket(channel, KISS_CMD_DATA_FRAME, fbuf, len(fbuf), nil, -1)   // KISS TCP
 	kissserial_send_rec_packet(channel, KISS_CMD_DATA_FRAME, fbuf, len(fbuf), nil, -1) // KISS serial port
 	kisspt_send_rec_packet(channel, KISS_CMD_DATA_FRAME, fbuf, len(fbuf), nil, -1)     // KISS pseudo terminal
+	rhpSvc.SendRecFrame(channel, pp, fbuf)                                             // RHP2 JSON API
 
 	if A_opt_ais_to_obj && len(ais_obj_packet) != 0 {
 		var ao_pp = ax25_from_text(ais_obj_packet, true)
@@ -1138,6 +1141,7 @@ func app_process_rec_packet(channel int, subchan int, slice int, pp *packet_t, a
 			kissNetSvc.SendRecPacket(channel, KISS_CMD_DATA_FRAME, ao_fbuf, len(ao_fbuf), nil, -1)
 			kissserial_send_rec_packet(channel, KISS_CMD_DATA_FRAME, ao_fbuf, len(ao_fbuf), nil, -1)
 			kisspt_send_rec_packet(channel, KISS_CMD_DATA_FRAME, ao_fbuf, len(ao_fbuf), nil, -1)
+			rhpSvc.SendRecFrame(channel, ao_pp, ao_fbuf)
 			ax25_delete(ao_pp)
 		}
 	}

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -765,8 +765,18 @@ func (svc *RHPService) handleSend(c *rhpClient, env map[string]json.RawMessage) 
 		return
 	}
 
+	// Copy the fields we need from the socket while holding c.mu to avoid
+	// a data race: LinkEstablished can mutate sock.remote concurrently.
 	c.mu.Lock()
 	var sock, ok = c.sockets[handle]
+	var sockMode, sockLocal, sockRemote string
+	var sockPort int
+	if ok {
+		sockMode = sock.mode
+		sockLocal = sock.local
+		sockRemote = sock.remote
+		sockPort = sock.port
+	}
 	c.mu.Unlock()
 	if !ok {
 		sendReply_(handle, rhpErrInvalidHandle, 0, "invalid handle")
@@ -775,11 +785,11 @@ func (svc *RHPService) handleSend(c *rhpClient, env map[string]json.RawMessage) 
 
 	var payload = []byte(data)
 
-	switch sock.mode {
+	switch sockMode {
 	case "dgram":
 		// Determine source and destination callsigns.
-		var src = sock.local
-		var dst = sock.remote
+		var src = sockLocal
+		var dst = sockRemote
 		// Allow per-send override of remote from the SEND message fields.
 		var remoteOverride = strings.ToUpper(optRHPStr(env, "remote"))
 		if remoteOverride != "" {
@@ -789,7 +799,7 @@ func (svc *RHPService) handleSend(c *rhpClient, env map[string]json.RawMessage) 
 			sendReply_(handle, rhpErrBadParam, 0, "dgram send requires local and remote callsigns")
 			return
 		}
-		var channel = sock.port
+		var channel = sockPort
 		if channel < 0 {
 			channel = 0 // default to channel 0 if "all channels"
 		}
@@ -805,17 +815,17 @@ func (svc *RHPService) handleSend(c *rhpClient, env map[string]json.RawMessage) 
 		sendReply_(handle, rhpErrOk, 0, "Ok")
 
 	case "stream":
-		if sock.local == "" || sock.remote == "" {
+		if sockLocal == "" || sockRemote == "" {
 			sendReply_(handle, rhpErrBadParam, 0, "stream send requires established connection")
 			return
 		}
-		var channel = sock.port
+		var channel = sockPort
 		if channel < 0 {
 			channel = 0
 		}
 		var addrs [AX25_MAX_ADDRS]string
-		addrs[AX25_SOURCE] = sock.local
-		addrs[AX25_DESTINATION] = sock.remote
+		addrs[AX25_SOURCE] = sockLocal
+		addrs[AX25_DESTINATION] = sockRemote
 		dlq_xmit_data_request(addrs, 2, channel, MAX_NET_CLIENTS+handle, AX25_PID_NO_LAYER_3, payload)
 		sendReply_(handle, rhpErrOk, rhpFlagConnected, "Ok")
 

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -64,8 +64,8 @@ const (
 type rhpAuthReply struct {
 	Type    string `json:"type"`
 	ID      int    `json:"id,omitempty"`
-	ErrCode int    `json:"errCode"`
-	ErrText string `json:"errText"`
+	ErrCode int    `json:"errcode"`
+	ErrText string `json:"errtext"`
 }
 
 // rhpOpenReply is the server response to an OPEN message.

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -251,15 +251,25 @@ func (svc *RHPService) LinkTerminated(_ int, rhpHandle int, _ string, _ string, 
 	if svc.port == 0 {
 		return
 	}
-	var c, sock = svc.findClientByRHPHandle(rhpHandle)
+	var c, _ = svc.findClientByRHPHandle(rhpHandle)
 	if c == nil {
 		return
 	}
 
 	// Remove the socket from the client's map since the link is gone.
 	c.mu.Lock()
-	delete(c.sockets, rhpHandle)
+	var sock, ok = c.sockets[rhpHandle]
+	if ok {
+		delete(c.sockets, rhpHandle)
+	}
 	c.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	// Clean up dlq resources while NOT holding c.mu.
+	svc.cleanupSocket(sock)
 
 	var msg = rhpCloseMsg{
 		Type:   "close",

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -609,9 +609,11 @@ func (svc *RHPService) handleOpen(c *rhpClient, env map[string]json.RawMessage) 
 	if portStr != "" && portStr != "-1" {
 		var n int
 		var _, serr = fmt.Sscanf(portStr, "%d", &n)
-		if serr == nil {
-			channel = n
+		if serr != nil {
+			sendReply(0, rhpErrBadParam, fmt.Sprintf("invalid port %q", portStr))
+			return
 		}
+		channel = n
 	}
 
 	// Allocate a handle for this socket.

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -394,11 +394,6 @@ func (svc *RHPService) SendRecFrame(channel int, pp *packet_t, fbuf []byte) {
 	}
 }
 
-// incSeqno returns the next global sequence number.
-func (svc *RHPService) incSeqno() int {
-	return int(svc.seqno.Add(1))
-}
-
 // Close shuts down the RHP2 server by closing the TCP listener.
 // It is a no-op if the service is disabled or already closed.
 func (svc *RHPService) Close() error {
@@ -409,6 +404,11 @@ func (svc *RHPService) Close() error {
 		return nil
 	}
 	return ln.Close()
+}
+
+// incSeqno returns the next global sequence number.
+func (svc *RHPService) incSeqno() int {
+	return int(svc.seqno.Add(1))
 }
 
 // listen accepts incoming TCP connections.

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -1,0 +1,867 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package direwolf
+
+/*------------------------------------------------------------------
+ *
+ * Purpose:	Provide service to other applications via the Remote
+ *		Host Protocol Version 2 (RHP2), as described in
+ *		https://wiki.oarc.uk/packet:white-papers:pwp-0222
+ *
+ * Description:	Listens on a configurable TCP port (disabled by default;
+ *		set RHPPORT in configuration to enable).  Client applications
+ *		connect and send/receive JSON messages framed with a 2-byte
+ *		big-endian length header.
+ *
+ *		Supported protocol family: AX25
+ *		Supported modes: dgram (UI frames), stream (connected),
+ *		                 trace (decoded monitoring), raw (binary)
+ *
+ *		Connected-mode (stream) sockets use the same ax25_link
+ *		state machine as the AGW server.  The "client" IDs used
+ *		with dlq_* functions are offset by MAX_NET_CLIENTS to
+ *		avoid collisions with AGW client indices.
+ *
+ *------------------------------------------------------------------*/
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// RHP2 error codes from the spec.
+const (
+	rhpErrOk            = 0
+	rhpErrInvalidHandle = 3
+	rhpErrBadParam      = 12
+)
+
+// RHP2 status flags (STATUS message, server→client).
+const (
+	rhpFlagConnected = 2 // Downlink is connected
+)
+
+// RHP2 OPEN flags.
+const (
+	rhpOpenFlagActiveOpen = 0x80
+)
+
+// RHP2 TRACE flags.
+const (
+	rhpTraceFlagIncoming = 0x01
+)
+
+// rhpAuthReply is the server response to an AUTH message.
+type rhpAuthReply struct {
+	Type    string `json:"type"`
+	ID      int    `json:"id,omitempty"`
+	ErrCode int    `json:"errCode"`
+	ErrText string `json:"errText"`
+}
+
+// rhpOpenReply is the server response to an OPEN message.
+type rhpOpenReply struct {
+	Type    string `json:"type"`
+	ID      int    `json:"id,omitempty"`
+	Handle  int    `json:"handle"`
+	ErrCode int    `json:"errcode"`
+	ErrText string `json:"errtext"`
+}
+
+// rhpCloseReply is the server response to a client-initiated CLOSE message.
+type rhpCloseReply struct {
+	Type    string `json:"type"`
+	ID      int    `json:"id,omitempty"`
+	Handle  int    `json:"handle"`
+	ErrCode int    `json:"errcode"`
+	ErrText string `json:"errtext"`
+}
+
+// rhpSendReply is the server response to a SEND message.
+type rhpSendReply struct {
+	Type    string `json:"type"`
+	ID      int    `json:"id,omitempty"`
+	Handle  int    `json:"handle"`
+	ErrCode int    `json:"errcode"`
+	ErrText string `json:"errtext"`
+	Status  int    `json:"status,omitempty"`
+}
+
+// rhpAcceptMsg is the server-initiated ACCEPT notification (incoming connection).
+type rhpAcceptMsg struct {
+	Type   string `json:"type"`
+	SeqNo  int    `json:"seqno"`
+	Handle int    `json:"handle"`
+	Remote string `json:"remote"`
+	Local  string `json:"local"`
+	Port   int    `json:"port"`
+}
+
+// rhpStatusMsg is the server-initiated STATUS notification.
+type rhpStatusMsg struct {
+	Type   string `json:"type"`
+	SeqNo  int    `json:"seqno"`
+	Handle int    `json:"handle"`
+	Flags  int    `json:"flags"`
+}
+
+// rhpCloseMsg is the server-initiated CLOSE notification (link terminated).
+type rhpCloseMsg struct {
+	Type   string `json:"type"`
+	SeqNo  int    `json:"seqno"`
+	Handle int    `json:"handle"`
+}
+
+// rhpRecvMsg is the server-initiated RECV notification for connected-mode data.
+type rhpRecvMsg struct {
+	Type   string `json:"type"`
+	SeqNo  int    `json:"seqno"`
+	Handle int    `json:"handle"`
+	Data   string `json:"data"`
+}
+
+// rhpTraceRecv is the server-initiated RECV notification for trace-mode frames.
+type rhpTraceRecv struct {
+	Type      string `json:"type"`
+	SeqNo     int    `json:"seqno"`
+	Handle    int    `json:"handle"`
+	Action    string `json:"action"`
+	Port      string `json:"port"`
+	Srce      string `json:"srce"`
+	Dest      string `json:"dest"`
+	Ctrl      int    `json:"ctrl"`
+	FrameType string `json:"frametype"`
+}
+
+// rhpRawRecv is the server-initiated RECV notification for raw-mode frames.
+type rhpRawRecv struct {
+	Type   string `json:"type"`
+	SeqNo  int    `json:"seqno"`
+	Handle int    `json:"handle"`
+	Action string `json:"action"`
+	Port   string `json:"port"`
+	Data   string `json:"data"`
+}
+
+// rhpDgramRecv is the server-initiated RECV notification for dgram-mode frames.
+type rhpDgramRecv struct {
+	Type   string `json:"type"`
+	SeqNo  int    `json:"seqno"`
+	Handle int    `json:"handle"`
+	Port   string `json:"port"`
+	Data   string `json:"data"`
+}
+
+// rhpSocket represents one virtual socket held by an RHP client.
+type rhpSocket struct {
+	handle int
+	pfam   string // "ax25"
+	mode   string // "dgram", "stream", "trace", "raw"
+	port   int    // radio channel (-1 = all)
+	local  string // local callsign, uppercase
+	remote string // remote callsign (for stream connect), uppercase
+	flags  int    // open/trace flags
+	linked bool   // dlq_register_callsign has been called (stream passive)
+}
+
+// rhpClient represents one TCP connection to the RHP server.
+type rhpClient struct {
+	conn       net.Conn
+	mu         sync.Mutex
+	sockets    map[int]*rhpSocket
+	nextHandle int
+}
+
+// RHPService is the top-level RHP2 server.
+type RHPService struct {
+	port  int
+	mu    sync.Mutex
+	cs    []*rhpClient
+	seqno atomic.Int32
+}
+
+// NewRHPService creates a new RHP service.  If the configured port is 0
+// the service is disabled (all methods are no-ops).
+func NewRHPService(mc *misc_config_s) *RHPService {
+	var svc = new(RHPService)
+	svc.port = mc.rhp_port
+	if svc.port == 0 {
+		text_color_set(DW_COLOR_INFO)
+		dw_printf("RHP2: Disabled.  Use RHPPORT in configuration to enable.\n")
+		return svc
+	}
+	text_color_set(DW_COLOR_INFO)
+	dw_printf("RHP2: Listening on TCP port %d.\n", svc.port)
+	go svc.listen()
+	return svc
+}
+
+// LinkEstablished is called when an AX.25 connection has been established.
+// It sends a STATUS (connected) to the socket owner.
+// For incoming connections (passive listener), it also sends an ACCEPT.
+func (svc *RHPService) LinkEstablished(channel int, rhpHandle int, remote string, own string, incoming bool) {
+	if svc.port == 0 {
+		return
+	}
+	var c, sock = svc.findClientByRHPHandle(rhpHandle)
+	if c == nil {
+		return
+	}
+
+	if incoming {
+		// The socket is a passive listener.  The connection arrived on it.
+		// Update remote address on the socket.
+		c.mu.Lock()
+		sock.remote = strings.ToUpper(remote)
+		c.mu.Unlock()
+
+		var msg = rhpAcceptMsg{
+			Type:   "accept",
+			SeqNo:  svc.incSeqno(),
+			Handle: sock.handle,
+			Remote: remote,
+			Local:  own,
+			Port:   channel,
+		}
+		writeRHPMsg(c, msg) //nolint:errcheck
+	}
+
+	// Send STATUS: CONNECTED.
+	var status = rhpStatusMsg{
+		Type:   "status",
+		SeqNo:  svc.incSeqno(),
+		Handle: sock.handle,
+		Flags:  rhpFlagConnected,
+	}
+	writeRHPMsg(c, status) //nolint:errcheck
+}
+
+// LinkTerminated is called when an AX.25 connection has been terminated.
+// It sends a server-initiated CLOSE to the socket owner.
+func (svc *RHPService) LinkTerminated(_ int, rhpHandle int, _ string, _ string, _ bool) {
+	if svc.port == 0 {
+		return
+	}
+	var c, sock = svc.findClientByRHPHandle(rhpHandle)
+	if c == nil {
+		return
+	}
+
+	// Remove the socket from the client's map since the link is gone.
+	c.mu.Lock()
+	delete(c.sockets, rhpHandle)
+	c.mu.Unlock()
+
+	var msg = rhpCloseMsg{
+		Type:   "close",
+		SeqNo:  svc.incSeqno(),
+		Handle: sock.handle,
+	}
+	writeRHPMsg(c, msg) //nolint:errcheck
+}
+
+// RecConnData is called when connected data has been received from the remote station.
+// It sends a RECV message to the socket owner.
+func (svc *RHPService) RecConnData(_ int, rhpHandle int, _ string, _ string, _ int, data []byte) {
+	if svc.port == 0 {
+		return
+	}
+	var c, sock = svc.findClientByRHPHandle(rhpHandle)
+	if c == nil {
+		return
+	}
+
+	var msg = rhpRecvMsg{
+		Type:   "recv",
+		SeqNo:  svc.incSeqno(),
+		Handle: sock.handle,
+		Data:   string(data),
+	}
+	writeRHPMsg(c, msg) //nolint:errcheck
+}
+
+// SendRecFrame is called from app_process_rec_packet for every received frame.
+// It routes the frame to matching sockets across all connected RHP clients.
+func (svc *RHPService) SendRecFrame(channel int, pp *packet_t, fbuf []byte) {
+	if svc.port == 0 {
+		return
+	}
+	if pp == nil {
+		return
+	}
+
+	var src = ax25_get_addr_with_ssid(pp, AX25_SOURCE)
+	var dst = ax25_get_addr_with_ssid(pp, AX25_DESTINATION)
+	var info = ax25_get_info(pp)
+
+	// Get frame type description for TRACE mode.
+	var _, ftypeDesc, _, _, _, _ = ax25_frame_type(pp)
+
+	// Get the control byte from the raw frame (after the addresses).
+	var ctrl = 0
+	if len(fbuf) > ax25_get_num_addr(pp)*7 {
+		ctrl = int(fbuf[ax25_get_num_addr(pp)*7])
+	}
+
+	svc.mu.Lock()
+	var clients = make([]*rhpClient, len(svc.cs))
+	copy(clients, svc.cs)
+	svc.mu.Unlock()
+
+	for _, c := range clients {
+		c.mu.Lock()
+		var sockets = make([]*rhpSocket, 0, len(c.sockets))
+		for _, s := range c.sockets {
+			sockets = append(sockets, s)
+		}
+		c.mu.Unlock()
+
+		for _, sock := range sockets {
+			if !channelMatches(sock.port, channel) {
+				continue
+			}
+
+			switch sock.mode {
+			case "trace":
+				// Deliver decoded frame metadata.
+				// 0x01 = incoming frames flag; all frames here are received.
+				if sock.flags&rhpTraceFlagIncoming == 0 {
+					continue
+				}
+				var msg = rhpTraceRecv{
+					Type:      "recv",
+					SeqNo:     svc.incSeqno(),
+					Handle:    sock.handle,
+					Action:    "rcvd",
+					Port:      fmt.Sprintf("%d", channel),
+					Srce:      src,
+					Dest:      dst,
+					Ctrl:      ctrl,
+					FrameType: ftypeDesc,
+				}
+				writeRHPMsg(c, msg) //nolint:errcheck
+
+			case "raw":
+				// Deliver raw frame bytes as base64.
+				if sock.flags&rhpTraceFlagIncoming == 0 {
+					continue
+				}
+				var msg = rhpRawRecv{
+					Type:   "recv",
+					SeqNo:  svc.incSeqno(),
+					Handle: sock.handle,
+					Action: "rcvd",
+					Port:   fmt.Sprintf("%d", channel),
+					Data:   base64.StdEncoding.EncodeToString(fbuf),
+				}
+				writeRHPMsg(c, msg) //nolint:errcheck
+
+			case "dgram":
+				// Deliver payload if destination matches (or socket is unbound).
+				if sock.local != "" && !strings.EqualFold(dst, sock.local) {
+					continue
+				}
+				var msg = rhpDgramRecv{
+					Type:   "recv",
+					SeqNo:  svc.incSeqno(),
+					Handle: sock.handle,
+					Port:   fmt.Sprintf("%d", channel),
+					Data:   string(info),
+				}
+				writeRHPMsg(c, msg) //nolint:errcheck
+			}
+		}
+	}
+}
+
+// incSeqno returns the next global sequence number.
+func (svc *RHPService) incSeqno() int {
+	return int(svc.seqno.Add(1))
+}
+
+// listen accepts incoming TCP connections.
+func (svc *RHPService) listen() {
+	var ln, err = net.Listen("tcp", fmt.Sprintf(":%d", svc.port))
+	if err != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("RHP2: Failed to listen on port %d: %v\n", svc.port, err)
+		return
+	}
+	defer ln.Close()
+
+	for {
+		var conn, aerr = ln.Accept()
+		if aerr != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("RHP2: Accept error: %v\n", aerr)
+			continue
+		}
+		var c = &rhpClient{
+			conn:       conn,
+			mu:         sync.Mutex{},
+			sockets:    make(map[int]*rhpSocket),
+			nextHandle: 0,
+		}
+		svc.mu.Lock()
+		svc.cs = append(svc.cs, c)
+		svc.mu.Unlock()
+		text_color_set(DW_COLOR_INFO)
+		dw_printf("RHP2: Client connected from %s\n", conn.RemoteAddr())
+		go svc.handleClient(c)
+	}
+}
+
+// removeClient removes a client from the service's list.
+func (svc *RHPService) removeClient(c *rhpClient) {
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	for i, x := range svc.cs {
+		if x == c {
+			svc.cs = append(svc.cs[:i], svc.cs[i+1:]...)
+			return
+		}
+	}
+}
+
+// handleClient is the receive loop for one TCP connection.
+func (svc *RHPService) handleClient(c *rhpClient) {
+	defer func() {
+		// Clean up all open sockets.
+		c.mu.Lock()
+		for _, sock := range c.sockets {
+			svc.cleanupSocket(sock)
+		}
+		c.sockets = make(map[int]*rhpSocket)
+		c.mu.Unlock()
+
+		c.conn.Close()
+		svc.removeClient(c)
+		text_color_set(DW_COLOR_INFO)
+		dw_printf("RHP2: Client disconnected.\n")
+	}()
+
+	for {
+		var buf, err = readRHPMsg(c.conn)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("RHP2: Read error: %v\n", err)
+			}
+			return
+		}
+
+		// Decode enough to get the type field.
+		var envelope map[string]json.RawMessage
+		var uerr = json.Unmarshal(buf, &envelope)
+		if uerr != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("RHP2: JSON parse error: %v\n", uerr)
+			continue
+		}
+
+		var typRaw, hasType = envelope["type"]
+		if !hasType {
+			continue
+		}
+		var typStr string
+		var terr = json.Unmarshal(typRaw, &typStr)
+		if terr != nil {
+			continue
+		}
+
+		switch strings.ToLower(typStr) {
+		case "auth":
+			svc.handleAuth(c, envelope)
+		case "open":
+			svc.handleOpen(c, envelope)
+		case "close":
+			svc.handleClose(c, envelope)
+		case "send":
+			svc.handleSend(c, envelope)
+		default:
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("RHP2: Unknown message type %q, ignoring.\n", typStr)
+		}
+	}
+}
+
+// cleanupSocket releases resources held by a socket.
+// Must NOT be called with c.mu held.
+func (svc *RHPService) cleanupSocket(sock *rhpSocket) {
+	if sock.mode != "stream" {
+		return
+	}
+	if sock.linked {
+		// Unregister callsign for passive listener.
+		dlq_unregister_callsign(sock.local, sock.port, MAX_NET_CLIENTS+sock.handle)
+	} else {
+		// Disconnect active/established connection.
+		var addrs [AX25_MAX_ADDRS]string
+		addrs[AX25_SOURCE] = sock.local
+		addrs[AX25_DESTINATION] = sock.remote
+		dlq_disconnect_request(addrs, 2, sock.port, MAX_NET_CLIENTS+sock.handle)
+	}
+}
+
+// findClientByRHPHandle searches all RHP clients for the socket with the given handle.
+// Returns nil, nil if not found.
+func (svc *RHPService) findClientByRHPHandle(rhpHandle int) (*rhpClient, *rhpSocket) {
+	svc.mu.Lock()
+	var clients = make([]*rhpClient, len(svc.cs))
+	copy(clients, svc.cs)
+	svc.mu.Unlock()
+
+	for _, c := range clients {
+		c.mu.Lock()
+		var sock = c.sockets[rhpHandle]
+		c.mu.Unlock()
+		if sock != nil {
+			return c, sock
+		}
+	}
+	return nil, nil
+}
+
+// handleAuth handles the AUTH message.  We accept all connections without
+// checking credentials (local/LAN clients don't require authentication per spec).
+func (svc *RHPService) handleAuth(c *rhpClient, env map[string]json.RawMessage) {
+	var id, hasID = optRHPInt(env, "id")
+
+	var replyID = 0
+	if hasID {
+		replyID = id
+	}
+	var reply = rhpAuthReply{
+		Type:    "authReply",
+		ID:      replyID,
+		ErrCode: rhpErrOk,
+		ErrText: "Ok",
+	}
+	writeRHPMsg(c, reply) //nolint:errcheck
+}
+
+// handleOpen handles the OPEN message (create a virtual socket).
+func (svc *RHPService) handleOpen(c *rhpClient, env map[string]json.RawMessage) {
+	var id, hasID = optRHPInt(env, "id")
+	var pfam = strings.ToLower(optRHPStr(env, "pfam"))
+	var mode = strings.ToLower(optRHPStr(env, "mode"))
+	var portStr = optRHPStr(env, "port")
+	var local = strings.ToUpper(optRHPStr(env, "local"))
+	var remote = strings.ToUpper(optRHPStr(env, "remote"))
+	var flags, _ = optRHPInt(env, "flags")
+
+	var replyID = 0
+	if hasID {
+		replyID = id
+	}
+
+	sendReply := func(handle, code int, text string) {
+		var r = rhpOpenReply{
+			Type:    "openReply",
+			ID:      replyID,
+			Handle:  handle,
+			ErrCode: code,
+			ErrText: text,
+		}
+		writeRHPMsg(c, r) //nolint:errcheck
+	}
+
+	if pfam != "ax25" {
+		sendReply(0, rhpErrBadParam, fmt.Sprintf("unsupported protocol family %q", pfam))
+		return
+	}
+
+	switch mode {
+	case "dgram", "stream", "trace", "raw":
+		// OK
+	default:
+		sendReply(0, rhpErrBadParam, fmt.Sprintf("unsupported mode %q", mode))
+		return
+	}
+
+	// Parse port (channel).  Empty or "-1" means all channels.
+	var channel = -1
+	if portStr != "" && portStr != "-1" {
+		var n int
+		var _, serr = fmt.Sscanf(portStr, "%d", &n)
+		if serr == nil {
+			channel = n
+		}
+	}
+
+	// Allocate a handle for this socket.
+	c.mu.Lock()
+	var handle = c.nextHandle
+	c.nextHandle++
+	var sock = &rhpSocket{
+		handle: handle,
+		pfam:   pfam,
+		mode:   mode,
+		port:   channel,
+		local:  local,
+		remote: remote,
+		flags:  flags,
+		linked: false,
+	}
+	c.sockets[handle] = sock
+	c.mu.Unlock()
+
+	// For stream mode: initiate or register for connections.
+	if mode == "stream" {
+		if flags&rhpOpenFlagActiveOpen != 0 {
+			// Active open: connect to remote station.
+			if local == "" || remote == "" {
+				c.mu.Lock()
+				delete(c.sockets, handle)
+				c.mu.Unlock()
+				sendReply(0, rhpErrBadParam, "stream active open requires local and remote")
+				return
+			}
+			if channel < 0 {
+				c.mu.Lock()
+				delete(c.sockets, handle)
+				c.mu.Unlock()
+				sendReply(0, rhpErrBadParam, "stream active open requires a specific port")
+				return
+			}
+			var addrs [AX25_MAX_ADDRS]string
+			addrs[AX25_SOURCE] = local
+			addrs[AX25_DESTINATION] = remote
+			dlq_connect_request(addrs, 2, channel, MAX_NET_CLIENTS+handle, AX25_PID_NO_LAYER_3)
+		} else {
+			// Passive open: listen for incoming connections on local callsign.
+			if local == "" {
+				c.mu.Lock()
+				delete(c.sockets, handle)
+				c.mu.Unlock()
+				sendReply(0, rhpErrBadParam, "stream passive open requires local callsign")
+				return
+			}
+			if channel < 0 {
+				c.mu.Lock()
+				delete(c.sockets, handle)
+				c.mu.Unlock()
+				sendReply(0, rhpErrBadParam, "stream passive open requires a specific port")
+				return
+			}
+			dlq_register_callsign(local, channel, MAX_NET_CLIENTS+handle)
+			c.mu.Lock()
+			sock.linked = true
+			c.mu.Unlock()
+		}
+	}
+
+	sendReply(handle, rhpErrOk, "ok")
+}
+
+// handleClose handles the CLOSE message from a client.
+func (svc *RHPService) handleClose(c *rhpClient, env map[string]json.RawMessage) {
+	var id, hasID = optRHPInt(env, "id")
+	var handle, hasHandle = optRHPInt(env, "handle")
+
+	var replyID = 0
+	if hasID {
+		replyID = id
+	}
+
+	sendReply := func(h, code int, text string) {
+		var r = rhpCloseReply{
+			Type:    "closeReply",
+			ID:      replyID,
+			Handle:  h,
+			ErrCode: code,
+			ErrText: text,
+		}
+		writeRHPMsg(c, r) //nolint:errcheck
+	}
+
+	if !hasHandle {
+		sendReply(0, rhpErrBadParam, "missing handle")
+		return
+	}
+
+	c.mu.Lock()
+	var sock, ok = c.sockets[handle]
+	if !ok {
+		c.mu.Unlock()
+		sendReply(handle, rhpErrInvalidHandle, "invalid handle")
+		return
+	}
+	delete(c.sockets, handle)
+	c.mu.Unlock()
+
+	svc.cleanupSocket(sock)
+	sendReply(handle, rhpErrOk, "Ok")
+}
+
+// handleSend handles the SEND message from a client.
+func (svc *RHPService) handleSend(c *rhpClient, env map[string]json.RawMessage) {
+	var id, hasID = optRHPInt(env, "id")
+	var handle, hasHandle = optRHPInt(env, "handle")
+	var data = optRHPStr(env, "data")
+
+	var replyID = 0
+	if hasID {
+		replyID = id
+	}
+
+	sendReply_ := func(h, code, status int, text string) {
+		var r = rhpSendReply{
+			Type:    "sendReply",
+			ID:      replyID,
+			Handle:  h,
+			ErrCode: code,
+			ErrText: text,
+			Status:  status,
+		}
+		writeRHPMsg(c, r) //nolint:errcheck
+	}
+
+	if !hasHandle {
+		sendReply_(0, rhpErrBadParam, 0, "missing handle")
+		return
+	}
+
+	c.mu.Lock()
+	var sock, ok = c.sockets[handle]
+	c.mu.Unlock()
+	if !ok {
+		sendReply_(handle, rhpErrInvalidHandle, 0, "invalid handle")
+		return
+	}
+
+	var payload = []byte(data)
+
+	switch sock.mode {
+	case "dgram":
+		// Determine source and destination callsigns.
+		var src = sock.local
+		var dst = sock.remote
+		// Allow per-send override of remote from the SEND message fields.
+		var remoteOverride = strings.ToUpper(optRHPStr(env, "remote"))
+		if remoteOverride != "" {
+			dst = remoteOverride
+		}
+		if src == "" || dst == "" {
+			sendReply_(handle, rhpErrBadParam, 0, "dgram send requires local and remote callsigns")
+			return
+		}
+		var channel = sock.port
+		if channel < 0 {
+			channel = 0 // default to channel 0 if "all channels"
+		}
+		var addrs [AX25_MAX_ADDRS]string
+		addrs[AX25_DESTINATION] = dst
+		addrs[AX25_SOURCE] = src
+		var pp = ax25_u_frame(addrs, 2, cr_cmd, frame_type_U_UI, 0, AX25_PID_NO_LAYER_3, payload)
+		if pp == nil {
+			sendReply_(handle, rhpErrBadParam, 0, "failed to build UI frame")
+			return
+		}
+		tq_append(channel, TQ_PRIO_1_LO, pp)
+		sendReply_(handle, rhpErrOk, 0, "Ok")
+
+	case "stream":
+		if sock.local == "" || sock.remote == "" {
+			sendReply_(handle, rhpErrBadParam, 0, "stream send requires established connection")
+			return
+		}
+		var channel = sock.port
+		if channel < 0 {
+			channel = 0
+		}
+		var addrs [AX25_MAX_ADDRS]string
+		addrs[AX25_SOURCE] = sock.local
+		addrs[AX25_DESTINATION] = sock.remote
+		dlq_xmit_data_request(addrs, 2, channel, MAX_NET_CLIENTS+handle, AX25_PID_NO_LAYER_3, payload)
+		sendReply_(handle, rhpErrOk, rhpFlagConnected, "Ok")
+
+	default:
+		sendReply_(handle, rhpErrBadParam, 0, "send not supported on this socket mode")
+	}
+}
+
+// --- Message framing -------------------------------------------------------
+
+// readRHPMsg reads one RHP2 message: 2-byte BE length followed by that many bytes.
+func readRHPMsg(conn net.Conn) ([]byte, error) {
+	var lenBuf [2]byte
+	var _, rerr = io.ReadFull(conn, lenBuf[:])
+	if rerr != nil {
+		return nil, rerr
+	}
+	var n = binary.BigEndian.Uint16(lenBuf[:])
+	if n == 0 {
+		return []byte{}, nil
+	}
+	var body = make([]byte, n)
+	var _, berr = io.ReadFull(conn, body)
+	if berr != nil {
+		return nil, berr
+	}
+	return body, nil
+}
+
+// writeRHPMsg serialises v as JSON and sends it with a 2-byte BE length header.
+// The caller must hold no locks that would block c.conn.Write.
+//
+//nolint:errchkjson // v is always a concrete struct defined in this file
+func writeRHPMsg(c *rhpClient, v any) error {
+	var data, merr = json.Marshal(v)
+	if merr != nil {
+		return merr
+	}
+	if len(data) > 65535 {
+		return fmt.Errorf("RHP2: message too large (%d bytes)", len(data))
+	}
+	var frame = make([]byte, 2+len(data))
+	binary.BigEndian.PutUint16(frame[:2], uint16(len(data)))
+	copy(frame[2:], data)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var _, werr = c.conn.Write(frame)
+	return werr
+}
+
+// --- Message field helpers --------------------------------------------------
+
+func optRHPInt(env map[string]json.RawMessage, key string) (int, bool) {
+	var raw, ok = env[key]
+	if !ok {
+		return 0, false
+	}
+	var n int
+	var err = json.Unmarshal(raw, &n)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func optRHPStr(env map[string]json.RawMessage, key string) string {
+	var raw, ok = env[key]
+	if !ok {
+		return ""
+	}
+	var s string
+	var err = json.Unmarshal(raw, &s)
+	if err != nil {
+		return ""
+	}
+	return s
+}
+
+// channelMatches returns true if sockPort matches the received channel.
+// sockPort == -1 means "all channels".
+func channelMatches(sockPort, channel int) bool {
+	return sockPort == -1 || sockPort == channel
+}

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -435,13 +435,19 @@ func (svc *RHPService) removeClient(c *rhpClient) {
 // handleClient is the receive loop for one TCP connection.
 func (svc *RHPService) handleClient(c *rhpClient) {
 	defer func() {
-		// Clean up all open sockets.
+		// Copy sockets under lock, then release before cleanup to avoid
+		// deadlock: cleanupSocket must NOT be called with c.mu held.
 		c.mu.Lock()
+		var socksToClear = make([]*rhpSocket, 0, len(c.sockets))
 		for _, sock := range c.sockets {
-			svc.cleanupSocket(sock)
+			socksToClear = append(socksToClear, sock)
 		}
 		c.sockets = make(map[int]*rhpSocket)
 		c.mu.Unlock()
+
+		for _, sock := range socksToClear {
+			svc.cleanupSocket(sock)
+		}
 
 		c.conn.Close()
 		svc.removeClient(c)

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -183,10 +183,11 @@ type rhpClient struct {
 
 // RHPService is the top-level RHP2 server.
 type RHPService struct {
-	port  int
-	mu    sync.Mutex
-	cs    []*rhpClient
-	seqno atomic.Int32
+	port     int
+	mu       sync.Mutex
+	cs       []*rhpClient
+	seqno    atomic.Int32
+	listener net.Listener
 }
 
 // NewRHPService creates a new RHP service.  If the configured port is 0
@@ -398,6 +399,18 @@ func (svc *RHPService) incSeqno() int {
 	return int(svc.seqno.Add(1))
 }
 
+// Close shuts down the RHP2 server by closing the TCP listener.
+// It is a no-op if the service is disabled or already closed.
+func (svc *RHPService) Close() error {
+	svc.mu.Lock()
+	var ln = svc.listener
+	svc.mu.Unlock()
+	if ln == nil {
+		return nil
+	}
+	return ln.Close()
+}
+
 // listen accepts incoming TCP connections.
 func (svc *RHPService) listen() {
 	var ln, err = net.Listen("tcp", fmt.Sprintf(":%d", svc.port))
@@ -406,6 +419,9 @@ func (svc *RHPService) listen() {
 		dw_printf("RHP2: Failed to listen on port %d: %v\n", svc.port, err)
 		return
 	}
+	svc.mu.Lock()
+	svc.listener = ln
+	svc.mu.Unlock()
 	defer ln.Close()
 
 	for {

--- a/src/rhp.go
+++ b/src/rhp.go
@@ -123,10 +123,10 @@ type rhpCloseMsg struct {
 
 // rhpRecvMsg is the server-initiated RECV notification for connected-mode data.
 type rhpRecvMsg struct {
-	Type   string `json:"type"`
-	SeqNo  int    `json:"seqno"`
-	Handle int    `json:"handle"`
-	Data   string `json:"data"`
+	Type   string          `json:"type"`
+	SeqNo  int             `json:"seqno"`
+	Handle int             `json:"handle"`
+	Data   json.RawMessage `json:"data"`
 }
 
 // rhpTraceRecv is the server-initiated RECV notification for trace-mode frames.
@@ -154,11 +154,11 @@ type rhpRawRecv struct {
 
 // rhpDgramRecv is the server-initiated RECV notification for dgram-mode frames.
 type rhpDgramRecv struct {
-	Type   string `json:"type"`
-	SeqNo  int    `json:"seqno"`
-	Handle int    `json:"handle"`
-	Port   string `json:"port"`
-	Data   string `json:"data"`
+	Type   string          `json:"type"`
+	SeqNo  int             `json:"seqno"`
+	Handle int             `json:"handle"`
+	Port   string          `json:"port"`
+	Data   json.RawMessage `json:"data"`
 }
 
 // rhpSocket represents one virtual socket held by an RHP client.
@@ -295,7 +295,7 @@ func (svc *RHPService) RecConnData(_ int, rhpHandle int, _ string, _ string, _ i
 		Type:   "recv",
 		SeqNo:  svc.incSeqno(),
 		Handle: sock.handle,
-		Data:   string(data),
+		Data:   rhpEncodeData(data),
 	}
 	writeRHPMsg(c, msg) //nolint:errcheck
 }
@@ -386,7 +386,7 @@ func (svc *RHPService) SendRecFrame(channel int, pp *packet_t, fbuf []byte) {
 					SeqNo:  svc.incSeqno(),
 					Handle: sock.handle,
 					Port:   fmt.Sprintf("%d", channel),
-					Data:   string(info),
+					Data:   rhpEncodeData(info),
 				}
 				writeRHPMsg(c, msg) //nolint:errcheck
 			}
@@ -783,7 +783,7 @@ func (svc *RHPService) handleSend(c *rhpClient, env map[string]json.RawMessage) 
 		return
 	}
 
-	var payload = []byte(data)
+	var payload = rhpDecodeData(data)
 
 	switch sockMode {
 	case "dgram":
@@ -908,4 +908,61 @@ func optRHPStr(env map[string]json.RawMessage, key string) string {
 // sockPort == -1 means "all channels".
 func channelMatches(sockPort, channel int) bool {
 	return sockPort == -1 || sockPort == channel
+}
+
+// --- RHP2 binary-to-string encoding ----------------------------------------
+//
+// RHP2 carries arbitrary byte payloads in JSON string fields using a
+// non-standard encoding:
+//   - Bytes 0x08–0x0D, 0x22, 0x5C → standard JSON two-character escapes
+//   - Bytes 0x20–0x7E (printable ASCII, except " and \) → literal
+//   - All other bytes → \uXXXX, where XXXX is the byte value in hex
+//
+// This is NOT valid UTF-8 / Unicode.  \uXXXX escapes encode raw byte
+// values, not code points; decoding reverses this by taking the low byte
+// of each rune.
+
+// rhpEncodeData encodes b to a JSON string literal (including surrounding
+// quotes) using the RHP2 binary encoding.  The returned value is ready to
+// embed as a json.RawMessage.
+func rhpEncodeData(b []byte) json.RawMessage {
+	var buf strings.Builder
+	buf.WriteByte('"')
+	for _, c := range b {
+		switch c {
+		case '\b':
+			buf.WriteString(`\b`)
+		case '\t':
+			buf.WriteString(`\t`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\f':
+			buf.WriteString(`\f`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		default:
+			if c >= 0x20 && c <= 0x7E {
+				buf.WriteByte(c)
+			} else {
+				fmt.Fprintf(&buf, `\u%04x`, c)
+			}
+		}
+	}
+	buf.WriteByte('"')
+	return json.RawMessage(buf.String())
+}
+
+// rhpDecodeData decodes an RHP2 data string that has already been
+// JSON-decoded into a Go string.  Each rune's low byte is the decoded byte;
+// this correctly reverses the \uXXXX encoding used by RHP2.
+func rhpDecodeData(s string) []byte {
+	var result = make([]byte, 0, len(s))
+	for _, r := range s {
+		result = append(result, byte(r))
+	}
+	return result
 }

--- a/src/rhp_impl_test.go
+++ b/src/rhp_impl_test.go
@@ -1,0 +1,679 @@
+package direwolf
+
+/*
+These are Claude-generated tests for the RHP2 server (rhp.go).
+
+They exercise the JSON message framing, socket lifecycle (OPEN/CLOSE/AUTH),
+and the SendRecFrame / LinkEstablished / LinkTerminated / RecConnData
+callbacks — all of which work without a running modem or transmit queue.
+
+Tests that require a live transmit queue (dgram SEND → tq_append) or a full
+ax25_link state machine are not included here.
+
+Failing tests may indicate a bug, or they may reflect implementation-specific
+behaviour that changed deliberately — check the context before assuming a bug.
+*/
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// freePort returns a TCP port that is free at the moment of the call.
+// There is an inherent TOCTOU race, but it is acceptable for tests.
+func freePort(t *testing.T) int {
+	t.Helper()
+	var ln, err = net.Listen("tcp", ":0") //nolint:gosec // G102: intentional, test server binds to all interfaces
+	require.NoError(t, err)
+	var addr, ok = ln.Addr().(*net.TCPAddr)
+	require.True(t, ok, "expected *net.TCPAddr")
+	var port = addr.Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+// startRHP starts an RHPService on a free port and returns the service and port.
+func startRHP(t *testing.T) (*RHPService, int) {
+	t.Helper()
+	var port = freePort(t)
+	var mc = new(misc_config_s)
+	mc.rhp_port = port
+	var svc = NewRHPService(mc)
+	return svc, port
+}
+
+// dialRHP dials the RHP server, retrying for up to 100 ms while it starts up.
+func dialRHP(t *testing.T, port int) net.Conn {
+	t.Helper()
+	var addr = fmt.Sprintf("localhost:%d", port)
+	var conn net.Conn
+	var err error
+	for range 20 {
+		conn, err = net.Dial("tcp", addr)
+		if err == nil {
+			t.Cleanup(func() { conn.Close() })
+			return conn
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.NoError(t, err, "could not connect to RHP server on port %d", port)
+	return nil
+}
+
+// rhpSend marshals msg and sends it with the 2-byte big-endian length header.
+//
+//nolint:errchkjson // test helper accepts map[string]any for convenience
+func rhpSend(t *testing.T, conn net.Conn, msg map[string]any) {
+	t.Helper()
+	var data, merr = json.Marshal(msg)
+	require.NoError(t, merr)
+	var frame = make([]byte, 2+len(data))
+	binary.BigEndian.PutUint16(frame[:2], uint16(len(data)))
+	copy(frame[2:], data)
+	var _, werr = conn.Write(frame)
+	require.NoError(t, werr)
+}
+
+// rhpRecvRaw reads one framed RHP message and returns the raw bytes.
+func rhpRecvRaw(t *testing.T, conn net.Conn) []byte {
+	t.Helper()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	var buf, rerr = readRHPMsg(conn)
+	require.NoError(t, rerr)
+	return buf
+}
+
+// rhpRecv reads one framed RHP message and decodes it into a map.
+func rhpRecv(t *testing.T, conn net.Conn) map[string]any {
+	t.Helper()
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(rhpRecvRaw(t, conn), &result))
+	return result
+}
+
+// rhpRecvAs reads one framed RHP message and unmarshals it into T.
+//
+//nolint:ireturn // generic helper must return T
+func rhpRecvAs[T any](t *testing.T, conn net.Conn) T {
+	t.Helper()
+	var result T
+	require.NoError(t, json.Unmarshal(rhpRecvRaw(t, conn), &result))
+	return result
+}
+
+// rhpMaybeRecv attempts to read one message, returning nil if nothing arrives
+// within a short timeout.  Used to assert that no message is sent.
+func rhpMaybeRecv(conn net.Conn) map[string]any {
+	conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond)) //nolint:errcheck
+	var buf, err = readRHPMsg(conn)
+	if err != nil {
+		return nil
+	}
+	var result map[string]any
+	json.Unmarshal(buf, &result) //nolint:errcheck
+	return result
+}
+
+// openSocket sends an OPEN message and returns the handle from OPENREPLY.
+// Fails the test if errcode != 0.
+func openSocket(t *testing.T, conn net.Conn, mode, port string, flags int) int {
+	t.Helper()
+	rhpSend(t, conn, map[string]any{
+		"type":  "open",
+		"id":    1,
+		"pfam":  "ax25",
+		"mode":  mode,
+		"port":  port,
+		"flags": flags,
+	})
+	var reply = rhpRecvAs[rhpOpenReply](t, conn)
+	require.Equal(t, "openReply", reply.Type, "expected openReply")
+	require.Equal(t, 0, reply.ErrCode, "expected errcode 0, got %v (%s)", reply.ErrCode, reply.ErrText)
+	return reply.Handle
+}
+
+// ---------------------------------------------------------------------------
+// AUTH
+// ---------------------------------------------------------------------------
+
+func TestRHP_Auth_ReturnsOK(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{"type": "auth", "user": "Q1TEST", "pass": "hunter2"})
+	var reply = rhpRecvAs[rhpAuthReply](t, conn)
+
+	assert.Equal(t, "authReply", reply.Type)
+	assert.Equal(t, 0, reply.ErrCode)
+	assert.Equal(t, "Ok", reply.ErrText)
+}
+
+func TestRHP_Auth_EchoesID(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{"type": "auth", "id": 42, "user": "Q1TEST", "pass": "x"})
+	var reply = rhpRecvAs[rhpAuthReply](t, conn)
+
+	assert.Equal(t, "authReply", reply.Type)
+	assert.Equal(t, 42, reply.ID)
+}
+
+// ---------------------------------------------------------------------------
+// OPEN / OPENREPLY
+// ---------------------------------------------------------------------------
+
+func TestRHP_Open_TraceReturnsHandle(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var handle = openSocket(t, conn, "trace", "0", 3)
+	assert.GreaterOrEqual(t, handle, 0)
+}
+
+func TestRHP_Open_RawReturnsHandle(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var handle = openSocket(t, conn, "raw", "0", 3)
+	assert.GreaterOrEqual(t, handle, 0)
+}
+
+func TestRHP_Open_DgramReturnsHandle(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var handle = openSocket(t, conn, "dgram", "0", 0)
+	assert.GreaterOrEqual(t, handle, 0)
+}
+
+func TestRHP_Open_HandlesAreSequential(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var h0 = openSocket(t, conn, "trace", "0", 3)
+	var h1 = openSocket(t, conn, "raw", "0", 3)
+	var h2 = openSocket(t, conn, "dgram", "0", 0)
+	assert.Equal(t, 0, h0)
+	assert.Equal(t, 1, h1)
+	assert.Equal(t, 2, h2)
+}
+
+func TestRHP_Open_InvalidPfamReturnsError(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{"type": "open", "pfam": "inet", "mode": "dgram"})
+	var reply = rhpRecvAs[rhpOpenReply](t, conn)
+
+	assert.Equal(t, "openReply", reply.Type)
+	assert.Equal(t, 12, reply.ErrCode)
+}
+
+func TestRHP_Open_InvalidModeReturnsError(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{"type": "open", "pfam": "ax25", "mode": "custom"})
+	var reply = rhpRecvAs[rhpOpenReply](t, conn)
+
+	assert.Equal(t, "openReply", reply.Type)
+	assert.Equal(t, 12, reply.ErrCode)
+}
+
+func TestRHP_Open_StreamPassiveReturnsHandle(t *testing.T) {
+	// Passive stream open registers a callsign with the dlq.
+	// dlq auto-initialises, so this is safe without a running recv loop.
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{
+		"type":  "open",
+		"id":    5,
+		"pfam":  "ax25",
+		"mode":  "stream",
+		"port":  "0",
+		"local": "Q1TEST",
+		"flags": 0, // passive (no 0x80)
+	})
+	var reply = rhpRecvAs[rhpOpenReply](t, conn)
+
+	assert.Equal(t, "openReply", reply.Type)
+	assert.Equal(t, 0, reply.ErrCode)
+	assert.Equal(t, 5, reply.ID)
+}
+
+func TestRHP_Open_StreamPassiveMissingLocalReturnsError(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{
+		"type":  "open",
+		"pfam":  "ax25",
+		"mode":  "stream",
+		"port":  "0",
+		"flags": 0,
+		// no "local"
+	})
+	var reply = rhpRecvAs[rhpOpenReply](t, conn)
+
+	assert.Equal(t, "openReply", reply.Type)
+	assert.Equal(t, 12, reply.ErrCode)
+}
+
+func TestRHP_Open_StreamActiveReturnsHandle(t *testing.T) {
+	// Active stream open enqueues a connect request via dlq.
+	// dlq auto-initialises; the request simply sits in the queue unprocessed.
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{
+		"type":   "open",
+		"pfam":   "ax25",
+		"mode":   "stream",
+		"port":   "0",
+		"local":  "Q1TEST",
+		"remote": "Q2TEST",
+		"flags":  0x80, // active open
+	})
+	var reply = rhpRecvAs[rhpOpenReply](t, conn)
+
+	assert.Equal(t, "openReply", reply.Type)
+	assert.Equal(t, 0, reply.ErrCode)
+}
+
+func TestRHP_Open_StreamActiveMissingRemoteReturnsError(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{
+		"type":  "open",
+		"pfam":  "ax25",
+		"mode":  "stream",
+		"port":  "0",
+		"local": "Q1TEST",
+		"flags": 0x80,
+		// no "remote"
+	})
+	var reply = rhpRecvAs[rhpOpenReply](t, conn)
+
+	assert.Equal(t, "openReply", reply.Type)
+	assert.Equal(t, 12, reply.ErrCode)
+}
+
+// ---------------------------------------------------------------------------
+// CLOSE / CLOSEREPLY
+// ---------------------------------------------------------------------------
+
+func TestRHP_Close_ValidHandleReturnsOK(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var handle = openSocket(t, conn, "trace", "0", 3)
+
+	rhpSend(t, conn, map[string]any{"type": "close", "id": 9, "handle": handle})
+	var reply = rhpRecvAs[rhpCloseReply](t, conn)
+
+	assert.Equal(t, "closeReply", reply.Type)
+	assert.Equal(t, 0, reply.ErrCode)
+	assert.Equal(t, 9, reply.ID)
+	assert.Equal(t, handle, reply.Handle)
+}
+
+func TestRHP_Close_InvalidHandleReturnsError(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{"type": "close", "handle": 999})
+	var reply = rhpRecvAs[rhpCloseReply](t, conn)
+
+	assert.Equal(t, "closeReply", reply.Type)
+	assert.Equal(t, 3, reply.ErrCode) // errInvalidHandle
+}
+
+func TestRHP_Close_MissingHandleReturnsError(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{"type": "close"})
+	var reply = rhpRecvAs[rhpCloseReply](t, conn)
+
+	assert.Equal(t, "closeReply", reply.Type)
+	assert.Equal(t, 12, reply.ErrCode) // errBadParam
+}
+
+// ---------------------------------------------------------------------------
+// SEND (stream only — dgram SEND is excluded as it requires a live tx queue)
+// ---------------------------------------------------------------------------
+
+func TestRHP_Send_StreamQueuesData(t *testing.T) {
+	// SEND on a stream socket calls dlq_xmit_data_request, which appends to
+	// the dlq (auto-initialised). We just verify the SENDREPLY is OK and
+	// that no panic occurs.
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	// Active-open stream socket: the connect request sits in the queue unprocessed,
+	// but local/remote are set, which is all SEND needs.
+	rhpSend(t, conn, map[string]any{
+		"type":   "open",
+		"pfam":   "ax25",
+		"mode":   "stream",
+		"port":   "0",
+		"local":  "Q1TEST",
+		"remote": "Q2TEST",
+		"flags":  0x80,
+	})
+	var openReply = rhpRecvAs[rhpOpenReply](t, conn)
+	var handle = openReply.Handle
+
+	rhpSend(t, conn, map[string]any{
+		"type":   "send",
+		"id":     7,
+		"handle": handle,
+		"data":   "Hello world",
+	})
+	var reply = rhpRecvAs[rhpSendReply](t, conn)
+
+	assert.Equal(t, "sendReply", reply.Type)
+	assert.Equal(t, 0, reply.ErrCode)
+	assert.Equal(t, 7, reply.ID)
+}
+
+func TestRHP_Send_InvalidHandleReturnsError(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{"type": "send", "handle": 42, "data": "hi"})
+	var reply = rhpRecvAs[rhpSendReply](t, conn)
+
+	assert.Equal(t, "sendReply", reply.Type)
+	assert.Equal(t, 3, reply.ErrCode) // errInvalidHandle
+}
+
+func TestRHP_Send_TraceSocketReturnsError(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var handle = openSocket(t, conn, "trace", "0", 3)
+	rhpSend(t, conn, map[string]any{"type": "send", "handle": handle, "data": "hi"})
+	var reply = rhpRecvAs[rhpSendReply](t, conn)
+
+	assert.Equal(t, "sendReply", reply.Type)
+	assert.Equal(t, 12, reply.ErrCode) // errBadParam: trace mode
+}
+
+// ---------------------------------------------------------------------------
+// SendRecFrame routing
+// ---------------------------------------------------------------------------
+
+// makeTestFrame builds a simple UI frame for use in SendRecFrame tests.
+func makeTestFrame(dst string) (*packet_t, []byte) {
+	var addrs [AX25_MAX_ADDRS]string
+	addrs[AX25_SOURCE] = "Q1TEST"
+	addrs[AX25_DESTINATION] = dst
+	var pp = ax25_u_frame(addrs, 2, cr_cmd, frame_type_U_UI, 0, AX25_PID_NO_LAYER_3, []byte("test payload"))
+	var fbuf = ax25_pack(pp)
+	return pp, fbuf
+}
+
+func TestRHP_SendRecFrame_DeliveredToTraceSocket(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+	openSocket(t, conn, "trace", "0", rhpTraceFlagIncoming)
+
+	var pp, fbuf = makeTestFrame("Q2TEST")
+	svc.SendRecFrame(0, pp, fbuf)
+
+	var recv = rhpRecv(t, conn)
+	assert.Equal(t, "recv", recv["type"])
+	assert.Equal(t, "Q1TEST", recv["srce"])
+	assert.Equal(t, "Q2TEST", recv["dest"])
+	assert.Equal(t, "rcvd", recv["action"])
+	assert.Equal(t, "0", recv["port"])
+}
+
+func TestRHP_SendRecFrame_NotDeliveredToTraceWithoutIncomingFlag(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+	openSocket(t, conn, "trace", "0", 0) // flags=0: no incoming flag
+
+	var pp, fbuf = makeTestFrame("Q2TEST")
+	svc.SendRecFrame(0, pp, fbuf)
+
+	assert.Nil(t, rhpMaybeRecv(conn), "trace socket without incoming flag should not receive")
+}
+
+func TestRHP_SendRecFrame_DeliveredToRawSocket(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+	openSocket(t, conn, "raw", "0", rhpTraceFlagIncoming)
+
+	var pp, fbuf = makeTestFrame("Q2TEST")
+	svc.SendRecFrame(0, pp, fbuf)
+
+	var recv = rhpRecv(t, conn)
+	assert.Equal(t, "recv", recv["type"])
+	assert.Equal(t, "rcvd", recv["action"])
+	// data field is base64-encoded — just check it's present and non-empty
+	assert.NotEmpty(t, recv["data"])
+}
+
+func TestRHP_SendRecFrame_DeliveredToDgramSocket_UnboundReceivesAll(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+	openSocket(t, conn, "dgram", "0", 0) // no local = receive everything
+
+	var pp, fbuf = makeTestFrame("APRS")
+	svc.SendRecFrame(0, pp, fbuf)
+
+	var recv = rhpRecv(t, conn)
+	assert.Equal(t, "recv", recv["type"])
+	assert.Equal(t, "test payload", recv["data"])
+}
+
+func TestRHP_SendRecFrame_DeliveredToDgramSocket_BoundMatchingDest(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	// Open a dgram socket bound to "APRS" as local (i.e. we receive frames destined to APRS)
+	rhpSend(t, conn, map[string]any{
+		"type":  "open",
+		"pfam":  "ax25",
+		"mode":  "dgram",
+		"port":  "0",
+		"local": "APRS",
+		"flags": 0,
+	})
+	var openReply = rhpRecvAs[rhpOpenReply](t, conn)
+	require.Equal(t, 0, openReply.ErrCode)
+
+	var pp, fbuf = makeTestFrame("APRS")
+	svc.SendRecFrame(0, pp, fbuf)
+
+	var recv = rhpRecv(t, conn)
+	assert.Equal(t, "recv", recv["type"])
+	assert.Equal(t, "test payload", recv["data"])
+}
+
+func TestRHP_SendRecFrame_NotDeliveredToDgramSocket_WrongDest(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{
+		"type":  "open",
+		"pfam":  "ax25",
+		"mode":  "dgram",
+		"port":  "0",
+		"local": "APRS",
+		"flags": 0,
+	})
+	rhpRecv(t, conn) // discard openReply
+
+	var pp, fbuf = makeTestFrame("CQ") // wrong destination
+	svc.SendRecFrame(0, pp, fbuf)
+
+	assert.Nil(t, rhpMaybeRecv(conn), "dgram socket bound to APRS should not receive frames destined to CQ")
+}
+
+func TestRHP_SendRecFrame_ChannelFilter(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+	openSocket(t, conn, "trace", "1", rhpTraceFlagIncoming) // bound to channel 1
+
+	var pp, fbuf = makeTestFrame("Q2TEST")
+	svc.SendRecFrame(0, pp, fbuf) // frame on channel 0 — should not be delivered
+
+	assert.Nil(t, rhpMaybeRecv(conn), "trace socket on channel 1 should not receive channel 0 frames")
+}
+
+func TestRHP_SendRecFrame_AllChannels(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	// Open trace socket with port="" (all channels)
+	rhpSend(t, conn, map[string]any{
+		"type":  "open",
+		"pfam":  "ax25",
+		"mode":  "trace",
+		"flags": rhpTraceFlagIncoming,
+		// no "port" field → all channels
+	})
+	rhpRecv(t, conn) // discard openReply
+
+	var pp, fbuf = makeTestFrame("Q2TEST")
+	svc.SendRecFrame(3, pp, fbuf) // arbitrary channel
+
+	var recv = rhpRecv(t, conn)
+	assert.Equal(t, "recv", recv["type"])
+	assert.Equal(t, "3", recv["port"])
+}
+
+func TestRHP_SendRecFrame_MultipleClients(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn1 = dialRHP(t, port)
+	var conn2 = dialRHP(t, port)
+	// Let the second connection be accepted
+	time.Sleep(10 * time.Millisecond)
+
+	openSocket(t, conn1, "trace", "0", rhpTraceFlagIncoming)
+	openSocket(t, conn2, "trace", "0", rhpTraceFlagIncoming)
+
+	var pp, fbuf = makeTestFrame("Q2TEST")
+	svc.SendRecFrame(0, pp, fbuf)
+
+	var recv1 = rhpRecv(t, conn1)
+	var recv2 = rhpRecv(t, conn2)
+	assert.Equal(t, "recv", recv1["type"])
+	assert.Equal(t, "recv", recv2["type"])
+}
+
+// ---------------------------------------------------------------------------
+// Connected-mode callbacks (LinkEstablished, LinkTerminated, RecConnData)
+// ---------------------------------------------------------------------------
+
+func TestRHP_LinkEstablished_OutgoingSendsStatus(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	// We use a trace socket as a stand-in — LinkEstablished just needs any
+	// socket to exist with that handle; it doesn't check the mode.
+	var handle = openSocket(t, conn, "trace", "0", 3)
+
+	svc.LinkEstablished(0, handle, "Q2TEST", "Q1TEST", false /* outgoing */)
+
+	var msg = rhpRecvAs[rhpStatusMsg](t, conn)
+	assert.Equal(t, "status", msg.Type)
+	assert.Equal(t, rhpFlagConnected, msg.Flags)
+	assert.Equal(t, handle, msg.Handle)
+}
+
+func TestRHP_LinkEstablished_IncomingSendsAcceptThenStatus(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var handle = openSocket(t, conn, "trace", "0", 3)
+
+	svc.LinkEstablished(0, handle, "Q2TEST", "Q1TEST", true /* incoming */)
+
+	var accept = rhpRecvAs[rhpAcceptMsg](t, conn)
+	assert.Equal(t, "accept", accept.Type)
+	assert.Equal(t, "Q2TEST", accept.Remote)
+	assert.Equal(t, "Q1TEST", accept.Local)
+	assert.Equal(t, handle, accept.Handle)
+
+	var status = rhpRecvAs[rhpStatusMsg](t, conn)
+	assert.Equal(t, "status", status.Type)
+	assert.Equal(t, rhpFlagConnected, status.Flags)
+}
+
+func TestRHP_LinkTerminated_SendsClose(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var handle = openSocket(t, conn, "trace", "0", 3)
+
+	svc.LinkTerminated(0, handle, "Q2TEST", "Q1TEST", false)
+
+	var msg = rhpRecvAs[rhpCloseMsg](t, conn)
+	assert.Equal(t, "close", msg.Type)
+	assert.Equal(t, handle, msg.Handle)
+}
+
+func TestRHP_RecConnData_SendsRecv(t *testing.T) {
+	var svc, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	var handle = openSocket(t, conn, "trace", "0", 3)
+
+	svc.RecConnData(0, handle, "Q2TEST", "Q1TEST", AX25_PID_NO_LAYER_3, []byte("connected data"))
+
+	var msg = rhpRecvAs[rhpRecvMsg](t, conn)
+	assert.Equal(t, "recv", msg.Type)
+	assert.Equal(t, handle, msg.Handle)
+	assert.Equal(t, "connected data", msg.Data)
+}
+
+// ---------------------------------------------------------------------------
+// Disabled service
+// ---------------------------------------------------------------------------
+
+func TestRHP_Disabled_SendRecFrameIsNoop(t *testing.T) {
+	var mc = new(misc_config_s)
+	mc.rhp_port = 0
+	var svc = NewRHPService(mc)
+
+	// None of these should panic.
+	var pp, fbuf = makeTestFrame("Q2TEST")
+	svc.SendRecFrame(0, pp, fbuf)
+	svc.LinkEstablished(0, 0, "Q2TEST", "Q1TEST", false)
+	svc.LinkTerminated(0, 0, "Q2TEST", "Q1TEST", false)
+	svc.RecConnData(0, 0, "Q2TEST", "Q1TEST", AX25_PID_NO_LAYER_3, []byte("x"))
+}
+
+// ---------------------------------------------------------------------------
+// Unknown message type
+// ---------------------------------------------------------------------------
+
+func TestRHP_UnknownMessageType_DoesNotCrash(t *testing.T) {
+	var _, port = startRHP(t)
+	var conn = dialRHP(t, port)
+
+	rhpSend(t, conn, map[string]any{"type": "frobnicate", "data": "whatever"})
+	// No reply is sent for unknown types; verify the connection is still usable.
+	time.Sleep(20 * time.Millisecond)
+	rhpSend(t, conn, map[string]any{"type": "auth", "user": "Q1TEST", "pass": "x"})
+	var reply = rhpRecv(t, conn)
+	assert.Equal(t, "authReply", reply["type"])
+}

--- a/src/rhp_impl_test.go
+++ b/src/rhp_impl_test.go
@@ -644,7 +644,9 @@ func TestRHP_RecConnData_SendsRecv(t *testing.T) {
 	var msg = rhpRecvAs[rhpRecvMsg](t, conn)
 	assert.Equal(t, "recv", msg.Type)
 	assert.Equal(t, handle, msg.Handle)
-	assert.Equal(t, "connected data", msg.Data)
+	var msgData string
+	require.NoError(t, json.Unmarshal(msg.Data, &msgData))
+	assert.Equal(t, "connected data", msgData)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/rhp_impl_test.go
+++ b/src/rhp_impl_test.go
@@ -44,12 +44,14 @@ func freePort(t *testing.T) int {
 }
 
 // startRHP starts an RHPService on a free port and returns the service and port.
+// The service is automatically shut down when the test finishes.
 func startRHP(t *testing.T) (*RHPService, int) {
 	t.Helper()
 	var port = freePort(t)
 	var mc = new(misc_config_s)
 	mc.rhp_port = port
 	var svc = NewRHPService(mc)
+	t.Cleanup(func() { svc.Close() }) //nolint:errcheck
 	return svc, port
 }
 

--- a/src/server.go
+++ b/src/server.go
@@ -747,6 +747,11 @@ func mon_desc(pp *packet_t) (byte, string) {
  *--------------------------------------------------------------------*/
 
 func server_link_established(channel int, client int, remote_call string, own_call string, incoming bool) {
+	if client >= MAX_NET_CLIENTS {
+		rhpSvc.LinkEstablished(channel, client-MAX_NET_CLIENTS, remote_call, own_call, incoming)
+		return
+	}
+
 	var reply = new(AGWPEMessage)
 
 	reply.Header.Portx = byte(channel)
@@ -796,6 +801,11 @@ func server_link_established(channel int, client int, remote_call string, own_ca
  *--------------------------------------------------------------------*/
 
 func server_link_terminated(channel int, client int, remote_call string, own_call string, timeout bool) {
+	if client >= MAX_NET_CLIENTS {
+		rhpSvc.LinkTerminated(channel, client-MAX_NET_CLIENTS, remote_call, own_call, timeout)
+		return
+	}
+
 	var reply = new(AGWPEMessage)
 
 	reply.Header.Portx = byte(channel)
@@ -840,6 +850,11 @@ func server_link_terminated(channel int, client int, remote_call string, own_cal
  *--------------------------------------------------------------------*/
 
 func server_rec_conn_data(channel int, client int, remote_call string, own_call string, pid int, data []byte) {
+	if client >= MAX_NET_CLIENTS {
+		rhpSvc.RecConnData(channel, client-MAX_NET_CLIENTS, remote_call, own_call, pid, data)
+		return
+	}
+
 	var reply = new(AGWPEMessage)
 
 	reply.Header.Portx = byte(channel)

--- a/src/util.go
+++ b/src/util.go
@@ -18,7 +18,9 @@ func SLEEP_SEC(s int) {
 }
 
 // Because sometimes it's really convenient to have C's ternary ?:
-func IfThenElse[T any](x bool, a T, b T) T { //nolint:ireturn
+//
+//nolint:ireturn // generic function must return T
+func IfThenElse[T any](x bool, a T, b T) T {
 	if x {
 		return a
 	} else {


### PR DESCRIPTION
Adds an RHP2 JSON/TCP server so other applications can use Samoyed
as a "packet engine", as described in
https://wiki.oarc.uk/packet:white-papers:pwp-0222

- New RHPPORT config directive (disabled by default; set RHPPORT 9000
  to enable)
- JSON messages framed with 2-byte big-endian length header on port 9000
- Supported modes: dgram (AX.25 UI frames), stream (connected AX.25),
  trace (decoded frame monitoring), raw (binary frame monitoring)
- Received frames routed to matching sockets via SendRecFrame
- Connected-mode (stream) sockets use the ax25_link state machine;
  client IDs are offset by MAX_NET_CLIENTS to avoid AGW collisions
- server.go notification functions (server_link_established etc.) route
  to RHP when client >= MAX_NET_CLIENTS

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
