### PR TITLE
chore: Add REUSE config for .claude dir

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -21,6 +21,7 @@ SPDX-License-Identifier = "GPL-2.0-or-later"
 [[annotations]]
 path = [
 	"*.md",
+	".claude/**",
 	".git*",
 	".github/**",
 	".golangci.yml",


### PR DESCRIPTION
Otherwise reuse tests keep failing for Claude-Code-created /.claude
(e.g. settings.local.json)
