### PR TITLE
refactor(AIS): Return errors and let callers handle printing

### DIFF
--- a/src/ais.go
+++ b/src/ais.go
@@ -270,12 +270,16 @@ func sextet_to_char(val int) (byte, error) {
  *
  *--------------------------------------------------------------------*/
 
-func ais_to_nmea(ais []byte) []byte {
+func ais_to_nmea(ais []byte) ([]byte, error) {
 	var payload []byte
 	// Number of resulting characters for payload.
 	var ns = uint(len(ais)*8+5) / 6
 	for k := range ns {
-		var ch, _ = sextet_to_char(get_field(ais, k*6, 6))
+		var ch, err = sextet_to_char(get_field(ais, k*6, 6))
+		if err != nil {
+			return nil, err
+		}
+
 		payload = append(payload, ch)
 	}
 
@@ -300,7 +304,7 @@ func ais_to_nmea(ais []byte) []byte {
 	var checksum = fmt.Sprintf("*%02X", cs&0x7f)
 	nmea = append(nmea, []byte(checksum)...)
 
-	return nmea
+	return nmea, nil
 }
 
 /*-------------------------------------------------------------------

--- a/src/ais.go
+++ b/src/ais.go
@@ -251,16 +251,13 @@ func char_to_sextet(ch byte) (int, error) {
 // Values 40 thru 63 become characters '`' thru 'w'.
 // This is known as "Payload Armoring."
 
-func sextet_to_char(val int) byte {
+func sextet_to_char(val int) (byte, error) {
 	if val >= 0 && val <= 39 {
-		return byte('0' + val)
+		return byte('0' + val), nil
 	} else if val >= 40 && val <= 63 {
-		return byte('`' + val - 40)
+		return byte('`' + val - 40), nil
 	} else {
-		text_color_set(DW_COLOR_ERROR)
-		dw_printf("Invalid 6 bit value %d from AIS HDLC payload.\n", val)
-
-		return '0'
+		return '0', fmt.Errorf("invalid 6-bit value %d from AIS HDLC payload", val)
 	}
 }
 
@@ -278,7 +275,8 @@ func ais_to_nmea(ais []byte) []byte {
 	// Number of resulting characters for payload.
 	var ns = uint(len(ais)*8+5) / 6
 	for k := range ns {
-		payload = append(payload, sextet_to_char(get_field(ais, k*6, 6)))
+		var ch, _ = sextet_to_char(get_field(ais, k*6, 6))
+		payload = append(payload, ch)
 	}
 
 	var nmea = []byte("!AIVDM,1,1,,A,")

--- a/src/ais.go
+++ b/src/ais.go
@@ -315,11 +315,17 @@ func ais_to_nmea(ais []byte) ([]byte, error) {
  *
  * Inputs:	sentence	NMEA sentence.
  *
- *		quiet		Suppress printing of error messages.
+ * Returns:	(*AISData, nil)		Success.
  *
- * Returns:	*AISData	Structured AIS message data
+ *		(nil, error)		Fatal error; data is unusable.
+ *					Callers should report the error and
+ *					discard the result.
  *
- * 			errcode 	0 for success, -1 for error.
+ *		(*AISData, error)	Non-fatal warning (e.g. filler-bit
+ *					mismatch); the returned AISData is
+ *					populated and may still be used.
+ *					Callers should report the error but
+ *					may proceed with the data.
  *
  *--------------------------------------------------------------------*/
 
@@ -336,7 +342,7 @@ type AISData struct {
 	comment     string
 }
 
-func ais_parse(sentence string, quiet bool) (*AISData, int) {
+func ais_parse(sentence string) (*AISData, error) {
 	var aisData = new(AISData)
 	aisData.mssi = "?"
 	aisData.lat = G_UNKNOWN
@@ -362,24 +368,14 @@ func ais_parse(sentence string, quiet bool) (*AISData, int) {
 	var data, checksumStr, found = strings.Cut(stemp, "*")
 
 	if !found {
-		if !quiet {
-			text_color_set(DW_COLOR_INFO)
-			dw_printf("Missing AIS sentence checksum.\n")
-		}
-
-		return aisData, -1
+		return nil, fmt.Errorf("missing AIS sentence checksum")
 	}
 
 	var _checksum, _ = strconv.ParseInt(checksumStr, 16, 0)
 	var checksum = byte(_checksum)
 
 	if calculatedChecksum != checksum {
-		if !quiet {
-			text_color_set(DW_COLOR_ERROR)
-			dw_printf("AIS sentence checksum error. Expected %02x but found %s.\n", calculatedChecksum, checksumStr)
-		}
-
-		return aisData, -1
+		return nil, fmt.Errorf("AIS sentence checksum error: expected %02x but found %s", calculatedChecksum, checksumStr)
 	}
 
 	// Extract the comma separated fields.
@@ -402,12 +398,7 @@ func ais_parse(sentence string, quiet bool) (*AISData, int) {
 	_ = radio_chan
 
 	if len(payload) == 0 {
-		if !quiet {
-			text_color_set(DW_COLOR_ERROR)
-			dw_printf("Payload is missing from AIS sentence.\n")
-		}
-
-		return aisData, -1
+		return nil, fmt.Errorf("payload is missing from AIS sentence")
 	}
 
 	// Convert character representation to bit vector.
@@ -417,12 +408,7 @@ func ais_parse(sentence string, quiet bool) (*AISData, int) {
 	for i, b := range payload {
 		var val, err = char_to_sextet(byte(b))
 		if err != nil {
-			if !quiet {
-				text_color_set(DW_COLOR_ERROR)
-				dw_printf("%v\n", err)
-			}
-
-			return aisData, -1
+			return nil, err
 		}
 
 		set_field(ais, uint(i)*6, 6, val)
@@ -434,12 +420,9 @@ func ais_parse(sentence string, quiet bool) (*AISData, int) {
 	var nfill, _ = strconv.Atoi(fill_bits)
 	var nbytes = (plen * 6) / 8
 
+	var fillerErr error
 	if nfill != plen*6-nbytes*8 {
-		if !quiet {
-			text_color_set(DW_COLOR_ERROR)
-			dw_printf("Number of filler bits is %d when %d is expected.\n",
-				nfill, plen*6-nbytes*8)
-		}
+		fillerErr = fmt.Errorf("number of filler bits is %d when %d is expected", nfill, plen*6-nbytes*8)
 	}
 
 	// Extract the fields of interest from a few message types.
@@ -536,7 +519,7 @@ func ais_parse(sentence string, quiet bool) (*AISData, int) {
 		aisData.description = fmt.Sprintf("AIS message type %d", aisType)
 	}
 
-	return aisData, 0
+	return aisData, fillerErr
 } /* end ais_parse */
 
 /*-------------------------------------------------------------------

--- a/src/ais.go
+++ b/src/ais.go
@@ -237,16 +237,13 @@ func get_field_string(base []byte, start uint, length uint) string {
 // Characters '0' thru 'W'  become values 0 thru 39.
 // Characters '`' thru 'w'  become values 40 thru 63.
 
-func char_to_sextet(ch byte) int {
+func char_to_sextet(ch byte) (int, error) {
 	if ch >= '0' && ch <= 'W' {
-		return int(ch - '0')
+		return int(ch - '0'), nil
 	} else if ch >= '`' && ch <= 'w' {
-		return int(ch - '`' + 40)
+		return int(ch - '`' + 40), nil
 	} else {
-		text_color_set(DW_COLOR_ERROR)
-		dw_printf("Invalid character \"%c\" found in AIS NMEA sentence payload.\n", ch)
-
-		return (0)
+		return 0, fmt.Errorf("invalid character %q in AIS NMEA sentence payload", ch)
 	}
 }
 
@@ -416,7 +413,17 @@ func ais_parse(sentence string, quiet bool) (*AISData, int) {
 	var ais = make([]byte, 256)
 
 	for i, b := range payload {
-		set_field(ais, uint(i)*6, 6, char_to_sextet(byte(b)))
+		var val, err = char_to_sextet(byte(b))
+		if err != nil {
+			if !quiet {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("%v\n", err)
+			}
+
+			return aisData, -1
+		}
+
+		set_field(ais, uint(i)*6, 6, val)
 	}
 
 	// Verify number of filler bits.

--- a/src/ais_direwolf_test.go
+++ b/src/ais_direwolf_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_AIS(t *testing.T) {
@@ -15,7 +16,10 @@ func test_sextet(t *testing.T) {
 	t.Helper()
 
 	for i := range 64 {
-		assert.Equal(t, i, char_to_sextet(sextet_to_char(i)))
+		var ch = sextet_to_char(i)
+		var val, err = char_to_sextet(ch)
+		require.NoError(t, err)
+		assert.Equal(t, i, val)
 	}
 }
 

--- a/src/ais_direwolf_test.go
+++ b/src/ais_direwolf_test.go
@@ -10,6 +10,7 @@ import (
 func Test_AIS(t *testing.T) {
 	test_sextet(t)
 	test_basic_parse(t)
+	test_parse_errors(t)
 }
 
 func test_sextet(t *testing.T) {
@@ -29,13 +30,25 @@ func test_basic_parse(t *testing.T) {
 
 	var ais = "!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0*4E" // Example from https://www.aggsoft.com/ais-decoder.htm
 
-	var aisData, status = ais_parse(ais, false)
+	var aisData, err = ais_parse(ais)
 
-	assert.Equal(t, 0, status)
+	require.NoError(t, err)
 	assert.Equal(t, "AIS 1: Position Report Class A", aisData.description)
 	assert.Equal(t, "366730000", aisData.mssi)
 	assert.Empty(t, aisData.comment)
 	assert.InDelta(t, -122, aisData.lon, 1)
 	assert.InDelta(t, 20.8, aisData.knots, 1)
 	assert.InDelta(t, 51.3, aisData.course, 1)
+}
+
+func test_parse_errors(t *testing.T) {
+	t.Helper()
+
+	var data, missingChecksumErr = ais_parse("!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0")
+	require.Error(t, missingChecksumErr)
+	assert.Nil(t, data)
+
+	var data2, checksumMismatchErr = ais_parse("!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0*FF")
+	require.Error(t, checksumMismatchErr)
+	assert.Nil(t, data2)
 }

--- a/src/ais_direwolf_test.go
+++ b/src/ais_direwolf_test.go
@@ -16,7 +16,8 @@ func test_sextet(t *testing.T) {
 	t.Helper()
 
 	for i := range 64 {
-		var ch = sextet_to_char(i)
+		var ch, chErr = sextet_to_char(i)
+		require.NoError(t, chErr)
 		var val, err = char_to_sextet(ch)
 		require.NoError(t, err)
 		assert.Equal(t, i, val)

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -2538,7 +2538,18 @@ func aprs_user_defined(A *decode_aprs_t, info []byte) {
 		bytes.HasPrefix(info, []byte("{DM")) { // Official after registering {D*
 		aprs_morse_code(A, info)
 	} else if info[0] == '{' && info[1] == USER_DEF_USER_ID && info[2] == USER_DEF_TYPE_AIS {
-		var aisData, _ = ais_parse(string(info[3:]), false)
+		var aisData, aisErr = ais_parse(string(info[3:]))
+		if aisErr != nil {
+			if !A.g_quiet {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("%v\n", aisErr)
+			}
+
+			if aisData == nil {
+				A.g_data_type_desc = "AIS"
+				return
+			}
+		}
 
 		A.g_data_type_desc = aisData.description
 		A.g_name = aisData.mssi

--- a/src/multi_modem.go
+++ b/src/multi_modem.go
@@ -262,7 +262,13 @@ func multi_modem_process_rec_frame(channel int, subchan int, slice int, fbuf []b
 
 	switch save_audio_config_p.achan[channel].modem_type {
 	case MODEM_AIS:
-		var nmea = ais_to_nmea(fbuf)
+		var nmea, err = ais_to_nmea(fbuf)
+		if err != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("%v\n", err)
+
+			return
+		}
 
 		// The intention is for the AIS sentences to go only to attached applications.
 		// e.g. SARTrack knows how to parse the AIS sentences.


### PR DESCRIPTION
- **refactor: Make char_to_sextet return error instead of dw_printf-ing**
- **refactor: Make sextet_to_char return error instead of dw_printf-ing**
- **refactor: Make ais_to_nmea return error to propagate from sextet_to_char**
- **refactor: Make ais_parse return error instead of dw_printf-ing**

This introduces slight behavioural changes due to increased parsing/conversion strictness, but this should be minor and preferred 