### PR TITLE
fix: Check heard length before slicing heard[:4]/heard[4]

### DIFF
--- a/src/ax25_pad.go
+++ b/src/ax25_pad.go
@@ -1670,7 +1670,7 @@ func ax25_get_first_not_repeated(this_p *packet_t) int {
  *
  *------------------------------------------------------------------------------*/
 
-func ax25_get_rr(this_p *packet_t, n int) int { //nolint:unused
+func ax25_get_rr(this_p *packet_t, n int) int {
 	Assert(this_p.magic1 == MAGIC)
 	Assert(this_p.magic2 == MAGIC)
 	Assert(n >= 0 && n < this_p.num_addr)

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -895,9 +895,9 @@ func app_process_rec_packet(channel int, subchan int, slice int, pp *packet_t, a
 			/* we are actually hearing the preceding station in the path. */
 
 			if h >= AX25_REPEATER_2 &&
+				len(heard) == 5 &&
 				strings.EqualFold(heard[:4], "WIDE") &&
-				unicode.IsDigit(rune(heard[4])) &&
-				len(heard) == 5 {
+				unicode.IsDigit(rune(heard[4])) {
 				var probably_really = ax25_get_addr_with_ssid(pp, h-1)
 
 				// audio level applies only for internal modem channels.

--- a/src/log.go
+++ b/src/log.go
@@ -247,9 +247,9 @@ func log_write(channel int, A *decode_aprs_t, pp *packet_t, alevel alevel_t, ret
 			}
 
 			if h >= AX25_REPEATER_2 &&
+				len(heard) == 5 &&
 				heard[:4] == "WIDE" &&
-				unicode.IsDigit(rune(heard[4])) &&
-				len(heard) == 5 {
+				unicode.IsDigit(rune(heard[4])) {
 				heard = ax25_get_addr_with_ssid(pp, h-1) + "?"
 			}
 		}
@@ -348,7 +348,7 @@ func log_write(channel int, A *decode_aprs_t, pp *packet_t, alevel alevel_t, ret
  *
  *------------------------------------------------------------------*/
 
-func log_rr_bits(A *decode_aprs_t, pp *packet_t) { //nolint:unused
+func log_rr_bits(A *decode_aprs_t, pp *packet_t) {
 	if true {
 		// Sanitize system type (manufacturer) changing any comma to period.
 		var smfr = strings.ReplaceAll(A.g_mfr, ",", ".")
@@ -369,9 +369,9 @@ func log_rr_bits(A *decode_aprs_t, pp *packet_t) { //nolint:unused
 			}
 
 			if h >= AX25_REPEATER_2 &&
+				len(heard) == 5 &&
 				heard[:4] == "WIDE" &&
-				unicode.IsDigit(rune(heard[4])) &&
-				len(heard) == 5 {
+				unicode.IsDigit(rune(heard[4])) {
 				heard = ax25_get_addr_with_ssid(pp, h-1) + "?"
 			}
 

--- a/src/log_impl_test.go
+++ b/src/log_impl_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package direwolf
+
+import "testing"
+
+// Regression test for a bug where heard[:4] and heard[4] were indexed
+// before checking len(heard) == 5, causing a panic whenever the heard
+// station's callsign was shorter than 4 characters.
+func TestLogRRBitsShortHeardDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	var pp = ax25_from_text("Q1TEST>APRS,Q2TEST*,AB*:test", true)
+	if pp == nil {
+		t.Fatal("failed to parse test packet")
+	}
+
+	if ax25_get_heard(pp) < AX25_REPEATER_2 {
+		t.Fatal("test packet did not set up heard station at or beyond AX25_REPEATER_2")
+	}
+
+	var A decode_aprs_t
+
+	log_rr_bits(&A, pp)
+}


### PR DESCRIPTION
## Summary
- `log_write` (src/log.go), `log_rr_bits` (src/log.go), and the digipeater logging in `direwolf.go` all sliced `heard[:4]` and indexed `heard[4]` before checking `len(heard) == 5`
- A heard callsign shorter than 4 characters (e.g. a short digipeater alias, not just `WIDEn-N`) would panic with a slice-bounds-out-of-range error
- Reordered each condition so `len(heard) == 5` is checked first, short-circuiting before the unsafe slice/index

## Test plan
- [x] Added `TestLogRRBitsShortHeardDoesNotPanic` in `src/log_impl_test.go`, which constructs a packet with a 2-character digipeater callsign in the repeated position and calls `log_rr_bits` — confirmed it panics on the old code and passes after the fix
- [x] `make fix`
- [x] `make check`
- [x] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)