### PR TITLE
refactor: Export AIS symbols called from other files

### DIFF
--- a/src/ais.go
+++ b/src/ais.go
@@ -270,7 +270,7 @@ func sextet_to_char(val int) (byte, error) {
  *
  *--------------------------------------------------------------------*/
 
-func ais_to_nmea(ais []byte) ([]byte, error) {
+func AISToNMEA(ais []byte) ([]byte, error) {
 	var payload []byte
 	// Number of resulting characters for payload.
 	var ns = uint(len(ais)*8+5) / 6
@@ -309,7 +309,7 @@ func ais_to_nmea(ais []byte) ([]byte, error) {
 
 /*-------------------------------------------------------------------
  *
- * Name:        ais_parse
+ * Name:        AISParse
  *
  * Purpose:    	Parse AIS sentence and extract interesting parts.
  *
@@ -330,26 +330,26 @@ func ais_to_nmea(ais []byte) ([]byte, error) {
  *--------------------------------------------------------------------*/
 
 type AISData struct {
-	description string //Description of AIS message type.
-	mssi        string //9 digit identifier.
-	lat         float64
-	lon         float64
-	knots       float64
-	course      float64
-	alt_m       float64
-	symtab      byte
-	symbol      byte
-	comment     string
+	Description string //Description of AIS message type.
+	MSSI        string //9 digit identifier.
+	Lat         float64
+	Lon         float64
+	Knots       float64
+	Course      float64
+	AltM        float64
+	Symtab      byte
+	Symbol      byte
+	Comment     string
 }
 
-func ais_parse(sentence string) (*AISData, error) {
+func AISParse(sentence string) (*AISData, error) {
 	var aisData = new(AISData)
-	aisData.mssi = "?"
-	aisData.lat = G_UNKNOWN
-	aisData.lon = G_UNKNOWN
-	aisData.knots = G_UNKNOWN
-	aisData.course = G_UNKNOWN
-	aisData.alt_m = G_UNKNOWN
+	aisData.MSSI = "?"
+	aisData.Lat = G_UNKNOWN
+	aisData.Lon = G_UNKNOWN
+	aisData.Knots = G_UNKNOWN
+	aisData.Course = G_UNKNOWN
+	aisData.AltM = G_UNKNOWN
 
 	var stemp = sentence
 
@@ -431,100 +431,100 @@ func ais_parse(sentence string) (*AISData, error) {
 	var aisType = get_field(ais, 0, 6)
 
 	if aisType >= 1 && aisType <= 27 {
-		aisData.mssi = fmt.Sprintf("%09d", get_field(ais, 8, 30))
+		aisData.MSSI = fmt.Sprintf("%09d", get_field(ais, 8, 30))
 	}
 
 	switch aisType {
 	case 1, 2, 3: // Position Report Class A
-		aisData.description = fmt.Sprintf("AIS %d: Position Report Class A", aisType)
-		aisData.symtab = '/'
-		aisData.symbol = 's' // Power boat (ship) side view
-		aisData.lon = get_field_lon(ais, 61, 28)
-		aisData.lat = get_field_lat(ais, 89, 27)
-		aisData.knots = get_field_speed(ais, 50, 10)
-		aisData.course = get_field_course(ais, 116, 12)
-		aisData.comment = get_ship_data(aisData.mssi)
+		aisData.Description = fmt.Sprintf("AIS %d: Position Report Class A", aisType)
+		aisData.Symtab = '/'
+		aisData.Symbol = 's' // Power boat (ship) side view
+		aisData.Lon = get_field_lon(ais, 61, 28)
+		aisData.Lat = get_field_lat(ais, 89, 27)
+		aisData.Knots = get_field_speed(ais, 50, 10)
+		aisData.Course = get_field_course(ais, 116, 12)
+		aisData.Comment = get_ship_data(aisData.MSSI)
 
 	case 4: // Base Station Report
-		aisData.description = fmt.Sprintf("AIS %d: Base Station Report", aisType)
-		aisData.symtab = '\\'
-		aisData.symbol = 'L' // Lighthouse
+		aisData.Description = fmt.Sprintf("AIS %d: Base Station Report", aisType)
+		aisData.Symtab = '\\'
+		aisData.Symbol = 'L' // Lighthouse
 		//year = get_field(ais, 38, 14);
 		//month = get_field(ais, 52, 4);
 		//day = get_field(ais, 56, 5);
 		//hour = get_field(ais, 61, 5);
 		//minute = get_field(ais, 66, 6);
 		//second = get_field(ais, 72, 6);
-		aisData.lon = get_field_lon(ais, 79, 28)
-		aisData.lat = get_field_lat(ais, 107, 27)
+		aisData.Lon = get_field_lon(ais, 79, 28)
+		aisData.Lat = get_field_lat(ais, 107, 27)
 		// Is this suitable or not?  Doesn't hurt, I suppose.
-		aisData.comment = get_ship_data(aisData.mssi)
+		aisData.Comment = get_ship_data(aisData.MSSI)
 
 	case 5: // Static and Voyage Related Data
-		aisData.description = fmt.Sprintf("AIS %d: Static and Voyage Related Data", aisType)
-		aisData.symtab = '/'
-		aisData.symbol = 's' // Power boat (ship) side view
+		aisData.Description = fmt.Sprintf("AIS %d: Static and Voyage Related Data", aisType)
+		aisData.Symtab = '/'
+		aisData.Symbol = 's' // Power boat (ship) side view
 		{
 			var callsign = get_field_string(ais, 70, 42)
 			var shipname = get_field_string(ais, 112, 120)
 			var destination = get_field_string(ais, 302, 120)
-			save_ship_data(aisData.mssi, shipname, callsign, destination)
-			aisData.comment = get_ship_data(aisData.mssi)
+			save_ship_data(aisData.MSSI, shipname, callsign, destination)
+			aisData.Comment = get_ship_data(aisData.MSSI)
 		}
 
 	case 9: // Standard SAR Aircraft Position Report
-		aisData.description = fmt.Sprintf("AIS %d: SAR Aircraft Position Report", aisType)
-		aisData.symtab = '/'
-		aisData.symbol = '\''                           // Small AIRCRAFT
-		aisData.alt_m = float64(get_field(ais, 38, 12)) // meters, 4095 means not available
-		aisData.lon = get_field_lon(ais, 61, 28)
-		aisData.lat = get_field_lat(ais, 89, 27)
+		aisData.Description = fmt.Sprintf("AIS %d: SAR Aircraft Position Report", aisType)
+		aisData.Symtab = '/'
+		aisData.Symbol = '\''                          // Small AIRCRAFT
+		aisData.AltM = float64(get_field(ais, 38, 12)) // meters, 4095 means not available
+		aisData.Lon = get_field_lon(ais, 61, 28)
+		aisData.Lat = get_field_lat(ais, 89, 27)
 
-		aisData.knots = get_field_speed(ais, 50, 10) // plane is knots, not knots/10
-		if aisData.knots != G_UNKNOWN {
-			aisData.knots *= 10.0
+		aisData.Knots = get_field_speed(ais, 50, 10) // plane is knots, not knots/10
+		if aisData.Knots != G_UNKNOWN {
+			aisData.Knots *= 10.0
 		}
 
-		aisData.course = get_field_course(ais, 116, 12)
-		aisData.comment = get_ship_data(aisData.mssi)
+		aisData.Course = get_field_course(ais, 116, 12)
+		aisData.Comment = get_ship_data(aisData.MSSI)
 
 	case 18: // Standard Class B CS Position Report
 		// As an oversimplification, Class A is commercial, B is recreational.
-		aisData.description = fmt.Sprintf("AIS %d: Standard Class B CS Position Report", aisType)
-		aisData.symtab = '/'
-		aisData.symbol = 'Y' // YACHT (sail)
-		aisData.lon = get_field_lon(ais, 57, 28)
-		aisData.lat = get_field_lat(ais, 85, 27)
-		aisData.comment = get_ship_data(aisData.mssi)
+		aisData.Description = fmt.Sprintf("AIS %d: Standard Class B CS Position Report", aisType)
+		aisData.Symtab = '/'
+		aisData.Symbol = 'Y' // YACHT (sail)
+		aisData.Lon = get_field_lon(ais, 57, 28)
+		aisData.Lat = get_field_lat(ais, 85, 27)
+		aisData.Comment = get_ship_data(aisData.MSSI)
 
 	case 19: // Extended Class B CS Position Report
-		aisData.description = fmt.Sprintf("AIS %d: Extended Class B CS Position Report", aisType)
-		aisData.symtab = '/'
-		aisData.symbol = 'Y' // YACHT (sail)
-		aisData.lon = get_field_lon(ais, 57, 28)
-		aisData.lat = get_field_lat(ais, 85, 27)
-		aisData.comment = get_ship_data(aisData.mssi)
+		aisData.Description = fmt.Sprintf("AIS %d: Extended Class B CS Position Report", aisType)
+		aisData.Symtab = '/'
+		aisData.Symbol = 'Y' // YACHT (sail)
+		aisData.Lon = get_field_lon(ais, 57, 28)
+		aisData.Lat = get_field_lat(ais, 85, 27)
+		aisData.Comment = get_ship_data(aisData.MSSI)
 
 	case 27: // Long Range AIS Broadcast message
-		aisData.description = fmt.Sprintf("AIS %d: Long Range AIS Broadcast message", aisType)
-		aisData.symtab = '\\'
-		aisData.symbol = 's'                     // OVERLAY SHIP/boat (top view)
-		aisData.lon = get_field_lon(ais, 44, 18) // Note: minutes/10 rather than usual /10000.
-		aisData.lat = get_field_lat(ais, 62, 17)
-		aisData.knots = get_field_speed(ais, 79, 6)   // Note: knots, not deciknots.
-		aisData.course = get_field_course(ais, 85, 9) // Note: degrees, not decidegrees.
-		aisData.comment = get_ship_data(aisData.mssi)
+		aisData.Description = fmt.Sprintf("AIS %d: Long Range AIS Broadcast message", aisType)
+		aisData.Symtab = '\\'
+		aisData.Symbol = 's'                    // OVERLAY SHIP/boat (top view)
+		aisData.Lon = get_field_lon(ais, 44, 18) // Note: minutes/10 rather than usual /10000.
+		aisData.Lat = get_field_lat(ais, 62, 17)
+		aisData.Knots = get_field_speed(ais, 79, 6)   // Note: knots, not deciknots.
+		aisData.Course = get_field_course(ais, 85, 9) // Note: degrees, not decidegrees.
+		aisData.Comment = get_ship_data(aisData.MSSI)
 
 	default:
-		aisData.description = fmt.Sprintf("AIS message type %d", aisType)
+		aisData.Description = fmt.Sprintf("AIS message type %d", aisType)
 	}
 
 	return aisData, fillerErr
-} /* end ais_parse */
+} /* end AISParse */
 
 /*-------------------------------------------------------------------
  *
- * Name:        ais_check_length
+ * Name:        AISCheckLength
  *
  * Purpose:    	Verify frame length against expected.
  *
@@ -538,7 +538,7 @@ func ais_parse(sentence string) (*AISData, error) {
  *
  *--------------------------------------------------------------------*/
 
-func ais_check_length(aisType int, length int) int {
+func AISCheckLength(aisType int, length int) int {
 	if aisType >= 1 && aisType < len(ValidAISLengths) {
 		var b = length * 8
 		if b >= ValidAISLengths[aisType].Min && b <= ValidAISLengths[aisType].Max {
@@ -554,7 +554,7 @@ func ais_check_length(aisType int, length int) int {
 		//dw_printf("AIS ERROR: message type %d is invalid.\n", aisType);
 		return (-1) // Invalid type.
 	}
-} // end ais_check_length
+} // end AISCheckLength
 
 /*-------------------------------------------------------------------
  *

--- a/src/ais.go
+++ b/src/ais.go
@@ -331,7 +331,7 @@ func AISToNMEA(ais []byte) ([]byte, error) {
 
 type AISData struct {
 	Description string //Description of AIS message type.
-	MSSI        string //9 digit identifier.
+	MMSI        string //9 digit identifier.
 	Lat         float64
 	Lon         float64
 	Knots       float64
@@ -344,7 +344,7 @@ type AISData struct {
 
 func AISParse(sentence string) (*AISData, error) {
 	var aisData = new(AISData)
-	aisData.MSSI = "?"
+	aisData.MMSI = "?"
 	aisData.Lat = G_UNKNOWN
 	aisData.Lon = G_UNKNOWN
 	aisData.Knots = G_UNKNOWN
@@ -431,7 +431,7 @@ func AISParse(sentence string) (*AISData, error) {
 	var aisType = get_field(ais, 0, 6)
 
 	if aisType >= 1 && aisType <= 27 {
-		aisData.MSSI = fmt.Sprintf("%09d", get_field(ais, 8, 30))
+		aisData.MMSI = fmt.Sprintf("%09d", get_field(ais, 8, 30))
 	}
 
 	switch aisType {
@@ -443,7 +443,7 @@ func AISParse(sentence string) (*AISData, error) {
 		aisData.Lat = get_field_lat(ais, 89, 27)
 		aisData.Knots = get_field_speed(ais, 50, 10)
 		aisData.Course = get_field_course(ais, 116, 12)
-		aisData.Comment = get_ship_data(aisData.MSSI)
+		aisData.Comment = get_ship_data(aisData.MMSI)
 
 	case 4: // Base Station Report
 		aisData.Description = fmt.Sprintf("AIS %d: Base Station Report", aisType)
@@ -458,7 +458,7 @@ func AISParse(sentence string) (*AISData, error) {
 		aisData.Lon = get_field_lon(ais, 79, 28)
 		aisData.Lat = get_field_lat(ais, 107, 27)
 		// Is this suitable or not?  Doesn't hurt, I suppose.
-		aisData.Comment = get_ship_data(aisData.MSSI)
+		aisData.Comment = get_ship_data(aisData.MMSI)
 
 	case 5: // Static and Voyage Related Data
 		aisData.Description = fmt.Sprintf("AIS %d: Static and Voyage Related Data", aisType)
@@ -468,8 +468,8 @@ func AISParse(sentence string) (*AISData, error) {
 			var callsign = get_field_string(ais, 70, 42)
 			var shipname = get_field_string(ais, 112, 120)
 			var destination = get_field_string(ais, 302, 120)
-			save_ship_data(aisData.MSSI, shipname, callsign, destination)
-			aisData.Comment = get_ship_data(aisData.MSSI)
+			save_ship_data(aisData.MMSI, shipname, callsign, destination)
+			aisData.Comment = get_ship_data(aisData.MMSI)
 		}
 
 	case 9: // Standard SAR Aircraft Position Report
@@ -486,7 +486,7 @@ func AISParse(sentence string) (*AISData, error) {
 		}
 
 		aisData.Course = get_field_course(ais, 116, 12)
-		aisData.Comment = get_ship_data(aisData.MSSI)
+		aisData.Comment = get_ship_data(aisData.MMSI)
 
 	case 18: // Standard Class B CS Position Report
 		// As an oversimplification, Class A is commercial, B is recreational.
@@ -495,7 +495,7 @@ func AISParse(sentence string) (*AISData, error) {
 		aisData.Symbol = 'Y' // YACHT (sail)
 		aisData.Lon = get_field_lon(ais, 57, 28)
 		aisData.Lat = get_field_lat(ais, 85, 27)
-		aisData.Comment = get_ship_data(aisData.MSSI)
+		aisData.Comment = get_ship_data(aisData.MMSI)
 
 	case 19: // Extended Class B CS Position Report
 		aisData.Description = fmt.Sprintf("AIS %d: Extended Class B CS Position Report", aisType)
@@ -503,17 +503,17 @@ func AISParse(sentence string) (*AISData, error) {
 		aisData.Symbol = 'Y' // YACHT (sail)
 		aisData.Lon = get_field_lon(ais, 57, 28)
 		aisData.Lat = get_field_lat(ais, 85, 27)
-		aisData.Comment = get_ship_data(aisData.MSSI)
+		aisData.Comment = get_ship_data(aisData.MMSI)
 
 	case 27: // Long Range AIS Broadcast message
 		aisData.Description = fmt.Sprintf("AIS %d: Long Range AIS Broadcast message", aisType)
 		aisData.Symtab = '\\'
-		aisData.Symbol = 's'                    // OVERLAY SHIP/boat (top view)
+		aisData.Symbol = 's'                     // OVERLAY SHIP/boat (top view)
 		aisData.Lon = get_field_lon(ais, 44, 18) // Note: minutes/10 rather than usual /10000.
 		aisData.Lat = get_field_lat(ais, 62, 17)
 		aisData.Knots = get_field_speed(ais, 79, 6)   // Note: knots, not deciknots.
 		aisData.Course = get_field_course(ais, 85, 9) // Note: degrees, not decidegrees.
-		aisData.Comment = get_ship_data(aisData.MSSI)
+		aisData.Comment = get_ship_data(aisData.MMSI)
 
 	default:
 		aisData.Description = fmt.Sprintf("AIS message type %d", aisType)

--- a/src/ais_direwolf_test.go
+++ b/src/ais_direwolf_test.go
@@ -30,25 +30,25 @@ func test_basic_parse(t *testing.T) {
 
 	var ais = "!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0*4E" // Example from https://www.aggsoft.com/ais-decoder.htm
 
-	var aisData, err = ais_parse(ais)
+	var aisData, err = AISParse(ais)
 
 	require.NoError(t, err)
-	assert.Equal(t, "AIS 1: Position Report Class A", aisData.description)
-	assert.Equal(t, "366730000", aisData.mssi)
-	assert.Empty(t, aisData.comment)
-	assert.InDelta(t, -122, aisData.lon, 1)
-	assert.InDelta(t, 20.8, aisData.knots, 1)
-	assert.InDelta(t, 51.3, aisData.course, 1)
+	assert.Equal(t, "AIS 1: Position Report Class A", aisData.Description)
+	assert.Equal(t, "366730000", aisData.MSSI)
+	assert.Empty(t, aisData.Comment)
+	assert.InDelta(t, -122, aisData.Lon, 1)
+	assert.InDelta(t, 20.8, aisData.Knots, 1)
+	assert.InDelta(t, 51.3, aisData.Course, 1)
 }
 
 func test_parse_errors(t *testing.T) {
 	t.Helper()
 
-	var data, missingChecksumErr = ais_parse("!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0")
+	var data, missingChecksumErr = AISParse("!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0")
 	require.Error(t, missingChecksumErr)
 	assert.Nil(t, data)
 
-	var data2, checksumMismatchErr = ais_parse("!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0*FF")
+	var data2, checksumMismatchErr = AISParse("!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0*FF")
 	require.Error(t, checksumMismatchErr)
 	assert.Nil(t, data2)
 }

--- a/src/ais_direwolf_test.go
+++ b/src/ais_direwolf_test.go
@@ -34,7 +34,7 @@ func test_basic_parse(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "AIS 1: Position Report Class A", aisData.Description)
-	assert.Equal(t, "366730000", aisData.MSSI)
+	assert.Equal(t, "366730000", aisData.MMSI)
 	assert.Empty(t, aisData.Comment)
 	assert.InDelta(t, -122, aisData.Lon, 1)
 	assert.InDelta(t, 20.8, aisData.Knots, 1)

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -2538,7 +2538,7 @@ func aprs_user_defined(A *decode_aprs_t, info []byte) {
 		bytes.HasPrefix(info, []byte("{DM")) { // Official after registering {D*
 		aprs_morse_code(A, info)
 	} else if info[0] == '{' && info[1] == USER_DEF_USER_ID && info[2] == USER_DEF_TYPE_AIS {
-		var aisData, aisErr = ais_parse(string(info[3:]))
+		var aisData, aisErr = AISParse(string(info[3:]))
 		if aisErr != nil {
 			if !A.g_quiet {
 				text_color_set(DW_COLOR_ERROR)
@@ -2551,16 +2551,16 @@ func aprs_user_defined(A *decode_aprs_t, info []byte) {
 			}
 		}
 
-		A.g_data_type_desc = aisData.description
-		A.g_name = aisData.mssi
-		A.g_lat = aisData.lat
-		A.g_lon = aisData.lon
-		A.g_speed_mph = DW_KNOTS_TO_MPH(aisData.knots)
-		A.g_course = aisData.course
-		A.g_altitude_ft = DW_METERS_TO_FEET(aisData.alt_m)
-		A.g_symbol_table = aisData.symtab
-		A.g_symbol_code = aisData.symbol
-		A.g_comment = aisData.comment
+		A.g_data_type_desc = aisData.Description
+		A.g_name = aisData.MSSI
+		A.g_lat = aisData.Lat
+		A.g_lon = aisData.Lon
+		A.g_speed_mph = DW_KNOTS_TO_MPH(aisData.Knots)
+		A.g_course = aisData.Course
+		A.g_altitude_ft = DW_METERS_TO_FEET(aisData.AltM)
+		A.g_symbol_table = aisData.Symtab
+		A.g_symbol_code = aisData.Symbol
+		A.g_comment = aisData.Comment
 
 		A.g_mfr = ""
 	} else if bytes.HasPrefix(info, []byte("{{")) {

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -2552,7 +2552,7 @@ func aprs_user_defined(A *decode_aprs_t, info []byte) {
 		}
 
 		A.g_data_type_desc = aisData.Description
-		A.g_name = aisData.MSSI
+		A.g_name = aisData.MMSI
 		A.g_lat = aisData.Lat
 		A.g_lon = aisData.Lon
 		A.g_speed_mph = DW_KNOTS_TO_MPH(aisData.Knots)

--- a/src/hdlc_rec2.go
+++ b/src/hdlc_rec2.go
@@ -729,7 +729,7 @@ func try_decode(block *rrbb_t, channel int, subchan int, slice int, alevel aleve
 
 		if actual_fcs == expected_fcs && save_audio_config_p.achan[channel].modem_type == MODEM_AIS {
 			// Sanity check for AIS.
-			if ais_check_length(int(H2.frame_buf[0]>>2)&0x3f, H2.frame_len-2) == 0 {
+			if AISCheckLength(int(H2.frame_buf[0]>>2)&0x3f, H2.frame_len-2) == 0 {
 				multi_modem_process_rec_frame(
 					channel,
 					subchan,

--- a/src/multi_modem.go
+++ b/src/multi_modem.go
@@ -262,7 +262,7 @@ func multi_modem_process_rec_frame(channel int, subchan int, slice int, fbuf []b
 
 	switch save_audio_config_p.achan[channel].modem_type {
 	case MODEM_AIS:
-		var nmea, err = ais_to_nmea(fbuf)
+		var nmea, err = AISToNMEA(fbuf)
 		if err != nil {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("%v\n", err)


### PR DESCRIPTION
## Summary

- Exports `AISParse`, `AISToNMEA`, and `AISCheckLength` (previously `ais_parse`, `ais_to_nmea`, `ais_check_length`)
- Exports all ten `AISData` struct fields (`Description`, `MSSI`, `Lat`, `Lon`, `Knots`, `Course`, `AltM`, `Symtab`, `Symbol`, `Comment`)
- Updates all callers in `decode_aprs.go`, `multi_modem.go`, `hdlc_rec2.go`, and `ais_direwolf_test.go`
- Internal helpers (`get_bit`, `set_bit`, `get_field*`, `char_to_sextet`, etc.) remain unexported as they stay within the package

This is preparatory work for moving `ais.go` into its own package.

## Test plan

- [x] `make all` passes clean (build + full test suite + linters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)