### PR TITLE
feat: Add samoyed-axudp, a KISS/UDP bridge for AX.25 frames (beta)

### DIFF
--- a/cmd/samoyed-axudp/main.go
+++ b/cmd/samoyed-axudp/main.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	direwolf "github.com/doismellburning/samoyed/src"
+	"github.com/spf13/pflag"
+)
+
+// samoyed-axudp bridges between samoyed-direwolf (via TCP KISS) and
+// remote packet radio nodes that speak AXUDP (raw AX.25 frames in UDP
+// datagrams), using a YAML config file.
+//
+// Usage:
+//
+//	samoyed-axudp [--config <file>] [--udpport <n>] [--kissport <n>]
+//
+// Config file (axudp.yaml):
+//
+//	maps:
+//	  - ax25addr: Q1TEST
+//	    host: 192.0.2.1
+//	    port: 20093
+//	  - ax25addr: Q2TEST
+//	    host: 192.0.2.2
+//	    port: 93
+
+func main() {
+	pflag.Usage = func() {
+		fmt.Fprintf(pflag.CommandLine.Output(), `samoyed-axudp [BETA] - AXUDP bridge for samoyed-direwolf
+
+NOTE: samoyed-axudp is beta software. Its behaviour, config file format,
+and flags may change in future releases without notice.
+
+Bridges between samoyed-direwolf (via TCP KISS) and remote packet radio
+nodes that speak AXUDP (raw AX.25 frames in UDP datagrams, per RFC 1226).
+samoyed-direwolf connects to samoyed-axudp using an
+NCHANNEL directive in its config file.
+
+Usage:
+  samoyed-axudp [--config <file>] [--udpport <n>] [--kissport <n>]
+
+Example config file (axudp.yaml):
+  maps:
+    - ax25addr: Q1TEST-1
+      host: 192.0.2.1
+      port: 93
+
+Example samoyed-direwolf config to connect via samoyed-axudp:
+  CHANNEL 2
+  MYCALL Q1TEST
+  NCHANNEL 2 localhost 8002
+
+Flags:
+`)
+		pflag.PrintDefaults()
+	}
+
+	var help = pflag.Bool("help", false, "Display help text.")
+	var configFile = pflag.String("config", "axudp.yaml", "Path to YAML config file")
+	var udpPort = pflag.Int("udpport", 20093, "UDP port to listen on (and source from)")
+	var kissPort = pflag.Int("kissport", 8002, "TCP port for KISS clients (samoyed-direwolf NCHANNEL target)")
+	var verbose = pflag.Bool("verbose", false, "Log every packet sent and received")
+	pflag.Parse()
+
+	if *help {
+		pflag.Usage()
+		os.Exit(0)
+	}
+
+	var maps, parseErr = direwolf.ParseAXUDPConfig(*configFile)
+	if parseErr != nil {
+		fmt.Fprintf(os.Stderr, "samoyed-axudp: reading config: %v\n", parseErr)
+		os.Exit(1)
+	}
+
+	fmt.Printf("samoyed-axudp: WARNING: this is beta software; behaviour may change in future releases\n")
+	fmt.Printf("samoyed-axudp: MAP table:\n")
+	for _, e := range maps {
+		fmt.Printf("  %s -> %s\n", e.AX25Addr, e.Addr)
+	}
+
+	var udpAddr, resolveErr = net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", *udpPort))
+	if resolveErr != nil {
+		fmt.Fprintf(os.Stderr, "samoyed-axudp: resolve UDP addr: %v\n", resolveErr)
+		os.Exit(1)
+	}
+
+	var udpConn, listenErr = net.ListenUDP("udp", udpAddr)
+	if listenErr != nil {
+		fmt.Fprintf(os.Stderr, "samoyed-axudp: UDP listen on port %d: %v\n", *udpPort, listenErr)
+		os.Exit(1)
+	}
+	fmt.Printf("samoyed-axudp: AXUDP listening on UDP port %d\n", *udpPort)
+
+	var b = direwolf.NewAXUDPBridge(maps, udpConn, *verbose)
+
+	go b.RunUDPListener()
+	b.RunKISSServer(*kissPort)
+}

--- a/src/axudp.go
+++ b/src/axudp.go
@@ -1,0 +1,459 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package direwolf
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AXUDPMapEntry holds one MAP line from the config.
+type AXUDPMapEntry struct {
+	AX25Addr string       // AX.25 address, i.e. callsign and optional SSID, e.g. "Q1TEST" or "Q1TEST-1"
+	Addr     string       // UDP address string for display/logging, e.g. "192.0.2.1:20093"
+	UDPAddr  *net.UDPAddr // pre-resolved UDP address for sending
+}
+
+// axudpYAMLConfig is the top-level structure of the axudp.yaml config file.
+type axudpYAMLConfig struct {
+	Maps []axudpYAMLMapEntry `yaml:"maps"`
+}
+
+// axudpYAMLMapEntry represents one entry under the "maps" key.
+type axudpYAMLMapEntry struct {
+	AX25Addr string `yaml:"ax25addr"`
+	Host     string `yaml:"host"`
+	Port     int    `yaml:"port"`
+}
+
+// ParseAXUDPConfig reads a YAML config file from path and returns the map entries.
+func ParseAXUDPConfig(path string) ([]AXUDPMapEntry, error) {
+	var data, err = os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg axudpYAMLConfig
+	var unmarshalErr = yaml.Unmarshal(data, &cfg)
+	if unmarshalErr != nil {
+		return nil, fmt.Errorf("parsing YAML config: %w", unmarshalErr)
+	}
+
+	var entries = make([]AXUDPMapEntry, 0, len(cfg.Maps))
+	for i, m := range cfg.Maps {
+		// Normalise ax25addr: strip surrounding whitespace, uppercase, and
+		// remove a trailing "-0" (SSID 0 is represented without any suffix by
+		// axudpExtractDest, so "CALL-0" would never match without this step).
+		var ax25addr = strings.ToUpper(strings.TrimSpace(m.AX25Addr))
+		ax25addr = strings.TrimSuffix(ax25addr, "-0")
+		if ax25addr == "" {
+			return nil, fmt.Errorf("map entry %d: ax25addr is empty", i)
+		}
+		if m.Host == "" {
+			return nil, fmt.Errorf("map entry %d: host is empty", i)
+		}
+		if m.Port < 1 || m.Port > 65535 {
+			return nil, fmt.Errorf("map entry %d: port %d out of range (1-65535)", i, m.Port)
+		}
+		var addr = net.JoinHostPort(m.Host, strconv.Itoa(m.Port))
+		var udpAddr, resolveErr = net.ResolveUDPAddr("udp", addr)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("map entry %d: resolving %s: %w", i, addr, resolveErr)
+		}
+		entries = append(entries, AXUDPMapEntry{
+			AX25Addr: ax25addr,
+			Addr:     addr,
+			UDPAddr:  udpAddr,
+		})
+	}
+	return entries, nil
+}
+
+// axudpExtractDest extracts the destination AX.25 address from a raw AX.25 frame.
+// Returns "" if the frame is too short.
+func axudpExtractDest(frame []byte) string {
+	if len(frame) < 7 {
+		return ""
+	}
+
+	var call [6]byte
+	for i := range 6 {
+		call[i] = frame[i] >> 1
+	}
+
+	var callstr = strings.TrimRight(string(call[:]), " ")
+
+	var ssid = (frame[6] >> 1) & 0x0F
+	if ssid != 0 {
+		callstr = fmt.Sprintf("%s-%d", callstr, ssid)
+	}
+
+	return callstr
+}
+
+// AXUDPBridge is the live state of the bridge.
+type AXUDPBridge struct {
+	maps    []AXUDPMapEntry
+	udpConn *net.UDPConn
+	verbose bool
+
+	mu      sync.Mutex
+	clients []net.Conn
+}
+
+// NewAXUDPBridge creates a new AXUDPBridge routing AXUDP datagrams according to maps,
+// sending/receiving on udpConn.  If verbose is set, every packet sent and received is logged.
+func NewAXUDPBridge(maps []AXUDPMapEntry, udpConn *net.UDPConn, verbose bool) *AXUDPBridge {
+	var b = new(AXUDPBridge)
+	b.maps = maps
+	b.udpConn = udpConn
+	b.verbose = verbose
+	return b
+}
+
+// maxUDPPayload is the maximum value of the UDP length field (which covers the
+// 8-byte UDP header plus payload, so actual payload is up to 8 bytes less).
+// Using this as a read buffer size guarantees ReadFromUDP never truncates a
+// datagram regardless of payload length.
+const maxUDPPayload = 65535
+
+// RunUDPListener reads incoming AXUDP datagrams and forwards them as KISS to all clients.
+func (b *AXUDPBridge) RunUDPListener() {
+	var buf = make([]byte, maxUDPPayload)
+	for {
+		var n, _, readErr = b.udpConn.ReadFromUDP(buf)
+		if readErr != nil {
+			// A UDP read error means the socket is broken; the UDP side of
+			// the bridge is now dead.  Exit so the process can be restarted
+			// rather than silently continuing with no incoming traffic.
+			fmt.Fprintf(os.Stderr, "samoyed-axudp: UDP listener fatal error: %v\n", readErr)
+			os.Exit(1)
+		}
+
+		if n < 1 {
+			continue
+		}
+
+		// CRC stripping and broadcastKISS are synchronous below, so it is safe
+		// to slice the read buffer directly without an extra allocation.
+		var raw = buf[:n]
+
+		// RFC 1226 specifies a 16-bit CRC-CCITT checksum for AXIP (TCP/IP);
+		// most AXUDP implementations have copied this over even though UDP
+		// already includes its own checksum.  There is no protocol negotiation
+		// and no way to distinguish such a peer from one that does not append a
+		// checksum.  We auto-detect by checking whether the trailing 2 bytes
+		// form a valid checksum; if so we strip them.
+		var ax25frame []byte
+		if stripped, ok := axudpStripCRC(raw); ok {
+			ax25frame = stripped
+		} else {
+			ax25frame = raw
+		}
+
+		if len(ax25frame) == 0 {
+			continue
+		}
+
+		if b.verbose {
+			// The first 7 bytes of an AX.25 frame are the destination address —
+			// for an incoming AXUDP datagram this is typically our local callsign.
+			var dest = axudpExtractDest(ax25frame)
+			fmt.Printf("samoyed-axudp: received AXUDP datagram, %d bytes, dest address=%q\n", n, dest)
+		}
+		b.broadcastKISS(ax25frame)
+	}
+}
+
+// RunKISSServer accepts TCP connections from KISS clients.
+func (b *AXUDPBridge) RunKISSServer(kissPort int) {
+	var ln, listenErr = net.Listen("tcp", fmt.Sprintf(":%d", kissPort))
+	if listenErr != nil {
+		fmt.Fprintf(os.Stderr, "samoyed-axudp: TCP listen on port %d: %v\n", kissPort, listenErr)
+		os.Exit(1)
+	}
+	fmt.Printf("samoyed-axudp: KISS TCP server listening on port %d\n", kissPort)
+
+	for {
+		var conn, acceptErr = ln.Accept()
+		if acceptErr != nil {
+			// A closed listener cannot recover; exit so the process can be
+			// restarted rather than spinning on a broken socket.
+			if errors.Is(acceptErr, net.ErrClosed) {
+				fmt.Fprintf(os.Stderr, "samoyed-axudp: accept fatal error: %v\n", acceptErr)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "samoyed-axudp: accept: %v\n", acceptErr)
+			continue
+		}
+		fmt.Printf("samoyed-axudp: new KISS client %v\n", conn.RemoteAddr())
+		go b.handleKISSClient(conn)
+	}
+}
+
+func (b *AXUDPBridge) addClient(c net.Conn) {
+	b.mu.Lock()
+	b.clients = append(b.clients, c)
+	b.mu.Unlock()
+}
+
+func (b *AXUDPBridge) removeClient(c net.Conn) {
+	b.mu.Lock()
+	var next []net.Conn
+	for _, cl := range b.clients {
+		if cl != c {
+			next = append(next, cl)
+		}
+	}
+	b.clients = next
+	b.mu.Unlock()
+}
+
+// axudpBroadcastWriteTimeout is the per-write deadline applied when forwarding
+// KISS frames to TCP clients.  A stalled client is disconnected after this
+// duration so it cannot block delivery to other clients.
+const axudpBroadcastWriteTimeout = 5 * time.Second
+
+// broadcastKISS sends a KISS-wrapped AX.25 frame to all KISS TCP clients.
+func (b *AXUDPBridge) broadcastKISS(ax25frame []byte) {
+	// Pre-check: minimum on-wire KISS overhead is 3 bytes (opening FEND +
+	// type byte + closing FEND), so even with zero escaping the encoded
+	// frame can never be shorter than len(ax25frame)+3. If that best case
+	// already exceeds the limit, skip the expensive encoding step entirely.
+	if len(ax25frame) > MAX_KISS_LEN-3 {
+		fmt.Fprintf(os.Stderr, "samoyed-axudp: dropping oversized AX.25 frame (%d bytes), too large to KISS-encode within %d bytes\n", len(ax25frame), MAX_KISS_LEN)
+		return
+	}
+
+	// Prepend type byte 0x00 (channel 0, DATA_FRAME) before KISS-encoding.
+	var payload = append([]byte{KISS_CMD_DATA_FRAME}, ax25frame...)
+	var kissframe = KissEncapsulate(payload)
+
+	// The nettnc.go KISS reader uses a fixed [MAX_KISS_LEN] accumulator: bytes
+	// beyond that limit are dropped with an error message, and when the closing
+	// FEND then arrives it writes at index MAX_KISS_LEN causing an out-of-bounds
+	// panic.  Drop the frame before writing to clients to prevent this.
+	if len(kissframe) > MAX_KISS_LEN {
+		fmt.Fprintf(os.Stderr, "samoyed-axudp: dropping oversized KISS frame (%d bytes > %d), AX.25 frame too large after encoding\n", len(kissframe), MAX_KISS_LEN)
+		return
+	}
+
+	b.mu.Lock()
+	var snapshot = make([]net.Conn, len(b.clients))
+	copy(snapshot, b.clients)
+	b.mu.Unlock()
+
+	for _, c := range snapshot {
+		var deadlineErr = c.SetWriteDeadline(time.Now().Add(axudpBroadcastWriteTimeout))
+		if deadlineErr != nil {
+			// Cannot set a deadline — treat as a broken connection and close it
+			// to unblock the read goroutine in handleKISSClient.
+			c.Close()
+			continue
+		}
+		var _, writeErr = c.Write(kissframe)
+		if writeErr != nil {
+			// Close the connection to unblock the read goroutine in
+			// handleKISSClient, which will call removeClient via its defer.
+			// We do not call removeClient here to keep teardown centralised.
+			c.Close()
+		}
+	}
+}
+
+// ax25AddrBase returns the AX.25 address without any SSID suffix (i.e. strips "-N").
+func ax25AddrBase(cs string) string {
+	if idx := strings.LastIndexByte(cs, '-'); idx >= 0 {
+		return cs[:idx]
+	}
+	return cs
+}
+
+// lookupMap finds the MAP entry for the given destination AX.25 address.
+// A MAP entry with no SSID matches any SSID of that base address;
+// a MAP entry with an SSID matches only that exact address-SSID pair.
+// Exact matches always take priority over wildcard (no-SSID) matches,
+// regardless of the order entries appear in the config file.
+func (b *AXUDPBridge) lookupMap(dest string) (AXUDPMapEntry, bool) {
+	// First pass: exact match (callsign + SSID must match precisely).
+	for _, e := range b.maps {
+		if e.AX25Addr == dest {
+			return e, true
+		}
+	}
+	// Second pass: base-call wildcard (entry has no SSID, matches any SSID).
+	for _, e := range b.maps {
+		if !strings.ContainsRune(e.AX25Addr, '-') && ax25AddrBase(dest) == e.AX25Addr {
+			return e, true
+		}
+	}
+	return AXUDPMapEntry{}, false //nolint: exhaustruct
+}
+
+// axudpAddCRC appends the 2-byte AXUDP checksum to frame and returns the
+// result.  The checksum is CRC-CCITT (poly 0x1021, seed 0xFFFF, final XOR
+// 0xFFFF) over the frame bytes, appended little-endian.
+func axudpAddCRC(frame []byte) []byte {
+	var crc = fcs_calc(frame)
+	return append(append([]byte(nil), frame...), byte(crc), byte(crc>>8))
+}
+
+// axudpStripCRC validates and strips the 2-byte AXUDP checksum from the
+// end of pkt.  Returns the AX.25 frame and true if valid, or nil and false if
+// the checksum is wrong or the packet is too short.
+func axudpStripCRC(pkt []byte) ([]byte, bool) {
+	if len(pkt) < 2 {
+		return nil, false
+	}
+	var frame = pkt[:len(pkt)-2]
+	var want = fcs_calc(frame)
+	var got = uint16(pkt[len(pkt)-2]) | uint16(pkt[len(pkt)-1])<<8
+	if got != want {
+		return nil, false
+	}
+	return frame, true
+}
+
+// sendAXUDP sends a raw AX.25 frame to the given UDP address.
+// A CRC-CCITT checksum is always appended (per RFC 1226 / AXUDP convention).
+func (b *AXUDPBridge) sendAXUDP(ax25frame []byte, entry AXUDPMapEntry) {
+	var pkt = axudpAddCRC(ax25frame)
+	var n, writeErr = b.udpConn.WriteTo(pkt, entry.UDPAddr)
+	if writeErr != nil {
+		fmt.Fprintf(os.Stderr, "samoyed-axudp: UDP send to %s: %v\n", entry.Addr, writeErr)
+	} else if b.verbose {
+		fmt.Printf("samoyed-axudp: sent %d bytes via AXUDP to %s\n", n, entry.Addr)
+	}
+}
+
+// handleKISSClient reads KISS frames from one TCP client and routes them as AXUDP.
+func (b *AXUDPBridge) handleKISSClient(conn net.Conn) {
+	defer conn.Close()
+	defer b.removeClient(conn)
+
+	b.addClient(conn)
+
+	var kf KISSFrame
+	var overflow bool
+
+	var buf = make([]byte, 2048)
+	for {
+		var n, readErr = conn.Read(buf)
+
+		// Process any bytes returned in this call before inspecting the error:
+		// Read is permitted to return (n>0, err) simultaneously, and we must
+		// not discard the final bytes of a stream.
+		if b.verbose && n > 0 {
+			fmt.Printf("samoyed-axudp: received %d bytes from KISS client %v\n", n, conn.RemoteAddr())
+		}
+
+		for _, byt := range buf[:n] {
+			my_kiss_rec_byte_axudp(&kf, &overflow, byt, b)
+		}
+
+		if readErr != nil {
+			fmt.Printf("samoyed-axudp: KISS client %v disconnected: %v\n", conn.RemoteAddr(), readErr)
+			return
+		}
+	}
+}
+
+// my_kiss_rec_byte_axudp accumulates one KISS byte.
+// When a complete frame is collected, the AX.25 payload is extracted
+// and forwarded to the appropriate AXUDP destination.
+// overflow must point to a caller-owned bool that persists across calls for the
+// same connection; it is set to true when a frame exceeds MAX_KISS_LEN and
+// cleared when collection resets, so the truncated frame is discarded.
+func my_kiss_rec_byte_axudp(kf *KISSFrame, overflow *bool, b byte, b2 *AXUDPBridge) {
+	if kf.state == KS_SEARCHING {
+		if b == FEND {
+			*overflow = false
+			kf.kiss_len = 0
+			kf.kiss_msg[kf.kiss_len] = b
+			kf.kiss_len++
+			kf.state = KS_COLLECTING
+		}
+
+		return
+	}
+
+	// Collecting.
+	if b == FEND {
+		if kf.kiss_len <= 1 {
+			// Empty or double-FEND — restart.
+			*overflow = false
+			kf.kiss_len = 0
+			kf.kiss_msg[kf.kiss_len] = b
+			kf.kiss_len++
+			kf.state = KS_COLLECTING
+
+			return
+		}
+
+		if *overflow || kf.kiss_len >= MAX_KISS_LEN {
+			// Frame exceeded MAX_KISS_LEN, or filled the buffer exactly
+			// leaving no room for the closing FEND — discard it entirely.
+			fmt.Fprintf(os.Stderr, "samoyed-axudp: KISS frame exceeded max length (%d bytes), discarding\n", MAX_KISS_LEN)
+			*overflow = false
+			kf.kiss_len = 0
+			kf.state = KS_SEARCHING
+
+			return
+		}
+
+		if kf.kiss_len < MAX_KISS_LEN {
+			kf.kiss_msg[kf.kiss_len] = b
+			kf.kiss_len++
+		}
+
+		var unwrapped = kiss_unwrap(kf.kiss_msg[:kf.kiss_len])
+
+		// unwrapped[0] is the type byte (channel << 4 | cmd).
+		// We only care about DATA_FRAME commands (lower nibble == 0).
+		if b2.verbose {
+			fmt.Printf("samoyed-axudp: KISS frame complete, %d bytes unwrapped, type byte 0x%02x\n", len(unwrapped), func() byte {
+				if len(unwrapped) > 0 {
+					return unwrapped[0]
+				}
+				return 0
+			}())
+		}
+		if len(unwrapped) >= 2 && (unwrapped[0]&0x0F) == KISS_CMD_DATA_FRAME {
+			var ax25frame = unwrapped[1:]
+			var dest = axudpExtractDest(ax25frame)
+			if b2.verbose {
+				fmt.Printf("samoyed-axudp: AX.25 frame dest=%q, %d bytes, forwarding via AXUDP\n", dest, len(ax25frame))
+			}
+			if dest == "" {
+				fmt.Fprintf(os.Stderr, "samoyed-axudp: frame too short to extract destination\n")
+			} else if entry, ok := b2.lookupMap(dest); ok {
+				b2.sendAXUDP(ax25frame, entry)
+			} else {
+				fmt.Fprintf(os.Stderr, "samoyed-axudp: no MAP entry for destination %s, dropping\n", dest)
+			}
+		} else if len(unwrapped) >= 1 && b2.verbose {
+			fmt.Printf("samoyed-axudp: ignoring non-data KISS command 0x%02x\n", unwrapped[0]&0x0F)
+		}
+
+		kf.kiss_len = 0
+		kf.state = KS_SEARCHING
+
+		return
+	}
+
+	if kf.kiss_len < MAX_KISS_LEN {
+		kf.kiss_msg[kf.kiss_len] = b
+		kf.kiss_len++
+	} else {
+		*overflow = true
+	}
+}

--- a/src/axudp_test.go
+++ b/src/axudp_test.go
@@ -1,0 +1,575 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package direwolf
+
+import (
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAXUDPAddCRC(t *testing.T) {
+	// A minimal AX.25 frame (14 bytes: dest + src address fields).
+	var frame = []byte{
+		0x82, 0xA0, 0x6E, 0x98, 0x9C, 0x40, 0xE0, // dest
+		0x82, 0xA0, 0x6E, 0x98, 0x9C, 0x42, 0x61, // src
+	}
+
+	var got = axudpAddCRC(frame)
+
+	// Must be 2 bytes longer.
+	if len(got) != len(frame)+2 {
+		t.Fatalf("axudpAddCRC: want len %d, got %d", len(frame)+2, len(got))
+	}
+
+	// Frame bytes must be unchanged at the start.
+	for i, b := range frame {
+		if got[i] != b {
+			t.Fatalf("axudpAddCRC: frame byte %d changed: want 0x%02x got 0x%02x", i, b, got[i])
+		}
+	}
+
+	// CRC is at the end as a LE uint16 and must equal FCSCalc(frame).
+	var want = fcs_calc(frame)
+	var crc = uint16(got[len(frame)]) | uint16(got[len(frame)+1])<<8
+	if crc != want {
+		t.Errorf("axudpAddCRC: crc=0x%04x want 0x%04x", crc, want)
+	}
+}
+
+func TestAXUDPStripCRC(t *testing.T) {
+	var frame = []byte{0xAA, 0xBB, 0xCC, 0xDD}
+	var withCRC = axudpAddCRC(frame)
+
+	var got, ok = axudpStripCRC(withCRC)
+	if !ok {
+		t.Fatal("axudpStripCRC: reported invalid checksum for a packet we just built")
+	}
+
+	if len(got) != len(frame) {
+		t.Fatalf("axudpStripCRC: want len %d, got %d", len(frame), len(got))
+	}
+
+	for i, b := range frame {
+		if got[i] != b {
+			t.Fatalf("axudpStripCRC: byte %d: want 0x%02x got 0x%02x", i, b, got[i])
+		}
+	}
+}
+
+func TestAXUDPStripCRCBadChecksum(t *testing.T) {
+	// A bare AX.25 frame with no CRC appended — should be rejected.
+	var raw = []byte{
+		0x82, 0xA0, 0x6E, 0x98, 0x9C, 0x40, 0xE0,
+		0x82, 0xA0, 0x6E, 0x98, 0x9C, 0x42, 0x61,
+	}
+
+	var _, ok = axudpStripCRC(raw)
+	if ok {
+		t.Error("axudpStripCRC: accepted a frame with no CRC appended (should have failed)")
+	}
+}
+
+func TestAXUDPParseConfig(t *testing.T) {
+	var dir = t.TempDir()
+	var p = filepath.Join(dir, "axudp.yaml")
+	var content = `maps:
+  - ax25addr: q1test
+    host: 192.0.2.1
+    port: 93
+  - ax25addr: Q2TEST-7
+    host: 192.0.2.2
+    port: 20093
+`
+	var writeErr = os.WriteFile(p, []byte(content), 0600)
+	if writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	var entries, err = ParseAXUDPConfig(p)
+	if err != nil {
+		t.Fatalf("ParseAXUDPConfig: unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("ParseAXUDPConfig: want 2 entries, got %d", len(entries))
+	}
+	if entries[0].AX25Addr != "Q1TEST" {
+		t.Errorf("entries[0].AX25Addr = %q, want %q", entries[0].AX25Addr, "Q1TEST")
+	}
+	if entries[0].Addr != "192.0.2.1:93" {
+		t.Errorf("entries[0].Addr = %q, want %q", entries[0].Addr, "192.0.2.1:93")
+	}
+	if entries[1].AX25Addr != "Q2TEST-7" {
+		t.Errorf("entries[1].AX25Addr = %q, want %q", entries[1].AX25Addr, "Q2TEST-7")
+	}
+	if entries[1].Addr != "192.0.2.2:20093" {
+		t.Errorf("entries[1].Addr = %q, want %q", entries[1].Addr, "192.0.2.2:20093")
+	}
+}
+
+func TestAXUDPParseConfigNormalisesAX25Addr(t *testing.T) {
+	var cases = []struct {
+		name     string
+		ax25addr string
+		wantNorm string
+	}{
+		{"lowercase", "q1test", "Q1TEST"},
+		{"with leading/trailing spaces", "  Q1TEST  ", "Q1TEST"},
+		{"ssid zero stripped", "Q1TEST-0", "Q1TEST"},
+		{"lowercase with ssid zero", "q1test-0", "Q1TEST"},
+		{"non-zero ssid preserved", "Q1TEST-7", "Q1TEST-7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var dir = t.TempDir()
+			var p = filepath.Join(dir, "axudp.yaml")
+			var content = "maps:\n  - ax25addr: " + tc.ax25addr + "\n    host: 192.0.2.1\n    port: 93\n"
+			var writeErr = os.WriteFile(p, []byte(content), 0600)
+			if writeErr != nil {
+				t.Fatal(writeErr)
+			}
+			var entries, err = ParseAXUDPConfig(p)
+			if err != nil {
+				t.Fatalf("ParseAXUDPConfig: unexpected error: %v", err)
+			}
+			if entries[0].AX25Addr != tc.wantNorm {
+				t.Errorf("AX25Addr = %q, want %q", entries[0].AX25Addr, tc.wantNorm)
+			}
+		})
+	}
+}
+
+func TestAXUDPParseConfigResolvesUDPAddr(t *testing.T) {
+	var dir = t.TempDir()
+	var p = filepath.Join(dir, "axudp.yaml")
+	var content = `maps:
+  - ax25addr: Q1TEST
+    host: 192.0.2.1
+    port: 93
+`
+	var writeErr = os.WriteFile(p, []byte(content), 0600)
+	if writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	var entries, err = ParseAXUDPConfig(p)
+	if err != nil {
+		t.Fatalf("ParseAXUDPConfig: unexpected error: %v", err)
+	}
+	if entries[0].UDPAddr == nil {
+		t.Fatal("ParseAXUDPConfig: UDPAddr is nil, expected resolved address")
+	}
+	if entries[0].UDPAddr.String() != "192.0.2.1:93" {
+		t.Errorf("UDPAddr = %q, want %q", entries[0].UDPAddr.String(), "192.0.2.1:93")
+	}
+}
+
+func TestAXUDPParseConfigFileNotFound(t *testing.T) {
+	var _, err = ParseAXUDPConfig("/nonexistent/axudp.yaml")
+	if err == nil {
+		t.Error("ParseAXUDPConfig: expected error for missing file, got nil")
+	}
+}
+
+func TestAXUDPParseConfigValidation(t *testing.T) {
+	var cases = []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "empty ax25addr",
+			content: `maps:
+  - ax25addr: ""
+    host: 192.0.2.1
+    port: 93
+`,
+		},
+		{
+			name: "empty host",
+			content: `maps:
+  - ax25addr: Q1TEST
+    host: ""
+    port: 93
+`,
+		},
+		{
+			name: "port zero",
+			content: `maps:
+  - ax25addr: Q1TEST
+    host: 192.0.2.1
+    port: 0
+`,
+		},
+		{
+			name: "port too high",
+			content: `maps:
+  - ax25addr: Q1TEST
+    host: 192.0.2.1
+    port: 65536
+`,
+		},
+		{
+			name: "whitespace-only ax25addr",
+			content: `maps:
+  - ax25addr: "   "
+    host: 192.0.2.1
+    port: 93
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var dir = t.TempDir()
+			var p = filepath.Join(dir, "axudp.yaml")
+			var writeErr = os.WriteFile(p, []byte(tc.content), 0600)
+			if writeErr != nil {
+				t.Fatal(writeErr)
+			}
+			var _, err = ParseAXUDPConfig(p)
+			if err == nil {
+				t.Errorf("ParseAXUDPConfig: expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestAXUDPParseConfigBadYAML(t *testing.T) {
+	var dir = t.TempDir()
+	var p = filepath.Join(dir, "axudp.yaml")
+	var writeErr = os.WriteFile(p, []byte("{ not valid yaml: ["), 0600)
+	if writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	var _, err = ParseAXUDPConfig(p)
+	if err == nil {
+		t.Error("ParseAXUDPConfig: expected error for malformed YAML, got nil")
+	}
+}
+
+func TestAXUDPLookupMap(t *testing.T) {
+	var b = new(AXUDPBridge)
+	b.maps = []AXUDPMapEntry{
+		{AX25Addr: "Q1TEST", Addr: "192.0.2.1:93", UDPAddr: nil},   // no SSID — should match all SSIDs
+		{AX25Addr: "Q2TEST-7", Addr: "192.0.2.2:93", UDPAddr: nil}, // with SSID — exact match only
+	}
+
+	var cases = []struct {
+		dest      string
+		wantAddr  string
+		wantFound bool
+	}{
+		// Q1TEST (no SSID) matches bare address and any SSID
+		{"Q1TEST", "192.0.2.1:93", true},
+		{"Q1TEST-1", "192.0.2.1:93", true},
+		{"Q1TEST-15", "192.0.2.1:93", true},
+		// Q2TEST-7 (with SSID) matches only exact
+		{"Q2TEST-7", "192.0.2.2:93", true},
+		{"Q2TEST", "", false},
+		{"Q2TEST-1", "", false},
+		// Unknown address
+		{"Q3TEST", "", false},
+	}
+
+	for _, tc := range cases {
+		var entry, ok = b.lookupMap(tc.dest)
+		if ok != tc.wantFound {
+			t.Errorf("lookupMap(%q): found=%v want %v", tc.dest, ok, tc.wantFound)
+			continue
+		}
+		if ok && entry.Addr != tc.wantAddr {
+			t.Errorf("lookupMap(%q): addr=%q want %q", tc.dest, entry.Addr, tc.wantAddr)
+		}
+	}
+}
+
+// TestAXUDPLookupMapExactBeforeWildcard verifies that an exact SSID match takes
+// priority over a no-SSID (wildcard) entry regardless of YAML order.
+func TestAXUDPLookupMapExactBeforeWildcard(t *testing.T) {
+	// Wildcard entry is listed first; specific SSID entry is listed second.
+	// A lookup for Q1TEST-7 must return the specific entry, not the wildcard.
+	var b = new(AXUDPBridge)
+	b.maps = []AXUDPMapEntry{
+		{AX25Addr: "Q1TEST", Addr: "192.0.2.1:93", UDPAddr: nil},   // wildcard — listed first
+		{AX25Addr: "Q1TEST-7", Addr: "192.0.2.2:93", UDPAddr: nil}, // specific SSID-7 — listed second
+	}
+
+	var entry, ok = b.lookupMap("Q1TEST-7")
+	if !ok {
+		t.Fatal("lookupMap(Q1TEST-7): not found")
+	}
+	if entry.Addr != "192.0.2.2:93" {
+		t.Errorf("lookupMap(Q1TEST-7): got addr %q, want specific entry 192.0.2.2:93 (exact match must beat wildcard)", entry.Addr)
+	}
+
+	// Wildcard should still match when no exact entry exists.
+	var entry2, ok2 = b.lookupMap("Q1TEST-3")
+	if !ok2 {
+		t.Fatal("lookupMap(Q1TEST-3): not found via wildcard")
+	}
+	if entry2.Addr != "192.0.2.1:93" {
+		t.Errorf("lookupMap(Q1TEST-3): got addr %q, want wildcard entry 192.0.2.1:93", entry2.Addr)
+	}
+}
+
+// TestKISSExactlyFullBufferDiscarded verifies that a KISS frame that fills the
+// accumulator buffer exactly (kf.kiss_len == MAX_KISS_LEN when the closing FEND
+// arrives, so no room to append the closing FEND) is treated as overflow and
+// discarded rather than forwarded as a truncated/unterminated frame.
+//
+// The frame is constructed so that, if forwarded, sendAXUDP would be called on a
+// bridge with a nil UDP connection, which would panic.  A panic therefore means
+// the frame was forwarded; no panic means it was correctly discarded.
+func TestKISSExactlyFullBufferDiscarded(t *testing.T) {
+	// Build a bridge with a map entry that matches the destination encoded in
+	// the test frame below.  The udpConn is intentionally left nil so that any
+	// accidental call to sendAXUDP panics immediately.
+	var b = new(AXUDPBridge)
+	b.maps = []AXUDPMapEntry{
+		{AX25Addr: "Q1TEST", Addr: "192.0.2.1:93", UDPAddr: nil},
+	}
+
+	// The KISS DATA frame payload is: type byte (0x00) followed by an AX.25
+	// frame whose first 7 bytes are the encoded destination "Q1TEST\x00" (SSID
+	// 0, end-of-address bit set → 0xE0).  We pad the rest to reach exactly
+	// MAX_KISS_LEN - 1 content bytes so that together with the opening FEND
+	// the accumulator holds exactly MAX_KISS_LEN bytes when the closing FEND
+	// arrives (kf.kiss_len == MAX_KISS_LEN, *overflow == false).
+	//
+	// AX.25 address encoding: each character shifted left one bit.
+	// Q=0x51<<1=0xA2, 1=0x31<<1=0x62, T=0x54<<1=0xA8, E=0x45<<1=0x8A, S=0x53<<1=0xA6, T=0x54<<1=0xA8
+	// SSID byte: 0xE0 (no SSID, end-of-address-field set for destination)
+	var ax25Dest = []byte{0xA2, 0x62, 0xA8, 0x8A, 0xA6, 0xA8, 0xE0}
+
+	// Total content bytes = 1 (type) + len(ax25Dest) + padding = MAX_KISS_LEN - 1
+	var padLen = MAX_KISS_LEN - 1 - 1 - len(ax25Dest)
+	var content []byte
+	content = append(content, KISS_CMD_DATA_FRAME) // type byte
+	content = append(content, ax25Dest...)
+	for range padLen {
+		content = append(content, 0x41)
+	}
+
+	// Build stream: FEND + content (MAX_KISS_LEN-1 bytes) + FEND.
+	// Opening FEND → kf.kiss_len = 1; content → kf.kiss_len = MAX_KISS_LEN;
+	// closing FEND arrives with kf.kiss_len == MAX_KISS_LEN, *overflow == false.
+	var buf []byte
+	buf = append(buf, FEND)
+	buf = append(buf, content...)
+	buf = append(buf, FEND)
+
+	// If the frame is forwarded despite being unterminated, sendAXUDP will
+	// dereference the nil udpConn and panic — recover it as a test failure.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("exactly-full buffer frame was forwarded (sendAXUDP panicked): %v", r)
+		}
+	}()
+
+	var kf KISSFrame
+	var overflow bool
+	for _, by := range buf {
+		my_kiss_rec_byte_axudp(&kf, &overflow, by, b)
+	}
+
+	// After the closing FEND the state machine must reset cleanly.
+	if overflow {
+		t.Error("overflow flag should be cleared after discarding exactly-full frame")
+	}
+	if kf.state != KS_SEARCHING {
+		t.Error("state != searching after exactly-full frame, want searching")
+	}
+	if kf.kiss_len != 0 {
+		t.Errorf("kiss_len = %d after exactly-full frame, want 0", kf.kiss_len)
+	}
+}
+
+// TestKISSOverflowDiscarded verifies that a frame whose raw KISS bytes exceed
+// MAX_KISS_LEN is discarded on the closing FEND rather than forwarded in
+// truncated form.  It checks that the state machine resets cleanly.
+func TestKISSOverflowDiscarded(t *testing.T) {
+	// Empty bridge — no maps, so even an accidentally forwarded frame would
+	// just log to stderr rather than panic.
+	var b = new(AXUDPBridge)
+
+	// Build a KISS input: FEND + type byte + MAX_KISS_LEN data bytes + FEND.
+	// MAX_KISS_LEN data bytes is enough to trigger the overflow condition.
+	var buf []byte
+	buf = append(buf, FEND)
+	buf = append(buf, KISS_CMD_DATA_FRAME)
+	for range MAX_KISS_LEN {
+		buf = append(buf, 0x41)
+	}
+	buf = append(buf, FEND)
+
+	var kf KISSFrame
+	var overflow bool
+	for _, by := range buf {
+		my_kiss_rec_byte_axudp(&kf, &overflow, by, b)
+	}
+
+	// After the closing FEND the overflow flag should be cleared and the state
+	// machine should be back in searching with kiss_len reset.
+	if overflow {
+		t.Error("overflow flag should be cleared after discarding frame")
+	}
+	if kf.state != KS_SEARCHING {
+		t.Error("state != searching after overflow frame, want searching")
+	}
+	if kf.kiss_len != 0 {
+		t.Errorf("kiss_len = %d after overflow frame, want 0", kf.kiss_len)
+	}
+}
+
+// fakeConn is a minimal net.Conn implementation that records Write calls.
+type fakeConn struct {
+	mu     sync.Mutex
+	writes [][]byte
+}
+
+func (f *fakeConn) Write(b []byte) (int, error) {
+	f.mu.Lock()
+	f.writes = append(f.writes, append([]byte(nil), b...))
+	f.mu.Unlock()
+	return len(b), nil
+}
+
+func (f *fakeConn) SetWriteDeadline(_ time.Time) error { return nil }
+func (f *fakeConn) Close() error                       { return nil }
+func (f *fakeConn) Read(_ []byte) (int, error)         { return 0, nil }
+func (f *fakeConn) LocalAddr() net.Addr                { return nil }
+func (f *fakeConn) RemoteAddr() net.Addr               { return nil }
+func (f *fakeConn) SetDeadline(_ time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(_ time.Time) error  { return nil }
+
+// singleReadConn is a net.Conn that returns a fixed payload together with
+// io.EOF on the first Read call, simulating a TCP connection that delivers its
+// last bytes in the same call as EOF (the (n>0, err!=nil) case permitted by the
+// io.Reader contract).  Subsequent calls return (0, io.EOF).
+type singleReadConn struct {
+	fakeConn
+
+	data []byte
+	mu   sync.Mutex
+	done bool
+}
+
+func (c *singleReadConn) Read(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.done {
+		return 0, io.EOF
+	}
+	c.done = true
+	return copy(b, c.data), io.EOF
+}
+
+// TestHandleKISSClientProcessesFinalReadBytes is a regression test for the
+// case where conn.Read returns (n>0, io.EOF): bytes in the final read must be
+// processed before the loop exits, not silently dropped.
+func TestHandleKISSClientProcessesFinalReadBytes(t *testing.T) {
+	// Create a UDP socket pair: src is used by the bridge, dst receives frames.
+	var srcPkt, srcErr = net.ListenPacket("udp", "127.0.0.1:0")
+	if srcErr != nil {
+		t.Fatal(srcErr)
+	}
+	defer srcPkt.Close()
+
+	var dstPkt, dstErr = net.ListenPacket("udp", "127.0.0.1:0")
+	if dstErr != nil {
+		t.Fatal(dstErr)
+	}
+	defer dstPkt.Close()
+
+	var dstUDP, dstOK = dstPkt.(*net.UDPConn)
+	if !dstOK {
+		t.Fatal("dstPkt is not a *net.UDPConn")
+	}
+	var dstLocalAddr = dstUDP.LocalAddr()
+	var dstAddr, dstAddrOK = dstLocalAddr.(*net.UDPAddr)
+	if !dstAddrOK {
+		t.Fatal("dstPkt local addr is not a *net.UDPAddr")
+	}
+
+	var srcUDP, srcOK = srcPkt.(*net.UDPConn)
+	if !srcOK {
+		t.Fatal("srcPkt is not a *net.UDPConn")
+	}
+
+	// Build a minimal KISS DATA frame carrying an AX.25 frame destined for Q1TEST.
+	// AX.25 encoding: each callsign character shifted left 1 bit.
+	// Q=0xA2 1=0x62 T=0xA8 E=0x8A S=0xA6 T=0xA8  SSID=0xE0 (no SSID, end-of-addr)
+	var ax25Dest = []byte{0xA2, 0x62, 0xA8, 0x8A, 0xA6, 0xA8, 0xE0}
+	// Arbitrary source address with end-of-address bit set.
+	var ax25Src = []byte{0xA4, 0x64, 0xAA, 0x8C, 0xA8, 0xAA, 0x61}
+	var ax25frame = append(ax25Dest, ax25Src...)
+	var payload = append([]byte{KISS_CMD_DATA_FRAME}, ax25frame...)
+	var kissframe = KissEncapsulate(payload)
+
+	// Set up a bridge with a MAP entry routing Q1TEST to dstPkt.
+	var b = new(AXUDPBridge)
+	b.maps = []AXUDPMapEntry{
+		{AX25Addr: "Q1TEST", Addr: dstAddr.String(), UDPAddr: dstAddr},
+	}
+	b.udpConn = srcUDP
+
+	// fconn delivers the full KISS frame + io.EOF in a single Read call.
+	var fconn = new(singleReadConn)
+	fconn.data = kissframe
+
+	var done = make(chan struct{})
+	go func() {
+		b.handleKISSClient(fconn)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleKISSClient did not exit after conn returned io.EOF")
+	}
+
+	// An AXUDP datagram must have been forwarded to dstPkt.
+	var setErr = dstUDP.SetReadDeadline(time.Now().Add(time.Second))
+	if setErr != nil {
+		t.Fatal(setErr)
+	}
+	var rxBuf = make([]byte, 4096)
+	var n, _, rxErr = dstUDP.ReadFromUDP(rxBuf)
+	if rxErr != nil {
+		t.Fatalf("no AXUDP datagram received — bytes from final read were dropped: %v", rxErr)
+	}
+	if n == 0 {
+		t.Fatal("received empty AXUDP datagram")
+	}
+}
+
+// TestBroadcastKISSDropsOversizedFrame verifies that broadcastKISS does not
+// write a KISS-encoded frame to clients when the on-wire length would exceed
+// MAX_KISS_LEN.  Oversized frames would be silently truncated by the nettnc.go
+// KISS reader, producing corrupt AX.25 data.
+func TestBroadcastKISSDropsOversizedFrame(t *testing.T) {
+	var b = new(AXUDPBridge)
+	var fc = new(fakeConn)
+	b.clients = []net.Conn{fc}
+
+	// An AX.25 frame large enough that KissEncapsulate produces > MAX_KISS_LEN
+	// bytes: payload = 1 type byte + ax25frame, encapsulated with 2 FENDs.
+	// With no bytes needing escaping, output = len(payload) + 2 bytes.
+	// We need len(payload) > MAX_KISS_LEN - 2, so len(ax25frame) >= MAX_KISS_LEN - 2.
+	var ax25frame = make([]byte, MAX_KISS_LEN)
+	b.broadcastKISS(ax25frame)
+
+	fc.mu.Lock()
+	var writeCount = len(fc.writes)
+	fc.mu.Unlock()
+
+	if writeCount != 0 {
+		t.Errorf("broadcastKISS wrote %d frame(s) to client for oversized frame, want 0", writeCount)
+	}
+}


### PR DESCRIPTION
Bridges a local KISS client to a remote node via the AXUDP protocol -
AX.25 over UDP.

Slightly experimental, subject to change, but works well enough to get
me on the UK network, with thanks to Tom M9TWM!

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
