### PR TITLE
fix: Even more config fixen

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -1557,7 +1557,13 @@ func handleCHANNEL(ps *parseState) bool {
 		return true
 	}
 
-	var n, _ = strconv.Atoi(t)
+	var n, nErr = strconv.Atoi(t)
+	if nErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Channel number must be numeric for CHANNEL command.\n", ps.line)
+
+		return true
+	}
 	if n >= 0 && n < MAX_RADIO_CHANS {
 		ps.channel = n
 

--- a/src/config.go
+++ b/src/config.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"fmt"
 	"math"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -4773,21 +4774,25 @@ func handleIGSERVER(ps *parseState) bool {
 
 	ps.igate.t2_server_name = t
 
-	/* If there is a : in the name, split it out as the port number. */
+	/* If there is a : in the name, split it out as the port number.
+	 * Use net.SplitHostPort to correctly handle bracketed IPv6 addresses like [::1]:8080.
+	 */
 
 	if strings.Contains(t, ":") {
-		var hostname, portStr, _ = strings.Cut(t, ":")
-		ps.igate.t2_server_name = hostname
+		var hostname, portStr, splitErr = net.SplitHostPort(t)
+		if splitErr == nil {
+			ps.igate.t2_server_name = hostname
 
-		var port, portErr = strconv.Atoi(portStr)
-		if port >= MIN_IP_PORT_NUMBER && port <= MAX_IP_PORT_NUMBER && portErr == nil {
-			ps.igate.t2_server_port = port
-		} else {
-			ps.igate.t2_server_port = DEFAULT_IGATE_PORT
+			var port, portErr = strconv.Atoi(portStr)
+			if port >= MIN_IP_PORT_NUMBER && port <= MAX_IP_PORT_NUMBER && portErr == nil {
+				ps.igate.t2_server_port = port
+			} else {
+				ps.igate.t2_server_port = DEFAULT_IGATE_PORT
 
-			text_color_set(DW_COLOR_ERROR)
-			dw_printf("Line %d: Invalid port number for IGate server. Using default %d.\n",
-				ps.line, ps.igate.t2_server_port)
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Invalid port number for IGate server. Using default %d.\n",
+					ps.line, ps.igate.t2_server_port)
+			}
 		}
 	}
 

--- a/src/config.go
+++ b/src/config.go
@@ -3799,7 +3799,12 @@ func handleTTVECTOR(ps *parseState) bool {
 		dw_printf("Line %d: Missing scale for TTVECTOR command.\n", ps.line)
 		return true
 	}
-	var scale, _ = strconv.ParseFloat(t, 64)
+	var scale, scaleErr = strconv.ParseFloat(t, 64)
+	if scaleErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid scale \"%s\" for TTVECTOR command.\n", ps.line, t)
+		return true
+	}
 
 	// Unit.
 

--- a/src/config.go
+++ b/src/config.go
@@ -4938,8 +4938,8 @@ func handleIGTXVIA(ps *parseState) bool {
 		return true
 	}
 
-	var n, _ = strconv.Atoi(t)
-	if n < 0 || n > MAX_TOTAL_CHANS-1 {
+	var n, nErr = strconv.Atoi(t)
+	if nErr != nil || n < 0 || n > MAX_TOTAL_CHANS-1 {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n",
 			MAX_TOTAL_CHANS-1, ps.line)

--- a/src/config.go
+++ b/src/config.go
@@ -1836,7 +1836,7 @@ func handleMODEM(ps *parseState) bool {
 	t = split("", false)
 	if t == "" {
 		/* all done. */
-		return true
+		return false
 	}
 
 	if alldigits(t) {

--- a/src/config.go
+++ b/src/config.go
@@ -5511,7 +5511,12 @@ func handleXBEACON(ps *parseState) bool {
 		/* Save line number because some errors will be reported later. */
 		ps.misc.beacon[ps.misc.num_beacons].lineno = ps.line
 
-		if beacon_options(ps.text[len("xBEACON")+1:], &(ps.misc.beacon[ps.misc.num_beacons]), ps.line, ps.audio) == nil {
+		// Pass "" so beacon_options continues from the current split() position
+		// rather than reinitialising the tokenizer. The main parse loop already
+		// called split(ps.text, false) to extract the keyword, leaving any
+		// options as the remaining state; passing "" here reads those options
+		// correctly and also handles the case where there are none.
+		if beacon_options("", &(ps.misc.beacon[ps.misc.num_beacons]), ps.line, ps.audio) == nil {
 			ps.misc.num_beacons++
 		}
 	} else {

--- a/src/config.go
+++ b/src/config.go
@@ -4576,6 +4576,7 @@ func handleTTOBJ(ps *parseState) bool {
 	var x = -1
 	var app = 0
 	var ig = 0
+	var whereToValid = true
 
 	for part := range strings.SplitSeq(t, ",") {
 		part = strings.TrimSpace(part)
@@ -4591,17 +4592,57 @@ func handleTTOBJ(ps *parseState) bool {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n", MAX_TOTAL_CHANS-1, ps.line)
 					x = -1
+					whereToValid = false
 				} else if ps.audio.chan_medium[x] != MEDIUM_RADIO &&
 					ps.audio.chan_medium[x] != MEDIUM_NETTNC {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: TTOBJ transmit channel %d is not valid.\n", ps.line, x)
 					x = -1
+					whereToValid = false
 				}
 			} else {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: Expected comma separated list with some combination of transmit channel, APP, and IG.\n", ps.line)
+				/* Check for legacy compact form like "APPIG" or "AIG" accepted by the old parser. */
+				var isLegacy = true
+				for _, c := range part {
+					if !unicode.IsDigit(c) && !strings.ContainsRune("aApPiIgG", c) {
+						isLegacy = false
+						break
+					}
+				}
+				if isLegacy {
+					for _, c := range part {
+						switch {
+						case c == 'a' || c == 'A':
+							app = 1
+						case c == 'i' || c == 'I':
+							ig = 1
+						case unicode.IsDigit(c):
+							x = int(c - '0')
+							if x < 0 || x > MAX_TOTAL_CHANS-1 {
+								text_color_set(DW_COLOR_ERROR)
+								dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n", MAX_TOTAL_CHANS-1, ps.line)
+								x = -1
+								whereToValid = false
+							} else if ps.audio.chan_medium[x] != MEDIUM_RADIO &&
+								ps.audio.chan_medium[x] != MEDIUM_NETTNC {
+								text_color_set(DW_COLOR_ERROR)
+								dw_printf("Config file, line %d: TTOBJ transmit channel %d is not valid.\n", ps.line, x)
+								x = -1
+								whereToValid = false
+							}
+						}
+					}
+				} else {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file, line %d: Expected comma separated list with some combination of transmit channel, APP, and IG.\n", ps.line)
+					whereToValid = false
+				}
 			}
 		}
+	}
+
+	if !whereToValid {
+		return true
 	}
 
 	// This enables the DTMF decoder on the specified channel.

--- a/src/config.go
+++ b/src/config.go
@@ -4518,9 +4518,10 @@ func handleTTMACRO(ps *parseState) bool {
 
 	var d_count [3]int
 
-	for j := 0; j < len(otemp.String()); j++ {
-		if otemp.String()[j] >= 'x' && otemp.String()[j] <= 'z' {
-			d_count[otemp.String()[j]-'x']++
+	var otempStr = otemp.String()
+	for j := 0; j < len(otempStr); j++ {
+		if otempStr[j] >= 'x' && otempStr[j] <= 'z' {
+			d_count[otempStr[j]-'x']++
 		}
 	}
 

--- a/src/config.go
+++ b/src/config.go
@@ -1347,7 +1347,7 @@ func handleADEVICE(ps *parseState) bool {
 
 	// ps.keyword holds the original token e.g. "ADEVICE" or "ADEVICE1".
 	if len(ps.keyword) >= 8 {
-		var i, iErr = strconv.Atoi(string(ps.keyword[7]))
+		var i, iErr = strconv.Atoi(ps.keyword[7:])
 		if iErr != nil {
 			dw_printf("Config file: Could not parse ADEVICE number on line %d: %s.\n", ps.line, iErr)
 			return true

--- a/src/config.go
+++ b/src/config.go
@@ -3964,22 +3964,40 @@ func handleTTUTM(ps *parseState) bool {
 
 	t = split("", false)
 	if t != "" {
+		var scaleVal, scaleErr = strconv.ParseFloat(t, 64)
+		if scaleErr != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Invalid scale \"%s\" for TTUTM command.\n", ps.line, t)
+			return true
+		}
 
-		tl.utm.scale, _ = strconv.ParseFloat(t, 64)
+		tl.utm.scale = scaleVal
 
 		// Optional x offset.
 
 		t = split("", false)
 		if t != "" {
+			var xOffset, xErr = strconv.ParseFloat(t, 64)
+			if xErr != nil {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Line %d: Invalid x offset \"%s\" for TTUTM command.\n", ps.line, t)
+				return true
+			}
 
-			tl.utm.x_offset, _ = strconv.ParseFloat(t, 64)
+			tl.utm.x_offset = xOffset
 
 			// Optional y offset.
 
 			t = split("", false)
 			if t != "" {
+				var yOffset, yErr = strconv.ParseFloat(t, 64)
+				if yErr != nil {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Line %d: Invalid y offset \"%s\" for TTUTM command.\n", ps.line, t)
+					return true
+				}
 
-				tl.utm.y_offset, _ = strconv.ParseFloat(t, 64)
+				tl.utm.y_offset = yOffset
 			}
 		}
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -4093,7 +4093,7 @@ func handleTTMHEAD(ps *parseState) bool {
 	 *			Pattern would be  B[0-9A-D]xxxx...
 	 *			Optional prefix is 10, 6, or 4 digits.
 	 *
-	 *			The total number of digts in both must be 4, 6, 10, or 12.
+	 *			The total number of digits in both must be 4, 6, 10, or 12.
 	 */
 
 	// TODO1.3:  TTMHEAD needs testing.
@@ -6246,7 +6246,7 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 	/*
 	 * Process symbol now that we have any later overlay.
 	 *
-	 * FIXME: Someone who used this was surprised to end up with Solar Powser  (S-).
+	 * FIXME: Someone who used this was surprised to end up with Solar Power  (S-).
 	 *	overlay=S symbol="/-"
 	 * We should complain if overlay used with symtab other than \.
 	 */

--- a/src/config.go
+++ b/src/config.go
@@ -5366,7 +5366,14 @@ func handleGPSNMEA(ps *parseState) bool {
 
 	t = split("", false)
 	if t != "" {
-		var n, _ = strconv.Atoi(t)
+		var n, nErr = strconv.Atoi(t)
+		if nErr != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file, line %d: Invalid speed \"%s\" for GPSNMEA command.\n", ps.line, t)
+
+			return true
+		}
+
 		ps.misc.gpsnmea_speed = n
 	} else {
 		ps.misc.gpsnmea_speed = 4800 // The standard at one time.

--- a/src/config.go
+++ b/src/config.go
@@ -5288,7 +5288,15 @@ func handleNULLMODEM(ps *parseState) bool {
 
 	t = split("", false)
 	if t != "" {
-		ps.misc.kiss_serial_speed, _ = strconv.Atoi(t)
+		var n, nErr = strconv.Atoi(t)
+		if nErr != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Config file: Invalid speed \"%s\" for NULLMODEM/SERIALKISS command on line %d.\n", t, ps.line)
+
+			return true
+		}
+
+		ps.misc.kiss_serial_speed = n
 	}
 	return false
 }

--- a/src/config.go
+++ b/src/config.go
@@ -5323,14 +5323,14 @@ func handleDNSSD(ps *parseState) bool {
 		return true
 	}
 
-	var n, _ = strconv.Atoi(t)
-	if n == 0 || n == 1 {
-		ps.misc.dns_sd_enabled = n != 0
-	} else {
+	var n, nErr = strconv.Atoi(t)
+	if nErr != nil || (n != 0 && n != 1) {
 		ps.misc.dns_sd_enabled = false
 
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Invalid integer value for DNSSD. Disabling dns-sd.\n", ps.line)
+	} else {
+		ps.misc.dns_sd_enabled = n != 0
 	}
 	return false
 }

--- a/src/config.go
+++ b/src/config.go
@@ -6012,8 +6012,8 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_type = SENDTO_IGATE
 				b.sendto_chan = 0
 			} else if value[0] == 'r' || value[0] == 'R' {
-				var n, _ = strconv.Atoi(value[1:])
-				if n < 0 || n >= MAX_TOTAL_CHANS {
+				var n, nErr = strconv.Atoi(value[1:])
+				if nErr != nil || n < 0 || n >= MAX_TOTAL_CHANS {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Simulated receive on channel %d is not valid.\n", line, n)
 
@@ -6029,8 +6029,8 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_type = SENDTO_RECV
 				b.sendto_chan = n
 			} else if value[0] == 't' || value[0] == 'T' || value[0] == 'x' || value[0] == 'X' {
-				var n, _ = strconv.Atoi(value[1:])
-				if n < 0 || n >= MAX_TOTAL_CHANS {
+				var n, nErr = strconv.Atoi(value[1:])
+				if nErr != nil || n < 0 || n >= MAX_TOTAL_CHANS {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, n)
 
@@ -6046,8 +6046,8 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_type = SENDTO_XMIT
 				b.sendto_chan = n
 			} else {
-				var n, _ = strconv.Atoi(value)
-				if n < 0 || n >= MAX_TOTAL_CHANS {
+				var n, nErr = strconv.Atoi(value)
+				if nErr != nil || n < 0 || n >= MAX_TOTAL_CHANS {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, n)
 

--- a/src/config.go
+++ b/src/config.go
@@ -5919,7 +5919,12 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 		} else if strings.EqualFold(keyword, "EVERY") {
 			b.every = parse_interval(value, line)
 		} else if strings.EqualFold(keyword, "SENDTO") {
-			if value[0] == 'i' || value[0] == 'I' {
+			if len(value) == 0 {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file, line %d: Missing value for SENDTO option.\n", line)
+
+				continue
+			} else if value[0] == 'i' || value[0] == 'I' {
 				b.sendto_type = SENDTO_IGATE
 				b.sendto_chan = 0
 			} else if value[0] == 'r' || value[0] == 'R' {

--- a/src/config.go
+++ b/src/config.go
@@ -4570,35 +4570,37 @@ func handleTTOBJ(ps *parseState) bool {
 		return true
 	}
 
-	// Can have any combination of number, APP, IG.
-	// Would it be easier with strtok?
+	// Can have any combination of channel number, APP, IG, separated by commas.
+	// Parse as a comma-separated list so multi-digit channels (>= 10) work correctly.
 
 	var x = -1
 	var app = 0
 	var ig = 0
 
-	for _, p := range t {
-		if unicode.IsDigit(p) {
-			x = int(p - '0')
-			if x < 0 || x > MAX_TOTAL_CHANS-1 {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n", MAX_TOTAL_CHANS-1, ps.line)
-				x = -1
-			} else if ps.audio.chan_medium[x] != MEDIUM_RADIO &&
-				ps.audio.chan_medium[x] != MEDIUM_NETTNC {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("Config file, line %d: TTOBJ transmit channel %d is not valid.\n", ps.line, x)
-				x = -1
-			}
-		} else if p == 'a' || p == 'A' {
+	for part := range strings.SplitSeq(t, ",") {
+		part = strings.TrimSpace(part)
+		if strings.EqualFold(part, "APP") || strings.EqualFold(part, "A") {
 			app = 1
-		} else if p == 'i' || p == 'I' {
+		} else if strings.EqualFold(part, "IG") || strings.EqualFold(part, "I") {
 			ig = 1
-		} else if strings.ContainsRune("pPgG,", p) {
-			// Skip?
 		} else {
-			text_color_set(DW_COLOR_ERROR)
-			dw_printf("Config file, line %d: Expected comma separated list with some combination of transmit channel, APP, and IG.\n", ps.line)
+			var chanNum, chanErr = strconv.Atoi(part)
+			if chanErr == nil {
+				x = chanNum
+				if x < 0 || x > MAX_TOTAL_CHANS-1 {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file: Transmit channel must be in range of 0 to %d on line %d.\n", MAX_TOTAL_CHANS-1, ps.line)
+					x = -1
+				} else if ps.audio.chan_medium[x] != MEDIUM_RADIO &&
+					ps.audio.chan_medium[x] != MEDIUM_NETTNC {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file, line %d: TTOBJ transmit channel %d is not valid.\n", ps.line, x)
+					x = -1
+				}
+			} else {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("Config file, line %d: Expected comma separated list with some combination of transmit channel, APP, and IG.\n", ps.line)
+			}
 		}
 	}
 

--- a/src/config.go
+++ b/src/config.go
@@ -4793,6 +4793,12 @@ func handleIGSERVER(ps *parseState) bool {
 				dw_printf("Line %d: Invalid port number for IGate server. Using default %d.\n",
 					ps.line, ps.igate.t2_server_port)
 			}
+		} else {
+			/* net.SplitHostPort failed (e.g. malformed input like "host:"); fall back to simple cut. */
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("Line %d: Could not parse IGate server address '%s': %v\n",
+				ps.line, t, splitErr)
+			ps.igate.t2_server_name, _, _ = strings.Cut(t, ":")
 		}
 	}
 

--- a/src/config.go
+++ b/src/config.go
@@ -6047,7 +6047,13 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_chan = 0
 			} else if value[0] == 'r' || value[0] == 'R' {
 				var n, nErr = strconv.Atoi(value[1:])
-				if nErr != nil || n < 0 || n >= MAX_TOTAL_CHANS {
+				if nErr != nil {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file, line %d: Non-numeric channel \"%s\" for SENDTO=r option.\n", line, value[1:])
+
+					continue
+				}
+				if n < 0 || n >= MAX_TOTAL_CHANS {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Simulated receive on channel %d is not valid.\n", line, n)
 
@@ -6064,7 +6070,13 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_chan = n
 			} else if value[0] == 't' || value[0] == 'T' || value[0] == 'x' || value[0] == 'X' {
 				var n, nErr = strconv.Atoi(value[1:])
-				if nErr != nil || n < 0 || n >= MAX_TOTAL_CHANS {
+				if nErr != nil {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file, line %d: Non-numeric channel \"%s\" for SENDTO=t option.\n", line, value[1:])
+
+					continue
+				}
+				if n < 0 || n >= MAX_TOTAL_CHANS {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, n)
 
@@ -6081,7 +6093,13 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				b.sendto_chan = n
 			} else {
 				var n, nErr = strconv.Atoi(value)
-				if nErr != nil || n < 0 || n >= MAX_TOTAL_CHANS {
+				if nErr != nil {
+					text_color_set(DW_COLOR_ERROR)
+					dw_printf("Config file, line %d: Non-numeric channel \"%s\" for SENDTO option.\n", line, value)
+
+					continue
+				}
+				if n < 0 || n >= MAX_TOTAL_CHANS {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, n)
 

--- a/src/config.go
+++ b/src/config.go
@@ -5044,7 +5044,13 @@ func handleAGWPORT(ps *parseState) bool {
 
 		return true
 	}
-	var n, _ = strconv.Atoi(t)
+	var n, nErr = strconv.Atoi(t)
+	if nErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid port number \"%s\" for AGWPORT command.\n", ps.line, t)
+
+		return true
+	}
 
 	t = split("", false)
 	if t != "" {
@@ -5096,7 +5102,13 @@ func handleKISSPORT(ps *parseState) bool {
 
 		return true
 	}
-	var n, _ = strconv.Atoi(t)
+	var n, nErr = strconv.Atoi(t)
+	if nErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid TCP port number \"%s\" for KISSPORT command.\n", ps.line, t)
+
+		return true
+	}
 
 	var tcp_port int
 	if (n >= MIN_IP_PORT_NUMBER && n <= MAX_IP_PORT_NUMBER) || n == 0 {

--- a/src/config.go
+++ b/src/config.go
@@ -1675,7 +1675,14 @@ func handleNCHANNEL(ps *parseState) bool {
 
 		return true
 	}
-	var n, _ = strconv.Atoi(t)
+	var n, nErr = strconv.Atoi(t)
+	if nErr != nil || n < MIN_IP_PORT_NUMBER || n > MAX_IP_PORT_NUMBER {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Line %d: Invalid TCP port number \"%s\" for NCHANNEL command. Must be in range %d to %d.\n",
+			ps.line, t, MIN_IP_PORT_NUMBER, MAX_IP_PORT_NUMBER)
+
+		return true
+	}
 	ps.audio.nettnc_port[nchan] = n
 	return false
 }

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -482,6 +482,18 @@ func Test_config_init_kissport(t *testing.T) {
 	})
 }
 
+// --- config_init MODEM all-options success ---
+
+func Test_config_init_modem_returns_success(t *testing.T) {
+	t.Run("MODEM with all options parsed successfully does not block subsequent directives", func(t *testing.T) {
+		// Regression test: handleMODEM returned true (error/stop) when all options
+		// were parsed and split returned "".  This caused subsequent directives like
+		// MYCALL to be skipped.  The correct return when successful is false.
+		var cfg, _ = configFromString(t, "MODEM 1200\nMYCALL Q1TEST\n")
+		assert.Equal(t, "Q1TEST", cfg.mycall[0])
+	})
+}
+
 // --- config_init DNSSD directive ---
 
 func Test_config_init_dnssd(t *testing.T) {

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -482,6 +482,25 @@ func Test_config_init_kissport(t *testing.T) {
 	})
 }
 
+// --- config_init DNSSD directive ---
+
+func Test_config_init_dnssd(t *testing.T) {
+	t.Run("DNSSD with non-numeric value is rejected and disabled", func(t *testing.T) {
+		var _, misc = configFromString(t, "DNSSD notanumber\n")
+		assert.False(t, misc.dns_sd_enabled)
+	})
+
+	t.Run("DNSSD 1 enables dns-sd", func(t *testing.T) {
+		var _, misc = configFromString(t, "DNSSD 1\n")
+		assert.True(t, misc.dns_sd_enabled)
+	})
+
+	t.Run("DNSSD 0 disables dns-sd", func(t *testing.T) {
+		var _, misc = configFromString(t, "DNSSD 0\n")
+		assert.False(t, misc.dns_sd_enabled)
+	})
+}
+
 // --- config_init SENDTO non-numeric channel suffix ---
 
 func Test_config_init_beacon_sendto_non_numeric(t *testing.T) {

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -426,3 +426,16 @@ func Test_config_init_modem_directive(t *testing.T) {
 		})
 	}
 }
+
+// --- config_init PBEACON directive (no options) ---
+
+func Test_config_init_pbeacon_no_options(t *testing.T) {
+	t.Run("PBEACON with no options does not panic", func(t *testing.T) {
+		// Regression test: handleXBEACON used ps.text[len("xBEACON")+1:] which
+		// would panic with an index out of range when the line had no trailing
+		// space or options (e.g. just "PBEACON").
+		assert.NotPanics(t, func() {
+			configFromString(t, "PBEACON\n")
+		})
+	})
+}

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -482,6 +482,28 @@ func Test_config_init_kissport(t *testing.T) {
 	})
 }
 
+// --- config_init SENDTO non-numeric channel suffix ---
+
+func Test_config_init_beacon_sendto_non_numeric(t *testing.T) {
+	t.Run("SENDTO=rXYZ with non-numeric channel suffix is rejected", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			configFromString(t, "PBEACON SENDTO=rXYZ\n")
+		})
+	})
+
+	t.Run("SENDTO=tXYZ with non-numeric channel suffix is rejected", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			configFromString(t, "PBEACON SENDTO=tXYZ\n")
+		})
+	})
+
+	t.Run("SENDTO=XYZ with non-numeric value is rejected", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			configFromString(t, "PBEACON SENDTO=XYZ\n")
+		})
+	})
+}
+
 // --- config_init SENDTO beacon option (empty value) ---
 
 func Test_config_init_beacon_sendto_empty(t *testing.T) {

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -427,6 +427,31 @@ func Test_config_init_modem_directive(t *testing.T) {
 	}
 }
 
+// --- config_init AGWPORT directive ---
+
+func Test_config_init_agwport(t *testing.T) {
+	t.Run("AGWPORT with non-numeric value is rejected without panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			configFromString(t, "AGWPORT notanumber\n")
+		})
+	})
+
+	t.Run("AGWPORT with valid port sets agwpe_port", func(t *testing.T) {
+		var _, misc = configFromString(t, "AGWPORT 8000\n")
+		assert.Equal(t, 8000, misc.agwpe_port)
+	})
+}
+
+// --- config_init KISSPORT directive ---
+
+func Test_config_init_kissport(t *testing.T) {
+	t.Run("KISSPORT with non-numeric value is rejected without panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			configFromString(t, "KISSPORT notanumber\n")
+		})
+	})
+}
+
 // --- config_init SENDTO beacon option (empty value) ---
 
 func Test_config_init_beacon_sendto_empty(t *testing.T) {

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -427,6 +427,23 @@ func Test_config_init_modem_directive(t *testing.T) {
 	}
 }
 
+// --- config_init ADEVICE multi-digit suffix ---
+
+func Test_config_init_adevice_multi_digit_suffix(t *testing.T) {
+	t.Run("ADEVICE11 two-digit suffix is parsed as 11 not 1", func(t *testing.T) {
+		// Regression test: handleADEVICE used string(ps.keyword[7]) which reads
+		// only one byte, so "ADEVICE11" would parse suffix "1" instead of "11".
+		// With the fix, suffix "11" is out of range and must be reported as an error
+		// rather than silently configuring device 1.
+		assert.NotPanics(t, func() {
+			configFromString(t, "ADEVICE11 hw:0,0\n")
+		})
+		// Device 1 must remain undefined (suffix 11 is out of range).
+		var cfg, _ = configFromString(t, "ADEVICE11 hw:0,0\n")
+		assert.Equal(t, 0, cfg.adev[1].defined)
+	})
+}
+
 // --- config_init CHANNEL non-numeric ---
 
 func Test_config_init_channel_non_numeric(t *testing.T) {

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -427,6 +427,19 @@ func Test_config_init_modem_directive(t *testing.T) {
 	}
 }
 
+// --- config_init CHANNEL non-numeric ---
+
+func Test_config_init_channel_non_numeric(t *testing.T) {
+	t.Run("CHANNEL with non-numeric value is rejected", func(t *testing.T) {
+		// Regression test: CHANNEL used strconv.Atoi with ignored error; non-numeric
+		// input would silently treat the channel as 0.  Now it must log an error and
+		// leave the channel unchanged.
+		assert.NotPanics(t, func() {
+			configFromString(t, "CHANNEL notanumber\n")
+		})
+	})
+}
+
 // --- config_init AGWPORT directive ---
 
 func Test_config_init_agwport(t *testing.T) {

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -427,6 +427,19 @@ func Test_config_init_modem_directive(t *testing.T) {
 	}
 }
 
+// --- config_init SENDTO beacon option (empty value) ---
+
+func Test_config_init_beacon_sendto_empty(t *testing.T) {
+	t.Run("SENDTO= with empty value does not panic", func(t *testing.T) {
+		// Regression test: beacon_options accessed value[0] without first checking
+		// len(value), which would panic with an index out of range when value is empty
+		// (i.e. SENDTO= with nothing after the equals sign).
+		assert.NotPanics(t, func() {
+			configFromString(t, "PBEACON SENDTO=\n")
+		})
+	})
+}
+
 // --- config_init PBEACON directive (no options) ---
 
 func Test_config_init_pbeacon_no_options(t *testing.T) {


### PR DESCRIPTION
- **fix: Report non-numeric SENDTO channel value explicitly in error message**
- **fix: Reject non-numeric speed in NULLMODEM/SERIALKISS command**
- **fix: Avoid repeated String() calls in TTMACRO definition scan loop**
- **fix: Return false from handleMODEM when all options are parsed successfully**
- **fix: Reject non-numeric transmit channel in IGTXVIA command**
- **fix: Reject non-numeric scale and offsets in TTUTM command**
- **fix: Reject non-numeric speed in GPSNMEA command**
- **fix: Reject non-numeric value for DNSSD command**
- **fix: Reject non-numeric channel suffix in SENDTO beacon option**
- **fix: Parse full numeric suffix of ADEVICE keyword, not just first character**
- **fix: Reject non-numeric channel number in CHANNEL command**
- **fix: Correct typos in comments ("digts" -> "digits", "Powser" -> "Power")**
- **fix: Accept legacy compact TTOBJ where-to forms like APPIG and AIG**
- **fix: Parse TTOBJ where-to as comma-separated list for multi-digit channels**
- **fix: Reject non-numeric scale in TTVECTOR**
- **fix: Emit error when net.SplitHostPort fails for IGSERVER address**
- **fix: Use net.SplitHostPort in IGSERVER to handle IPv6 addresses**
- **fix: Validate NCHANNEL TCP port is numeric and in valid range**
- **fix: Reject non-numeric port in AGWPORT and KISSPORT**
- **fix: Validate SENDTO value is non-empty before indexing value[0]**
- **fix: Avoid panic in handleXBEACON when beacon line has no options**