### PR TITLE
ci: Configure Dependabot for /docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "uv"
+    directory: "/docs"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Closes #517

Adds explicit `uv` ecosystem entry for `/docs` to the Dependabot configuration, matching the ecosystem that Dependabot was already auto-detecting (as evidenced by the starlette bump PR #532 with branch prefix `dependabot/uv/docs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)