### PR TITLE
fix: Only initialise PortAudio if required

### DIFF
--- a/src/audio.go
+++ b/src/audio.go
@@ -722,6 +722,34 @@ var adev [MAX_ADEVS]*adev_s
 var portaudioMu sync.Mutex
 var portaudioRefCount int
 
+// anyDeviceRequiresPortAudio reports whether any configured audio device needs
+// PortAudio (i.e. is a soundcard rather than stdin or UDP).  Used to skip
+// portaudio.Initialize() when all devices are stdin/UDP, so that samoyed can
+// run on systems with no working PortAudio host backend (issue #501).
+func anyDeviceRequiresPortAudio(pa *audio_s) bool {
+	for a := range MAX_ADEVS {
+		if pa.adev[a].defined == 0 {
+			continue
+		}
+
+		var inName = pa.adev[a].adevice_in
+		var inIsStdinOrDash = strings.EqualFold(inName, "stdin") || inName == "-"
+		var inIsUDP = strings.HasPrefix(strings.ToLower(inName), "udp:")
+
+		if !inIsStdinOrDash && !inIsUDP {
+			return true
+		}
+
+		var outIsUDP = strings.HasPrefix(strings.ToLower(pa.adev[a].adevice_out), "udp:")
+
+		if !outIsUDP {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Originally 40.  Version 1.2, try 10 for lower latency.
 
 const ONE_BUF_TIME = 10
@@ -959,31 +987,37 @@ func findPortAudioDevice(name string, forInput bool) *portaudio.DeviceInfo {
 func audio_open(pa *audio_s) int {
 	save_audio_config_p = pa
 
-	// Initialize PortAudio, using a refcount so that multiple audio_open/
-	// audio_close cycles are correctly paired with Initialize/Terminate.
-	portaudioMu.Lock()
+	// Initialize PortAudio only if at least one configured device needs a
+	// soundcard.  Pure stdin/UDP configurations must work on systems with no
+	// working PortAudio host backend (issue #501).
+	var portaudioAcquired = false
 
-	if portaudioRefCount == 0 {
-		var err = portaudio.Initialize()
-		if err != nil {
-			portaudioMu.Unlock()
-			text_color_set(DW_COLOR_ERROR)
-			dw_printf("PortAudio initialization failed: %v\n", err)
+	if anyDeviceRequiresPortAudio(pa) {
+		portaudioMu.Lock()
 
-			return -1
+		if portaudioRefCount == 0 {
+			var err = portaudio.Initialize()
+			if err != nil {
+				portaudioMu.Unlock()
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("PortAudio initialization failed: %v\n", err)
+
+				return -1
+			}
 		}
+
+		portaudioRefCount++
+		portaudioAcquired = true
+
+		portaudioMu.Unlock()
 	}
-
-	portaudioRefCount++
-
-	portaudioMu.Unlock()
 
 	// If audio_open fails after this point, roll back the refcount increment
 	// so it stays correctly paired with audio_close calls.
 	var openSucceeded = false
 
 	defer func() {
-		if !openSucceeded {
+		if portaudioAcquired && !openSucceeded {
 			portaudioMu.Lock()
 
 			portaudioRefCount--

--- a/src/audio_test.go
+++ b/src/audio_test.go
@@ -241,6 +241,67 @@ func Test_audioFlushReal_UDP_sendsBytes(t *testing.T) {
 	assert.Equal(t, testData, buf[:n])
 }
 
+// --- anyDeviceRequiresPortAudio ---
+
+func makeAudioConfig(inName, outName string) *audio_s {
+	var pa = new(audio_s)
+	pa.adev[0].defined = 1
+	pa.adev[0].adevice_in = inName
+	pa.adev[0].adevice_out = outName
+
+	return pa
+}
+
+func Test_anyDeviceRequiresPortAudio(t *testing.T) {
+	tests := []struct {
+		name string
+		pa   *audio_s
+		want bool
+	}{
+		{
+			name: "no devices defined",
+			pa:   new(audio_s),
+			want: false,
+		},
+		{
+			name: "stdin in, udp out",
+			pa:   makeAudioConfig("stdin", "udp:127.0.0.1:1234"),
+			want: false,
+		},
+		{
+			name: "dash in, udp out",
+			pa:   makeAudioConfig("-", "udp:127.0.0.1:1234"),
+			want: false,
+		},
+		{
+			name: "udp in (uppercase), udp out",
+			pa:   makeAudioConfig("UDP:7355", "udp:127.0.0.1:1234"),
+			want: false,
+		},
+		{
+			name: "stdin in, soundcard out",
+			pa:   makeAudioConfig("stdin", "default"),
+			want: true,
+		},
+		{
+			name: "soundcard in, udp out",
+			pa:   makeAudioConfig("default", "udp:127.0.0.1:1234"),
+			want: true,
+		},
+		{
+			name: "soundcard in, soundcard out",
+			pa:   makeAudioConfig("default", "default"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, anyDeviceRequiresPortAudio(tt.pa))
+		})
+	}
+}
+
 func Test_audioFlushReal_UDP_emptyBuffer_isNoop(t *testing.T) {
 	var dev = setupAdev0(t)
 	dev.udp_out_sock = &net.UDPConn{} // non-nil socket; must not be written to


### PR DESCRIPTION
Add anyDeviceRequiresPortAudio() to check whether any configured
device actually needs a soundcard (as opposed to stdin or UDP).

audio_open() now skips portaudio.Initialize() entirely when all
devices use stdin/UDP, allowing Samoyed to start on systems with
no working PortAudio host backend.

Fixes #501

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
