### PR TITLE
fix: More config fixen

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -3637,7 +3637,7 @@ func handleTTCORRAL(ps *parseState) bool {
 	t = split("", false)
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
-		dw_printf("Line %d: Missing longitude for TTCORRAL command.\n", ps.line)
+		dw_printf("Line %d: Missing offset-or-ambiguity for TTCORRAL command.\n", ps.line)
 		return true
 	}
 	ps.tt.corral_offset = parse_ll(t, LAT, ps.line)

--- a/src/config.go
+++ b/src/config.go
@@ -5907,7 +5907,13 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_chan = 0
 			} else if value[0] == 'r' || value[0] == 'R' {
 				var n, _ = strconv.Atoi(value[1:])
-				if (n < 0 || n >= MAX_TOTAL_CHANS || p_audio_config.chan_medium[n] == MEDIUM_NONE) && p_audio_config.chan_medium[n] != MEDIUM_IGATE {
+				if n < 0 || n >= MAX_TOTAL_CHANS {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file, line %d: Simulated receive on channel %d is not valid.\n", line, n)
+
+					continue
+				}
+				if p_audio_config.chan_medium[n] == MEDIUM_NONE {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Simulated receive on channel %d is not valid.\n", line, n)
 
@@ -5918,7 +5924,13 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_chan = n
 			} else if value[0] == 't' || value[0] == 'T' || value[0] == 'x' || value[0] == 'X' {
 				var n, _ = strconv.Atoi(value[1:])
-				if (n < 0 || n >= MAX_TOTAL_CHANS || p_audio_config.chan_medium[n] == MEDIUM_NONE) && p_audio_config.chan_medium[n] != MEDIUM_IGATE {
+				if n < 0 || n >= MAX_TOTAL_CHANS {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, n)
+
+					continue
+				}
+				if p_audio_config.chan_medium[n] == MEDIUM_NONE {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, n)
 
@@ -5929,7 +5941,13 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_chan = n
 			} else {
 				var n, _ = strconv.Atoi(value)
-				if (n < 0 || n >= MAX_TOTAL_CHANS || p_audio_config.chan_medium[n] == MEDIUM_NONE) && p_audio_config.chan_medium[n] != MEDIUM_IGATE {
+				if n < 0 || n >= MAX_TOTAL_CHANS {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, n)
+
+					continue
+				}
+				if p_audio_config.chan_medium[n] == MEDIUM_NONE {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, n)
 
@@ -6159,7 +6177,14 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 	/* Check is here because could be using default channel when SENDTO= is not specified. */
 
 	if b.sendto_type == SENDTO_XMIT {
-		if (b.sendto_chan < 0 || b.sendto_chan >= MAX_TOTAL_CHANS || p_audio_config.chan_medium[b.sendto_chan] == MEDIUM_NONE) && p_audio_config.chan_medium[b.sendto_chan] != MEDIUM_IGATE {
+		if b.sendto_chan < 0 || b.sendto_chan >= MAX_TOTAL_CHANS {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, b.sendto_chan)
+
+			return errors.New("TODO")
+		}
+
+		if p_audio_config.chan_medium[b.sendto_chan] == MEDIUM_NONE {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, b.sendto_chan)
 

--- a/src/config.go
+++ b/src/config.go
@@ -5104,7 +5104,7 @@ func handleKISSPORT(ps *parseState) bool {
 		var channelErr error
 
 		kissChannel, channelErr = strconv.Atoi(t)
-		if ps.channel < 0 || kissChannel >= MAX_TOTAL_CHANS || channelErr != nil {
+		if kissChannel < 0 || kissChannel >= MAX_TOTAL_CHANS || channelErr != nil {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Line %d: Invalid channel %d for KISSPORT command.  Must be in range 0 thru %d.\n", ps.line, kissChannel, MAX_TOTAL_CHANS-1)
 

--- a/src/config.go
+++ b/src/config.go
@@ -1641,10 +1641,14 @@ func handleNCHANNEL(ps *parseState) bool {
 		} else {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Line %d: NCHANNEL can't use channel %d because it is already in use.\n", ps.line, nchan)
+
+			return true
 		}
 	} else {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: NCHANNEL number must in range of %d to %d.\n", ps.line, MAX_RADIO_CHANS, MAX_TOTAL_CHANS-1)
+
+		return true
 	}
 
 	t = split("", false)

--- a/src/config.go
+++ b/src/config.go
@@ -15,7 +15,7 @@ package direwolf
 
 import (
 	"bufio"
-	"errors"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -5850,7 +5850,7 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file: No = found in, %s, on line %d.\n", t, line)
 
-			return errors.New("TODO")
+			return fmt.Errorf("config file line %d: no = found in %q", line, t)
 		}
 
 		// QUICK TEMP EXPERIMENT, maybe permanent new feature.
@@ -6103,7 +6103,7 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file, line %d: Invalid option keyword, %s.\n", line, keyword)
 
-			return errors.New("TODO")
+			return fmt.Errorf("config file line %d: invalid option keyword %q", line, keyword)
 		}
 	}
 
@@ -6187,14 +6187,14 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, b.sendto_chan)
 
-			return errors.New("TODO")
+			return fmt.Errorf("config file line %d: send-to channel %d is out of range", line, b.sendto_chan)
 		}
 
 		if p_audio_config.chan_medium[b.sendto_chan] == MEDIUM_NONE {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, b.sendto_chan)
 
-			return errors.New("TODO")
+			return fmt.Errorf("config file line %d: send-to channel %d has no medium configured", line, b.sendto_chan)
 		}
 
 		if p_audio_config.chan_medium[b.sendto_chan] == MEDIUM_IGATE { // Prevent subscript out of bounds.
@@ -6203,14 +6203,14 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Config file: MYCALL must be set for channel %d before beaconing is allowed.\n", 0)
 
-				return errors.New("TODO")
+				return fmt.Errorf("config file line %d: MYCALL must be set for channel 0 before beaconing", line)
 			}
 		} else {
 			if IsNoCall(p_audio_config.mycall[b.sendto_chan]) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Config file: MYCALL must be set for channel %d before beaconing is allowed.\n", b.sendto_chan)
 
-				return errors.New("TODO")
+				return fmt.Errorf("config file line %d: MYCALL must be set for channel %d before beaconing", line, b.sendto_chan)
 			}
 		}
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -1652,7 +1652,7 @@ func handleNCHANNEL(ps *parseState) bool {
 		}
 	} else {
 		text_color_set(DW_COLOR_ERROR)
-		dw_printf("Line %d: NCHANNEL number must in range of %d to %d.\n", ps.line, MAX_RADIO_CHANS, MAX_TOTAL_CHANS-1)
+		dw_printf("Line %d: NCHANNEL number must be in range of %d to %d.\n", ps.line, MAX_RADIO_CHANS, MAX_TOTAL_CHANS-1)
 
 		return true
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -1383,29 +1383,35 @@ func handleADEVICE(ps *parseState) bool {
 		return true
 	}
 
-	ps.audio.adev[ps.adevice].defined = 1
-
 	// New case for release 1.8.
 
 	if t == "=" {
+		t = split("", false)
 		text_color_set(DW_COLOR_ERROR)
-		dw_printf("Config file: ADEVICE = n (copy-from) is not yet implemented. Line %d.\n", ps.line)
+		if t == "" {
+			dw_printf("Config file: ADEVICE%d mapping syntax requires a source device number on line %d.\n", ps.adevice, ps.line)
+		} else {
+			dw_printf("Config file: ADEVICE%d = %s mapping syntax is not implemented on line %d.\n", ps.adevice, t, ps.line)
+		}
 
 		return true
-	} else {
-		/* First channel of device is valid. */
-		// This might be changed to UDP or STDIN when the device name is examined.
-		ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)] = MEDIUM_RADIO
-
-		ps.audio.adev[ps.adevice].adevice_in = t
-		ps.audio.adev[ps.adevice].adevice_out = t
-
-		t = split("", false)
-		if t != "" {
-			// Different audio devices for receive and transmit.
-			ps.audio.adev[ps.adevice].adevice_out = t
-		}
 	}
+
+	ps.audio.adev[ps.adevice].defined = 1
+
+	/* First channel of device is valid. */
+	// This might be changed to UDP or STDIN when the device name is examined.
+	ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)] = MEDIUM_RADIO
+
+	ps.audio.adev[ps.adevice].adevice_in = t
+	ps.audio.adev[ps.adevice].adevice_out = t
+
+	t = split("", false)
+	if t != "" {
+		// Different audio devices for receive and transmit.
+		ps.audio.adev[ps.adevice].adevice_out = t
+	}
+
 	return false
 }
 

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -340,6 +340,15 @@ func Test_config_init_adevice(t *testing.T) {
 		assert.Equal(t, "hw:1,0", cfg.adev[1].adevice_in)
 		assert.Equal(t, "hw:1,0", cfg.adev[1].adevice_out)
 	})
+
+	t.Run("ADEVICE1 = n mapping syntax is rejected and leaves device 1 undefined", func(t *testing.T) {
+		var cfg, _ = configFromString(t, "ADEVICE1 = 0\n")
+		// The = (copy-from) mapping syntax is unimplemented; the handler must
+		// return early without marking device 1 as defined or assigning any
+		// channel medium for its first channel (channel 2 = ADEVFIRSTCHAN(1)).
+		assert.Equal(t, 0, cfg.adev[1].defined)
+		assert.Equal(t, MEDIUM_NONE, cfg.chan_medium[ADEVFIRSTCHAN(1)])
+	})
 }
 
 // --- config_init CHANNEL directive ---


### PR DESCRIPTION
- **fix: Return early in NCHANNEL error cases to prevent out-of-bounds access**
- **fix: Validate kissChannel lower bound in KISSPORT, not ps.channel**
- **fix: Split SENDTO chan_medium checks to prevent out-of-bounds panics**
- **fix: Correct TTCORRAL error message for missing third parameter**
- **fix: Reject unimplemented ADEVICE= mapping syntax with a clear error**
