### PR TITLE
fix: Don't panic in decode_aprs on empty information field

### DIFF
--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -212,12 +212,6 @@ func decode_aprs(pp *packet_t, quiet bool, third_party_src string) *decode_aprs_
 
 	A.g_quiet = quiet
 
-	if unicode.IsPrint(rune(pinfo[0])) {
-		A.g_data_type_desc = fmt.Sprintf("ERROR!!!  Unknown APRS Data Type Indicator \"%c\"", pinfo[0])
-	} else {
-		A.g_data_type_desc = fmt.Sprintf("ERROR!!!  Unknown APRS Data Type Indicator: unprintable 0x%02x", pinfo[0])
-	}
-
 	A.g_symbol_table = '/' /* Default to primary table. */
 	A.g_symbol_code = ' '  /* What should we have for default symbol? */
 
@@ -241,6 +235,28 @@ func decode_aprs(pp *packet_t, quiet bool, third_party_src string) *decode_aprs_
 	A.g_footprint_lat = G_UNKNOWN
 	A.g_footprint_lon = G_UNKNOWN
 	A.g_footprint_radius = G_UNKNOWN
+
+	/*
+	 * Extract source and destination including the SSID.
+	 */
+	if third_party_src != "" {
+		A.g_src = third_party_src
+	} else {
+		A.g_src = ax25_get_addr_with_ssid(pp, AX25_SOURCE)
+	}
+
+	A.g_dest = ax25_get_addr_with_ssid(pp, AX25_DESTINATION)
+
+	if len(pinfo) == 0 {
+		A.g_data_type_desc = "AX.25 UI frame with empty information field"
+		return A
+	}
+
+	if unicode.IsPrint(rune(pinfo[0])) {
+		A.g_data_type_desc = fmt.Sprintf("ERROR!!!  Unknown APRS Data Type Indicator \"%c\"", pinfo[0])
+	} else {
+		A.g_data_type_desc = fmt.Sprintf("ERROR!!!  Unknown APRS Data Type Indicator: unprintable 0x%02x", pinfo[0])
+	}
 
 	// Check for RFONLY or NOGATE in the destination field.
 	// Actual cases observed.
@@ -300,21 +316,8 @@ func decode_aprs(pp *packet_t, quiet bool, third_party_src string) *decode_aprs_
 			return A
 		} else {
 			A.g_data_type_desc = "Third Party Header: Unable to parse payload."
-			A.g_src = ax25_get_addr_with_ssid(pp, AX25_SOURCE)
-			A.g_dest = ax25_get_addr_with_ssid(pp, AX25_DESTINATION)
 		}
 	}
-
-	/*
-	 * Extract source and destination including the SSID.
-	 */
-	if third_party_src != "" {
-		A.g_src = third_party_src
-	} else {
-		A.g_src = ax25_get_addr_with_ssid(pp, AX25_SOURCE)
-	}
-
-	A.g_dest = ax25_get_addr_with_ssid(pp, AX25_DESTINATION)
 
 	//dw_printf ("DEBUG decode_aprs source=%s, dest=%s\n", A.g_src, A.g_dest);
 

--- a/src/decode_aprs_test.go
+++ b/src/decode_aprs_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package direwolf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that decode_aprs does not panic on an AX.25 UI frame with an empty
+// information field, as sent by linbpq ID broadcasts (issue #504).
+func Test_decode_aprs_empty_info(t *testing.T) {
+	deviceIDData = NewDeviceIDData()
+
+	var pp = ax25_from_text("Q1TEST>ID:", true)
+	assert.NotNil(t, pp)
+
+	// Must not panic, and must return a populated struct.
+	var A = decode_aprs(pp, true, "")
+	assert.NotNil(t, A)
+	assert.Equal(t, "AX.25 UI frame with empty information field", A.g_data_type_desc)
+	assert.Equal(t, "Q1TEST", A.g_src)
+	assert.Equal(t, "ID", A.g_dest)
+}


### PR DESCRIPTION
AX.25 UI frames with an empty information field (e.g. linbpq ID
broadcasts like `<NODECALL>>ID:`) caused a runtime panic at the first
`pinfo[0]` access in decode_aprs().

Move field initialisation before the length check so the returned
struct is fully populated, then return early with a descriptive
data_type_desc when pinfo is empty.

This is a porting bug with likely relatives elsewhere - in C you can
~always look at `str[0]` because strings are null-terminated, and I
often didn't think to add length>0 checks beforehand when porting to Go

Fixes #504. Thanks to Tom @M0LTE for finding this!

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
