### PR TITLE
fix: Don't override config MODEM settings when -B flag is not provided

### DIFF
--- a/src/config_test.go
+++ b/src/config_test.go
@@ -1,9 +1,11 @@
 package direwolf
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- alldigits ---
@@ -184,6 +186,65 @@ func Test_IsNoCall(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, IsNoCall(tt.callsign))
+		})
+	}
+}
+
+// --- config_init MODEM directive ---
+
+func Test_config_init_modem_directive(t *testing.T) {
+	tests := []struct {
+		name          string
+		configContent string
+		wantBaud      int
+		wantModemType modem_t
+	}{
+		{
+			name:          "1200 baud AFSK",
+			configContent: "MODEM 1200\n",
+			wantBaud:      1200,
+			wantModemType: MODEM_AFSK,
+		},
+		{
+			name:          "9600 baud G3RUH implicit",
+			configContent: "MODEM 9600\n",
+			wantBaud:      9600,
+			wantModemType: MODEM_SCRAMBLE,
+		},
+		{
+			name:          "9600 baud G3RUH explicit option",
+			configContent: "MODEM 9600 g3ruh\n",
+			wantBaud:      9600,
+			wantModemType: MODEM_SCRAMBLE,
+		},
+		{
+			name:          "300 baud HF AFSK",
+			configContent: "MODEM 300\n",
+			wantBaud:      300,
+			wantModemType: MODEM_AFSK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp(t.TempDir(), "direwolf*.conf")
+			require.NoError(t, err)
+			_, err = tmpFile.WriteString(tt.configContent)
+			require.NoError(t, err)
+			require.NoError(t, tmpFile.Close())
+
+			var audioConfig = new(audio_s)
+			var digiConfig digi_config_s
+			var cdigiConfig cdigi_config_s
+			var ttConfig tt_config_s
+			var igateConfig igate_config_s
+			var miscConfig misc_config_s
+
+			config_init(tmpFile.Name(), audioConfig, &digiConfig, &cdigiConfig,
+				&ttConfig, &igateConfig, &miscConfig)
+
+			assert.Equal(t, tt.wantBaud, audioConfig.achan[0].baud)
+			assert.Equal(t, tt.wantModemType, audioConfig.achan[0].modem_type)
 		})
 	}
 }

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -325,7 +325,7 @@ x = Silence FX.25 information.`)
 		audio_config.adev[0].bits_per_sample = *bitsPerSample
 	}
 
-	if *bitrateStr != "" {
+	if pflag.Lookup("bitrate").Changed {
 		var bitrate, bitrateParseErr = strconv.Atoi(*bitrateStr)
 		if *bitrateStr == "AIS" {
 			bitrate = 0xA15A15


### PR DESCRIPTION
- The `-B`/`--bitrate` CLI flag in `direwolf.go` had a default of `"1200"` (a non-empty string), so the baud/modem-type override block ran on every startup even when the user hadn't passed `-B`
- This silently reset `achan[0].baud` and `achan[0].modem_type` to 1200 baud AFSK after `config_init` had already applied the config file's `MODEM` directive
- Fix: gate the override block on `pflag.Lookup("bitrate").Changed` so it only runs when `-B` is explicitly provided, preserving the meaningful `1200` default in `--help` output
- Adds `config_init` tests for MODEM directive parsing (300/1200/9600 baud, with and without `g3ruh` option), written as an attempt to reproduce the bug

Fixes #502 - thanks to @M0LTE for raising!