### PR TITLE
Quick wins from TODO.md §0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@ report's §5 sequencing, with quick wins pulled to the top.
       parse errors + usage instead of silently continuing with zero values.
 - [x] Remove `//nolint:unused` dead stats counters in `igate.go`, or wire
       them up if they should be live.
-- [ ] Delete `IfThenElse` from `util.go` (evaluates both arms — footgun for
+- [x] Delete `IfThenElse` from `util.go` (evaluates both arms — footgun for
       side-effecting/nil-deref arms; hides control flow). Update call sites.
 - [ ] Delete `exit()` wrapper from `util.go` so remaining `os.Exit` sites are
       grep-able; migrate call sites case-by-case as part of §2.3 below.

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ report's §5 sequencing, with quick wins pulled to the top.
 - [x] Fix `strconv.ParseFloat`/`Atoi` error swallowing in
       `cmd/samoyed-ll2utm/main.go` and `cmd/samoyed-utm2ll/main.go` — print
       parse errors + usage instead of silently continuing with zero values.
-- [ ] Remove `//nolint:unused` dead stats counters in `igate.go`, or wire
+- [x] Remove `//nolint:unused` dead stats counters in `igate.go`, or wire
       them up if they should be live.
 - [ ] Delete `IfThenElse` from `util.go` (evaluates both arms — footgun for
       side-effecting/nil-deref arms; hides control flow). Update call sites.

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ report's §5 sequencing, with quick wins pulled to the top.
       them up if they should be live.
 - [x] Delete `IfThenElse` from `util.go` (evaluates both arms — footgun for
       side-effecting/nil-deref arms; hides control flow). Update call sites.
-- [ ] Delete `exit()` wrapper from `util.go` so remaining `os.Exit` sites are
+- [x] Delete `exit()` wrapper from `util.go` so remaining `os.Exit` sites are
       grep-able; migrate call sites case-by-case as part of §2.3 below.
 
 ## 1. Move standalone tool implementations out of `src/` (§2.6)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,235 @@
+# TODO
+
+Prioritised task list derived from `CODE_QUALITY_REPORT.md` (analysis date
+2026-07-06, commit `cb3923e`). Ordered roughly by value/effort per the
+report's §5 sequencing, with quick wins pulled to the top.
+
+## 0. Quick wins (do first, low effort/risk)
+
+- [x] Fix `strconv.ParseFloat`/`Atoi` error swallowing in
+      `cmd/samoyed-ll2utm/main.go` and `cmd/samoyed-utm2ll/main.go` — print
+      parse errors + usage instead of silently continuing with zero values.
+- [ ] Remove `//nolint:unused` dead stats counters in `igate.go`, or wire
+      them up if they should be live.
+- [ ] Delete `IfThenElse` from `util.go` (evaluates both arms — footgun for
+      side-effecting/nil-deref arms; hides control flow). Update call sites.
+- [ ] Delete `exit()` wrapper from `util.go` so remaining `os.Exit` sites are
+      grep-able; migrate call sites case-by-case as part of §2.3 below.
+
+## 1. Move standalone tool implementations out of `src/` (§2.6)
+
+Mechanical, big reduction in library surface, unblocks lint ratcheting.
+Move each `*Main()` body (and its globals) into its `cmd/samoyed-*/`
+directory, or a shared `internal/tools/…` package where logic is genuinely
+shared.
+
+- [ ] `atest.go` → `cmd/samoyed-atest/` (17 globals, 27 exit sites; also
+      replace `unsafe.Sizeof` WAV header I/O with `binary.Read` sizes)
+- [ ] `gen_packets.go` → `cmd/samoyed-gen-packets/` (11 globals, 16 exits)
+- [ ] `kissutil.go` → `cmd/samoyed-kissutil/` (10 globals)
+- [ ] `aclients.go` → `cmd/samoyed-aclients/` (hand-rolled AGW parsing —
+      share with `agwpe.go`, see §5 below)
+- [ ] `tnctest.go` → `cmd/samoyed-tnctest/` (11 globals incl. `[MAX_TNC]`
+      state arrays)
+- [ ] `walk96.go` → its `cmd/` dir
+- [ ] `fxrec.go`, `fxsend.go` → their `cmd/` dirs
+- [ ] `cm108_main_linux.go` → its `cmd/` dir
+- [ ] `decode_aprs_main.go` → its `cmd/` dir
+- [ ] `dwgpsnmea_main.go` → its `cmd/` dir
+- [ ] `ttcalc_main.go`, `text2tt.go` (Main half), `tt2text.go` (Main half)
+      → their `cmd/` dirs
+
+## 2. Output abstraction (§2.5)
+
+- [ ] Introduce a `Console` interface (`Printf(color, format, ...)`) owned
+      by the top-level app and threaded through service structs, replacing
+      `text_color_set()` + `dw_printf()` globals in `textcolor.go`/`util.go`.
+- [ ] Delete the stdout-pipe hijack in `testutils.go` once output is
+      injectable; move `testutils.go` itself into a `testsupport` package
+      or `_test.go` file (it's currently a non-test file exporting test
+      helpers into the production package).
+- [ ] Route `-q`/`q_h_opt`/`q_d_opt` quiet-flag handling through the new
+      abstraction instead of globals in `direwolf.go`.
+
+## 3. Channel-ise `dlq` and `tq` (§2.4)
+
+Biggest correctness payoff; existing ported test suites protect behaviour.
+
+- [ ] Replace `dlq.go`'s intrusive linked list, `dlq_mutex`,
+      `dlq_wake_up_chan` condition-variable pattern, `*_thread_is_waiting`
+      flags, and manual leak counters with a single buffered
+      `chan *dlq_item_t`.
+- [ ] Replace `tq.go`'s per-channel priority linked lists +
+      `sync.Cond`/mutex/`xmit_thread_is_waiting` with two buffered channels
+      per radio channel (hi/lo priority) and a `select` in the xmit loop;
+      replace `tq_count_bytes`'s locked list-walk with atomic counters.
+- [ ] In `ax25_pad.go`: drop `magic1`/`magic2` canaries, drop intrusive
+      `nextp` once queues are channels, consider `frame_data []byte`
+      instead of the fixed max-size array, and convert the 59 accessor
+      functions to methods on `*packet_t`.
+
+## 4. Error handling: return errors, don't print-and-exit (§2.3)
+
+- [ ] Library functions return `error` (wrap with `%w` once
+      `wrapcheck`/`err113` are re-enabled); only `main`/`*Main()` call
+      `os.Exit`.
+- [ ] Fix `NewWaypointSender` in `waypoint.go` (prints and returns a sender
+      with a nil socket on failure — silent no-op sender).
+- [ ] Fix `log_write` in `log.go` (silently drops the log on open failure
+      after one message).
+- [ ] `config.go`: collect `[]error` across the 84 `handle*` functions
+      instead of printing mid-parse; report once. Biggest win for testable
+      config validation.
+- [ ] Audit remaining `os.Exit`/`exit(1)` sites in library code (21
+      non-test files per report), including `ptt.go` (8 sites),
+      `demod_psk.go` (3 sites), `dtmf.go` (2 sites), and others — convert to
+      error returns.
+- [ ] `pfilter.go`: return errors from the filter expression evaluator
+      instead of printing to stdout, so bad filter configs fail loudly at
+      config time.
+- [ ] Review `Assert()` call sites (panic-based, fine during the port) —
+      convert to `error` or add a comment explaining the invariant, one at
+      a time as files are touched.
+
+## 5. Continue globals → service-struct migrations (§2.2)
+
+Roughly in order of value; each is independently mergeable (see
+`samoyed-obj` skill / `waypoint.go` template).
+
+- [ ] `igate.go` (24 globals) → `IGateClient` struct (socket, stats, dedupe
+      history, delayed-packet queue); unify the two duplicate hand-rolled
+      dedupe history rings (`rx2ig_*`, `ig2tx_*`) into one generic ring
+      type; add a small connection state machine for reconnect/`ok_to_send`.
+- [ ] `ax25_link.go` (14 globals) → `DataLinkService` owning the DLSM list
+      + timers; split into `ax25_link_dl.go` / `ax25_link_lm.go` /
+      `ax25_link_timers.go` by the spec's own layering (2192-line ported
+      test file provides cover).
+- [ ] `gen_tone.go` (14 globals) → `ToneGenerator` per channel.
+- [ ] `hdlc_rec.go` (9 globals) → per-channel/subchannel receiver state
+      struct per slicer (mostly already in `demod_state.go`).
+- [ ] `dlq.go` (9 globals) — resolved by the channel rewrite in §3.
+- [ ] `tq.go` / `xmit.go` (5 globals) → fold `tq` state into the existing
+      `XmitService`; stop `xmit.go` reaching into package-level `tq_*`
+      functions.
+- [ ] `kiss.go`, `kissserial.go`, `nettnc.go` (4 globals each) → per-port
+      structs.
+- [ ] `log.go` (4 `g_*` globals) → `PacketLogger` struct; also de-duplicate
+      the "who did we hear" logic shared with `direwolf.go` (its own
+      comment flags this).
+- [ ] `textcolor.go` (1 global) — resolved by §2 Console abstraction.
+- [ ] `dwgps.go`/`dwgpsnmea.go` (3+2 globals) → `GPSSource` struct; replace
+      the `dwgpsnmea_get_fd` port-sharing back-door used by `waypoint.go`
+      with an explicit shared-port type.
+- [ ] `audio.go` (4 globals) → finish struct conversion so multiple audio
+      devices are instances, not array slots; error returns instead of
+      print-and-continue on device failures.
+- [ ] `audio_stats.go` (4 globals) → small ticker struct.
+- [ ] `multi_modem.go` (3 globals, candidate matrix) → struct per channel.
+- [ ] `dtmf.go` (4 globals) → struct (plus exit-site fixes from §4).
+- [ ] `tt_user.go` (5 globals) → struct with mutex it already needs.
+- [ ] `digipeater.go`/`cdigipeater.go` → light struct conversion for config
+      pointers/regexes when touched.
+- [ ] `server.go` (AGW server, 4 globals) → `AGWServer` struct; stop
+      per-command error printing to stdout (protocol errors invisible to
+      clients).
+- [ ] `nettnc.go` (4 globals) → per-channel struct.
+- [ ] `cmd/samoyed-appserver/main.go` — convert `session []session_s`
+      "clear callsign means unused" slots to `map[sessionKey]*session`
+      behind a small server struct; replace the receive-loop if/else chain
+      with a table of handlers.
+- [ ] `cmd/samoyed-log2gpx/main.go` — replace package-level
+      `var things []thing_t` accumulator with pass/return slice; switch GPX
+      generation from `fmt.Printf` string building to `encoding/xml` with
+      structs (currently a real bug: unescaped `<`/`&` in APRS comments
+      produces invalid GPX — add a regression test case for this).
+
+## 6. Split `config.go` (6375 lines)
+
+- [ ] Split into `config_audio.go`, `config_channel.go`, `config_aprs.go`,
+      etc.
+- [ ] Replace the `handleX(ps *parseState) bool` dispatch with a registry
+      `map[string]func(*parseState) error` so adding a keyword is data, not
+      a switch arm.
+- [ ] Make `parseState` own tokenization instead of the `split(str,
+      rest_of_line)` hidden-state tokenizer.
+- [ ] Return errors (depends on §4).
+
+## 7. Package split (§2.1) — do last
+
+Do once globals are gone; moves become mostly `git mv` + import fixes.
+
+- [ ] `internal/ax25/` — `ax25_pad*.go`, `ax25_link.go`, `xid.go`,
+      `fcs_calc.go`
+- [ ] `internal/aprs/` — `decode_aprs.go`, `encode_aprs.go`, `telemetry.go`,
+      `symbols.go`, `latlong.go`, `base91.go`, `deviceid.go`, `aprs.go`
+- [ ] `internal/dsp/` — `demod*.go`, `dsp.go`, `hdlc_rec*.go`,
+      `hdlc_send.go`, `gen_tone.go`, `pll_dcd.go`, `rrbb.go`,
+      `multi_modem.go`, `dtmf.go`, `morse.go`
+- [ ] `internal/fec/fx25/` — `fx25*.go`
+- [ ] `internal/fec/il2p/` — `il2p*.go` (best-factored subsystem already —
+      use as the template)
+- [ ] `internal/kiss/` — `kiss*.go`, `kissnet.go`, `kissserial.go`
+- [ ] `internal/agw/` — `server.go`, `agwpe.go` + a shared AGW client
+      package (promote one real client used by `appserver`, `aclients`,
+      and `tnctest`, replacing their three divergent AGW implementations)
+- [ ] `internal/audio/` — `audio.go`, `audio_stats.go`
+- [ ] `internal/ptt/` — `ptt.go`, `cm108*.go`, `gpiod*.go`,
+      `serial_port.go` (also consider replacing archived
+      `github.com/pkg/term` with `go.bug.st/serial`)
+- [ ] `internal/gps/` — `dwgps.go`, `dwgpsnmea.go`, `coordconv.go`
+- [ ] `internal/tt/` — `aprs_tt.go`, `tt_text.go`, `tt_user.go`,
+      `text2tt.go`, `tt2text.go`
+- [ ] `internal/igate/` — `igate.go`
+- [ ] `internal/config/` — `config.go`
+- [ ] `internal/tui/` — `textcolor.go` + the output abstraction from §2
+- [ ] `cmd/<tool>/` — each remaining tool implementation moves next to its
+      `main` (should already be mostly done via §1)
+- [ ] `internal/version/` — single ldflags target for `SAMOYED_VERSION`
+      once the split is underway
+
+## 8. Lint debt ratchet (§2.8)
+
+Cheapest first; enable per-file as each file is converted rather than
+flipping a linter globally.
+
+- [ ] `whitespace`, `godot` (mechanical)
+- [ ] `intrange`, `dupword`, `perfsprint`, `prealloc`
+- [ ] `err113`, `wrapcheck` (alongside §4 error-handling work)
+- [ ] `paralleltest`, `testpackage` (after §5 globals work — needed for
+      test parallelism)
+- [ ] `funlen`, `gocyclo`, `maintidx` (cyclop max-complexity 150!) — last,
+      driven by the `config.go` (§6) and `ax25_link.go` (§5) splits
+
+## 9. Naming/style cleanups (opportunistic — do when touching a file, don't churn otherwise)
+
+- [ ] Rename `snake_case` functions/types (`ax25_get_addr_with_ssid`,
+      `dlq_item_t`, `session_s`) as files get struct treatment.
+- [ ] Rename reserved-word workarounds `_type`, `_chan` in `dlq_item_t` to
+      `kind`, `channel`.
+- [ ] Replace `G_UNKNOWN` sentinel floats in `util.go` (`DW_X_TO_Y`
+      conversions) with a `type Knots float64`-style unit layer or
+      `math.NaN()` + `IsUnknown()` helper.
+- [ ] Convert function-header comment blocks (`Purpose:/Inputs:/Outputs:`)
+      to godoc when a file is refactored; drop stale parts (e.g. "Global
+      Out:" lists once globals are gone) and `/* end foo */` trailers.
+- [ ] Rename `decode_aprs_t` result struct's `g_*`-prefixed fields (they're
+      struct fields, not globals) when `decode_aprs.go` is split by
+      data-type family (position/object/telemetry/mic-e/weather).
+- [ ] Rename `aprs.go` or merge into `encode_aprs.go` (name oversells a
+      25-line file of two wire-format structs).
+- [ ] Make `fx25_init.go`'s global RS tables explicit as immutable
+      (`sync.Once` or package `init`).
+- [ ] Document `tt_text.go`'s 4 const-like table globals as immutable
+      (`var … = [...]`) or generate them.
+
+## 10. Repo hygiene
+
+- [ ] Makefile TODOs: `coverpkg` duplication, fuzz target naming.
+- [ ] One-shot `reuse annotate` pass to raise per-file SPDX header coverage
+      (currently 8 of 150 `src/` files; REUSE.toml covers the rest so this
+      is cosmetic/provenance, not a compliance gap).
+- [ ] `version.go`: resolve the `MAJOR_VERSION`/`MINOR_VERSION` CalVer
+      mismatch TODO by deriving the protocol version constants separately
+      from the display version.
+</content>
+</invoke>

--- a/cmd/samoyed-ll2utm/main.go
+++ b/cmd/samoyed-ll2utm/main.go
@@ -23,8 +23,19 @@ func main() {
 		return
 	}
 
-	var lat, _ = strconv.ParseFloat(os.Args[1], 64)
-	var lon, _ = strconv.ParseFloat(os.Args[2], 64)
+	var lat, latErr = strconv.ParseFloat(os.Args[1], 64)
+	if latErr != nil {
+		fmt.Printf("Invalid latitude: %s\n\n", latErr)
+		usage()
+		os.Exit(1)
+	}
+
+	var lon, lonErr = strconv.ParseFloat(os.Args[2], 64)
+	if lonErr != nil {
+		fmt.Printf("Invalid longitude: %s\n\n", lonErr)
+		usage()
+		os.Exit(1)
+	}
 
 	var latlng = s2.LatLng{
 		Lat: s1.Angle(D2R(lat)),

--- a/cmd/samoyed-utm2ll/main.go
+++ b/cmd/samoyed-utm2ll/main.go
@@ -31,7 +31,11 @@ func main() {
 		}
 		zlet = unicode.ToUpper(zlet)
 
-		var zone, _ = strconv.Atoi(zoneStr)
+		var zone, zoneErr = strconv.Atoi(zoneStr)
+		if zoneErr != nil {
+			fmt.Printf("Invalid zone: %s\n\n", zoneErr)
+			usage()
+		}
 
 		var hemisphere coordconv.Hemisphere
 		if zlet == 0 {
@@ -49,8 +53,17 @@ func main() {
 			}
 		}
 
-		var easting, _ = strconv.ParseFloat(os.Args[2], 64)
-		var northing, _ = strconv.ParseFloat(os.Args[3], 64)
+		var easting, eastingErr = strconv.ParseFloat(os.Args[2], 64)
+		if eastingErr != nil {
+			fmt.Printf("Invalid easting: %s\n\n", eastingErr)
+			usage()
+		}
+
+		var northing, northingErr = strconv.ParseFloat(os.Args[3], 64)
+		if northingErr != nil {
+			fmt.Printf("Invalid northing: %s\n\n", northingErr)
+			usage()
+		}
 
 		var utmCoord = coordconv.UTMCoord{
 			Zone:       zone,

--- a/src/audio.go
+++ b/src/audio.go
@@ -1491,7 +1491,7 @@ func audio_get_real(a int) int {
 				if errors.Is(err, io.EOF) {
 					text_color_set(DW_COLOR_INFO)
 					dw_printf("\nEnd of file on stdin.  Exiting.\n")
-					exit(0)
+					os.Exit(0)
 				}
 
 				text_color_set(DW_COLOR_ERROR)

--- a/src/ax25_pad.go
+++ b/src/ax25_pad.go
@@ -535,7 +535,9 @@ func ax25_from_text(monitor string, strict bool) *packet_t {
 		return (nil)
 	}
 
-	var addrTemp, ssidTemp, _, ok = ax25_parse_addr(AX25_SOURCE, string(pa), IfThenElse(strict, 1, 0))
+	var strictInt = boolToInt(strict)
+
+	var addrTemp, ssidTemp, _, ok = ax25_parse_addr(AX25_SOURCE, string(pa), strictInt)
 
 	if !ok {
 		text_color_set(DW_COLOR_ERROR)
@@ -556,7 +558,7 @@ func ax25_from_text(monitor string, strict bool) *packet_t {
 	pa, stuff, _ = bytes.Cut(stuff, []byte{','})
 	// Note: if no comma found, pa contains the destination and stuff is empty (no digipeaters)
 
-	addrTemp, ssidTemp, _, ok = ax25_parse_addr(AX25_DESTINATION, string(pa), IfThenElse(strict, 1, 0))
+	addrTemp, ssidTemp, _, ok = ax25_parse_addr(AX25_DESTINATION, string(pa), strictInt)
 
 	if !ok {
 		text_color_set(DW_COLOR_ERROR)
@@ -604,7 +606,7 @@ func ax25_from_text(monitor string, strict bool) *packet_t {
 
 		var heardTemp bool
 
-		addrTemp, ssidTemp, heardTemp, ok = ax25_parse_addr(k, string(pa), IfThenElse(strict, 1, 0))
+		addrTemp, ssidTemp, heardTemp, ok = ax25_parse_addr(k, string(pa), strictInt)
 		if !ok {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Failed to create packet from text.  Bad digipeater address\n")
@@ -853,7 +855,10 @@ func ax25_parse_addr(position int, in_addr string, strictness int) (string, int,
 
 	// dw_printf ("ax25_parse_addr in: %s\n", in_addr);
 
-	var maxlen = IfThenElse(strictness > 0, 6, (AX25_MAX_ADDR_LEN - 1))
+	var maxlen = AX25_MAX_ADDR_LEN - 1
+	if strictness > 0 {
+		maxlen = 6
+	}
 
 	for i, p := range in_addr {
 		if p == '-' || p == '*' {
@@ -2364,6 +2369,15 @@ func pid_to_text(p int) string {
 	}
 }
 
+// printableOrDot returns b, or '.' if b is not a printable character - for hex-dump-style address display.
+func printableOrDot(b byte) byte {
+	if unicode.IsPrint(rune(b)) {
+		return b
+	}
+
+	return '.'
+}
+
 func ax25_hex_dump(this_p *packet_t) {
 	var fptr = this_p.frame_data
 
@@ -2392,24 +2406,24 @@ func ax25_hex_dump(this_p *packet_t) {
 	// Any non printable characters will be printed as "." here.
 
 	dw_printf(" dest    %c%c%c%c%c%c %2d c/r=%d res=%d last=%d\n",
-		IfThenElse(unicode.IsPrint(rune(fptr[0]>>1)), fptr[0]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[1]>>1)), fptr[1]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[2]>>1)), fptr[2]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[3]>>1)), fptr[3]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[4]>>1)), fptr[4]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[5]>>1)), fptr[5]>>1, '.'),
+		printableOrDot(fptr[0]>>1),
+		printableOrDot(fptr[1]>>1),
+		printableOrDot(fptr[2]>>1),
+		printableOrDot(fptr[3]>>1),
+		printableOrDot(fptr[4]>>1),
+		printableOrDot(fptr[5]>>1),
 		(fptr[6]&SSID_SSID_MASK)>>SSID_SSID_SHIFT,
 		(fptr[6]&SSID_H_MASK)>>SSID_H_SHIFT,
 		(fptr[6]&SSID_RR_MASK)>>SSID_RR_SHIFT,
 		fptr[6]&SSID_LAST_MASK)
 
 	dw_printf(" source  %c%c%c%c%c%c %2d c/r=%d res=%d last=%d\n",
-		IfThenElse(unicode.IsPrint(rune(fptr[7]>>1)), fptr[7]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[8]>>1)), fptr[8]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[9]>>1)), fptr[9]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[10]>>1)), fptr[10]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[11]>>1)), fptr[11]>>1, '.'),
-		IfThenElse(unicode.IsPrint(rune(fptr[12]>>1)), fptr[12]>>1, '.'),
+		printableOrDot(fptr[7]>>1),
+		printableOrDot(fptr[8]>>1),
+		printableOrDot(fptr[9]>>1),
+		printableOrDot(fptr[10]>>1),
+		printableOrDot(fptr[11]>>1),
+		printableOrDot(fptr[12]>>1),
 		(fptr[13]&SSID_SSID_MASK)>>SSID_SSID_SHIFT,
 		(fptr[13]&SSID_H_MASK)>>SSID_H_SHIFT,
 		(fptr[13]&SSID_RR_MASK)>>SSID_RR_SHIFT,
@@ -2418,12 +2432,12 @@ func ax25_hex_dump(this_p *packet_t) {
 	for n := 2; n < this_p.num_addr; n++ {
 		dw_printf(" digi %d  %c%c%c%c%c%c %2d   h=%d res=%d last=%d\n",
 			n-1,
-			IfThenElse(unicode.IsPrint(rune(fptr[n*7+0]>>1)), fptr[n*7+0]>>1, '.'),
-			IfThenElse(unicode.IsPrint(rune(fptr[n*7+1]>>1)), fptr[n*7+1]>>1, '.'),
-			IfThenElse(unicode.IsPrint(rune(fptr[n*7+2]>>1)), fptr[n*7+2]>>1, '.'),
-			IfThenElse(unicode.IsPrint(rune(fptr[n*7+3]>>1)), fptr[n*7+3]>>1, '.'),
-			IfThenElse(unicode.IsPrint(rune(fptr[n*7+4]>>1)), fptr[n*7+4]>>1, '.'),
-			IfThenElse(unicode.IsPrint(rune(fptr[n*7+5]>>1)), fptr[n*7+5]>>1, '.'),
+			printableOrDot(fptr[n*7+0]>>1),
+			printableOrDot(fptr[n*7+1]>>1),
+			printableOrDot(fptr[n*7+2]>>1),
+			printableOrDot(fptr[n*7+3]>>1),
+			printableOrDot(fptr[n*7+4]>>1),
+			printableOrDot(fptr[n*7+5]>>1),
 			(fptr[n*7+6]&SSID_SSID_MASK)>>SSID_SSID_SHIFT,
 			(fptr[n*7+6]&SSID_H_MASK)>>SSID_H_SHIFT,
 			(fptr[n*7+6]&SSID_RR_MASK)>>SSID_RR_SHIFT,

--- a/src/config.go
+++ b/src/config.go
@@ -432,11 +432,17 @@ func parse_ll(str string, which parse_ll_which_e, line int) float64 {
 
 	degrees *= float64(sign)
 
-	var limit = float64(IfThenElse(which == LAT, 90, 180))
+	var limit = 180.0
+	var whichName = "longitude"
+
+	if which == LAT {
+		limit = 90.0
+		whichName = "latitude"
+	}
+
 	if degrees < -limit || degrees > limit {
 		text_color_set(DW_COLOR_ERROR)
-		dw_printf("Line %d: Number of degrees in \"%s\" is out of range for %s\n", line, str,
-			IfThenElse(which == LAT, "latitude", "longitude"))
+		dw_printf("Line %d: Number of degrees in \"%s\" is out of range for %s\n", line, str, whichName)
 	}
 	//dw_printf ("%s = %f\n", str, degrees);
 	return degrees
@@ -2031,7 +2037,10 @@ func handleMODEM(ps *parseState) bool {
 					return true
 				}
 
-				ps.audio.achan[ps.channel].v26_alternative = IfThenElse((strings.EqualFold(t, "V26A")), V26_A, V26_B)
+				ps.audio.achan[ps.channel].v26_alternative = V26_B
+				if strings.EqualFold(t, "V26A") {
+					ps.audio.achan[ps.channel].v26_alternative = V26_A
+				}
 			} else if t[0] == '/' { /* /div */
 				var n, _ = strconv.Atoi(t[1:])
 

--- a/src/config.go
+++ b/src/config.go
@@ -1377,7 +1377,7 @@ func handleADEVICE(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file: Missing name of audio device for ADEVICE command on line %d.\n", ps.line)
 		rtfm()
-		exit(1)
+		os.Exit(1)
 	}
 
 	// Do not allow same adevice to be defined more than once.

--- a/src/demod.go
+++ b/src/demod.go
@@ -682,11 +682,16 @@ func demod_init(pa *audio_s) int {
 					#endif
 					*/
 
+					var modemName = "K9NG/G3RUH"
+					if save_audio_config_p.achan[channel].modem_type == MODEM_AIS {
+						modemName = "AIS"
+					}
+
 					text_color_set(DW_COLOR_DEBUG)
 					dw_printf("Channel %d: %d baud, %s, %s, %d sample rate x %d",
 						channel,
 						save_audio_config_p.achan[channel].baud,
-						IfThenElse(save_audio_config_p.achan[channel].modem_type == MODEM_AIS, "AIS", "K9NG/G3RUH"),
+						modemName,
 						save_audio_config_p.achan[channel].profiles,
 						save_audio_config_p.adev[ACHAN2ADEV(channel)].samples_per_sec,
 						save_audio_config_p.achan[channel].upsample)

--- a/src/demod.go
+++ b/src/demod.go
@@ -12,6 +12,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"os"
 	"strings"
 	"unicode"
 )
@@ -954,7 +955,7 @@ func demod_process_sample(channel int, subchan int, sam int) {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Invalid combination of options.  Exiting.\n")
 			// Would probably work but haven't thought about it or tested yet.
-			exit(1)
+			os.Exit(1)
 		} else {
 			demod_psk_process_sample(channel, subchan, sam, D)
 		}

--- a/src/demod_9600.go
+++ b/src/demod_9600.go
@@ -556,7 +556,7 @@ func nudge_pll_9600(channel int, subchannel int, slice int, demod_out_f float64,
 
 	if D.slicer[slice].prev_d_c_pll > 1000000000 && D.slicer[slice].data_clock_pll < -1000000000 {
 		/* Overflow.  Was large positive, wrapped around, now large negative. */
-		hdlc_rec_bit_new(channel, subchannel, slice, IfThenElse(demod_out_f > 0, 1, 0), D.modem_type == MODEM_SCRAMBLE, D.slicer[slice].lfsr,
+		hdlc_rec_bit_new(channel, subchannel, slice, boolToInt(demod_out_f > 0), D.modem_type == MODEM_SCRAMBLE, D.slicer[slice].lfsr,
 			&(D.slicer[slice].pll_nudge_total), &(D.slicer[slice].pll_symbol_count))
 		D.slicer[slice].pll_symbol_count++
 

--- a/src/demod_afsk.go
+++ b/src/demod_afsk.go
@@ -22,6 +22,7 @@ package direwolf
 
 import (
 	"math"
+	"os"
 )
 
 var DCD_CONFIG_AFSK = GenericDCDConfig()
@@ -250,7 +251,7 @@ func demod_afsk_init(_samples_per_sec int, _baud int, mark_freq int,
 	default:
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Invalid AFSK demodulator profile = %c\n", profile)
-		exit(1)
+		os.Exit(1)
 	}
 
 	TUNE("TUNE_PRE_BAUD", D.prefilter_baud, "prefilter_baud", "%.3f")

--- a/src/demod_afsk.go
+++ b/src/demod_afsk.go
@@ -753,7 +753,7 @@ func nudge_pll_afsk(channel int, subchannel int, slice int, demod_out float64, D
 		*/
 
 		// #if 1
-		hdlc_rec_bit(channel, subchannel, slice, IfThenElse(demod_out > 0, 1, 0), false, quality)
+		hdlc_rec_bit(channel, subchannel, slice, boolToInt(demod_out > 0), false, quality)
 		/*
 			#else  // TODO: new feature to measure data speed error.
 			// Maybe hdlc_rec_bit could provide indication when frame starts.
@@ -783,5 +783,5 @@ func nudge_pll_afsk(channel int, subchannel int, slice int, demod_out float64, D
 	/*
 	 * Remember demodulator output so we can compare next time.
 	 */
-	D.slicer[slice].prev_demod_data = IfThenElse(demod_data, 1, 0)
+	D.slicer[slice].prev_demod_data = boolToInt(demod_data)
 } /* end nudge_pll */

--- a/src/demod_psk.go
+++ b/src/demod_psk.go
@@ -60,6 +60,7 @@ package direwolf
 
 import (
 	"math"
+	"os"
 	"unicode"
 )
 
@@ -449,7 +450,7 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
 		dw_printf("Decrease the audio sample rate or increase the baud rate or\n")
 		dw_printf("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 			MAX_FILTER_SIZE)
-		exit(1)
+		os.Exit(1)
 	}
 
 	if D.u.psk.delay_line_taps > MAX_FILTER_SIZE {
@@ -458,7 +459,7 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
 		dw_printf("Decrease the audio sample rate or increase the baud rate or\n")
 		dw_printf("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 			MAX_FILTER_SIZE)
-		exit(1)
+		os.Exit(1)
 	}
 
 	if D.u.psk.lp_filter_taps > MAX_FILTER_SIZE {
@@ -467,7 +468,7 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
 		dw_printf("Decrease the audio sample rate or increase the baud rate or\n")
 		dw_printf("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 			MAX_FILTER_SIZE)
-		exit(1)
+		os.Exit(1)
 	}
 
 	/*

--- a/src/fx25_init.go
+++ b/src/fx25_init.go
@@ -39,6 +39,7 @@ package direwolf
 
 import (
 	"math/bits"
+	"os"
 )
 
 const EXIT_FAILURE = 1
@@ -154,7 +155,7 @@ func fx25_init(debug_level int) {
 		if fx25Tab[i].rs == nil {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("FX.25 internal error: init_rs_char failed!\n")
-			exit(EXIT_FAILURE)
+			os.Exit(EXIT_FAILURE)
 		}
 	}
 

--- a/src/fx25_rec.go
+++ b/src/fx25_rec.go
@@ -343,7 +343,7 @@ func my_unstuff(channel int, subchannel int, slice int, pin []byte, ilen int) []
 	var frame_buf []byte
 	for i := 0; i < ilen; i++ {
 		for imask := byte(0x01); imask != 0; imask <<= 1 {
-			var dbit = byte(IfThenElse((pin[i]&imask) != 0, 1, 0))
+			var dbit = byte(boolToInt((pin[i] & imask) != 0))
 
 			pat_det >>= 1 // Shift the most recent eight bits thru the pattern detector.
 			pat_det |= dbit << 7

--- a/src/hdlc_rec.go
+++ b/src/hdlc_rec.go
@@ -407,7 +407,7 @@ func hdlc_rec_bit_new(channel int, subchannel int, slice int, _raw int, is_scram
 	// EAS does not use HDLC.
 
 	if g_audio_p.achan[channel].modem_type == MODEM_EAS {
-		eas_rec_bit(channel, subchannel, slice, IfThenElse(raw, 1, 0), not_used_remove)
+		eas_rec_bit(channel, subchannel, slice, boolToInt(raw), not_used_remove)
 		return
 	}
 
@@ -425,7 +425,7 @@ func hdlc_rec_bit_new(channel int, subchannel int, slice int, _raw int, is_scram
 	var dbit bool /* Data bit after undoing NRZI. */
 
 	if is_scrambled {
-		var descram = descramble(IfThenElse(raw, 1, 0), &(H.lfsr))
+		var descram = descramble(boolToInt(raw), &(H.lfsr))
 
 		dbit = (descram == H.prev_descram)
 		H.prev_descram = descram
@@ -440,8 +440,8 @@ func hdlc_rec_bit_new(channel int, subchannel int, slice int, _raw int, is_scram
 	// Don't waste time on this if AIS.  EAS does not get this far.
 
 	if g_audio_p.achan[channel].modem_type != MODEM_AIS {
-		fx25_rec_bit(channel, subchannel, slice, IfThenElse(dbit, 1, 0))
-		il2p_rec_bit(channel, subchannel, slice, IfThenElse(raw, 1, 0)) // Note: skip NRZI.
+		fx25_rec_bit(channel, subchannel, slice, boolToInt(dbit))
+		il2p_rec_bit(channel, subchannel, slice, boolToInt(raw)) // Note: skip NRZI.
 	}
 
 	/*
@@ -458,7 +458,7 @@ func hdlc_rec_bit_new(channel int, subchannel int, slice int, _raw int, is_scram
 		H.flag4_det |= 0x80000000
 	}
 
-	rrbb_append_bit(H.rrbb, byte(IfThenElse(raw, 1, 0)))
+	rrbb_append_bit(H.rrbb, byte(boolToInt(raw)))
 
 	if H.pat_det == 0x7e {
 		rrbb_chop8(H.rrbb)
@@ -573,7 +573,7 @@ func hdlc_rec_bit_new(channel int, subchannel int, slice int, _raw int, is_scram
 		H.olen = 0 /* Allow accumulation of octets. */
 		H.frame_len = 0
 
-		rrbb_append_bit(H.rrbb, byte(IfThenElse(H.prev_raw, 1, 0))) /* Last bit of flag.  Needed to get first data bit. */
+		rrbb_append_bit(H.rrbb, byte(boolToInt(H.prev_raw))) /* Last bit of flag.  Needed to get first data bit. */
 		/* Now that we are saving other initial state information, */
 		/* it would be sensible to do the same for this instead */
 		/* of lumping it in with the frame data bits. */

--- a/src/igate.go
+++ b/src/igate.go
@@ -146,38 +146,8 @@ var s_debug int
  * TODO: should have debug option to print these occasionally.
  */
 
-var stats_failed_connect int //nolint:unused
-/* Number of times we tried to connect to */
-/* a server and failed.  A small number is not */
-/* a bad thing.  Each name should have a bunch */
-/* of addresses for load balancing and */
-/* redundancy. */
-
-var stats_connects int //nolint:unused
-/* Number of successful connects to a server. */
-/* Normally you'd expect this to be 1.  */
-/* Could be larger if one disappears and we */
-/* try again to find a different one. */
-
-var stats_connect_at time.Time //nolint:unused
-/* Most recent time connection was established. */
-/* can be used to determine elapsed connect time. */
-
-var stats_rf_recv_packets int //nolint:unused
-/* Number of candidate packets from the radio. */
-/* This is not the total number of AX.25 frames received */
-/* over the radio; only APRS packets get this far. */
-
 var stats_uplink_packets int /* Number of packets passed along to the IGate */
 /* server after filtering. */
-
-var stats_uplink_bytes int //nolint:unused
-/* Total number of bytes sent to IGate server */
-/* including login, packets, and heartbeats. */
-
-var stats_downlink_bytes int //nolint:unused
-/* Total number of bytes from IGate server including */
-/* packets, heartbeats, other messages. */
 
 var stats_downlink_packets int /* Number of packets from IGate server for possible transmission. */
 /* Fewer might be transmitted due to filtering or rate limiting. */
@@ -268,13 +238,7 @@ func igate_init(p_audio_config *audio_s, p_igate_config *igate_config_s, p_digi_
 	save_igate_config_p = p_igate_config
 	save_digi_config_p = p_digi_config
 
-	stats_failed_connect = 0
-	stats_connects = 0
-	stats_connect_at = time.Time{}
-	stats_rf_recv_packets = 0
 	stats_uplink_packets = 0
-	stats_uplink_bytes = 0
-	stats_downlink_bytes = 0
 	stats_downlink_packets = 0
 	stats_rf_xmit_packets = 0
 	stats_msg_cnt = 0
@@ -353,14 +317,10 @@ func connect_thread() {
 		 */
 		if igate_sock == nil {
 			var conn, connErr = net.Dial("tcp", net.JoinHostPort(server_name, strconv.Itoa(save_igate_config_p.t2_server_port)))
-			stats_connects++
-			stats_connect_at = time.Now()
 
 			if connErr != nil {
 				text_color_set(DW_COLOR_INFO)
 				dw_printf("Connect to IGate server %s failed.\n\n", server_name)
-
-				stats_failed_connect++
 			} else {
 				/* Success. */
 				text_color_set(DW_COLOR_INFO)
@@ -464,10 +424,6 @@ func igate_send_rec_packet(channel int, recv_pp *packet_t) {
 	if !ok_to_send {
 		return /* Login not complete. */
 	}
-
-	/* Gather statistics. */
-
-	stats_rf_recv_packets++
 
 	/*
 	 * Check for filtering from specified channel to the IGate server.
@@ -825,8 +781,6 @@ func send_msg_to_server(imsg string) {
 
 	imsg += "\r\n"
 
-	stats_uplink_bytes += len(imsg)
-
 	var _, err = igate_sock.Write([]byte(imsg)) // TODO KG Should imsg just be a []byte?
 	if err != nil {
 		text_color_set(DW_COLOR_ERROR)
@@ -908,7 +862,6 @@ func igate_recv_thread() {
 
 		for {
 			var ch = get1ch()
-			stats_downlink_bytes++
 
 			// I never expected to see a nul character but it can happen.
 			// If found, change it to <0x00> and ax25_from_text will change it back to a single byte.

--- a/src/il2p_header.go
+++ b/src/il2p_header.go
@@ -287,7 +287,7 @@ func il2p_type_1_header(pp *packet_t, max_fec int) ([]byte, int) {
 		// PID is set to 0, meaning none, for S frames.
 		SET_UI(hdr, 0)
 		SET_PID(hdr, 0)
-		SET_CONTROL(hdr, (pf<<6)|(nr<<3)|(((IfThenElse((cr == cr_cmd), 1, 0))|(IfThenElse((cr == cr_11), 1, 0)))<<2))
+		SET_CONTROL(hdr, (pf<<6)|(nr<<3)|((boolToInt(cr == cr_cmd)|boolToInt(cr == cr_11))<<2))
 
 		// This gets OR'ed into the above.
 		switch frame_type {
@@ -348,7 +348,7 @@ func il2p_type_1_header(pp *packet_t, max_fec int) ([]byte, int) {
 		// same bits.  We see this in the second example in the protocol spec.
 		// The original UI frame has both C bits of 0 so it is received as a response.
 
-		SET_CONTROL(hdr, (pf<<6)|(((IfThenElse((cr == cr_cmd), 1, 0))|(IfThenElse((cr == cr_11), 1, 0)))<<2))
+		SET_CONTROL(hdr, (pf<<6)|((boolToInt(cr == cr_cmd)|boolToInt(cr == cr_11))<<2))
 
 		// This gets OR'ed into the above.
 		switch frame_type {
@@ -525,7 +525,12 @@ func il2p_decode_header_type_1(hdr []byte, num_sym_changed int) *packet_t {
 		// 'S' frame.
 		// The control field contains: P/F N(R) C S S
 		var control = GET_CONTROL(hdr)
-		var cr = IfThenElse((control&0x04) != 0, cr_cmd, cr_res)
+
+		var cr = cr_res
+		if (control & 0x04) != 0 {
+			cr = cr_cmd
+		}
+
 		var ftype ax25_frame_type_t
 
 		switch control & 0x03 {
@@ -548,7 +553,12 @@ func il2p_decode_header_type_1(hdr []byte, num_sym_changed int) *packet_t {
 		// 'U' frame other than 'UI'.
 		// The control field contains: P/F OPCODE{3) C x x
 		var control = GET_CONTROL(hdr)
-		var cr = IfThenElse((control&0x04) != 0, cr_cmd, cr_res)
+
+		var cr = cr_res
+		if (control & 0x04) != 0 {
+			cr = cr_cmd
+		}
+
 		var axpid = 0 // unused for U other than UI.
 		var ftype ax25_frame_type_t
 
@@ -580,7 +590,12 @@ func il2p_decode_header_type_1(hdr []byte, num_sym_changed int) *packet_t {
 		// 'UI' frame.
 		// The control field contains: P/F OPCODE{3) C x x
 		var control = GET_CONTROL(hdr)
-		var cr = IfThenElse((control&0x04) != 0, cr_cmd, cr_res)
+
+		var cr = cr_res
+		if (control & 0x04) != 0 {
+			cr = cr_cmd
+		}
+
 		var ftype = frame_type_U_UI
 		var pf = (control >> 6) & 0x01
 		var axpid = decode_pid(GET_PID(hdr))

--- a/src/il2p_init.go
+++ b/src/il2p_init.go
@@ -1,6 +1,8 @@
 //nolint:gochecknoglobals
 package direwolf
 
+import "os"
+
 // Interesting related stuff:
 // https://www.kernel.org/doc/html/v4.15/core-api/librs.html
 // https://berthub.eu/articles/posts/reed-solomon-for-programmers/
@@ -49,7 +51,7 @@ func il2p_init(il2p_debug int) {
 		if Tab[i].rs == nil {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("IL2P internal error: init_rs_char failed!\n")
-			exit(1)
+			os.Exit(1)
 		}
 	}
 } // end il2p_init

--- a/src/il2p_scramble.go
+++ b/src/il2p_scramble.go
@@ -58,7 +58,7 @@ func il2p_scramble_block(in []byte) []byte {
 	var om byte = 0x80 // Output bit mask;
 	for ib := range in {
 		for im := byte(0x80); im != 0; im >>= 1 {
-			var s = scramble_bit(IfThenElse(((in[ib]&im) != 0), 1, 0), &tx_lfsr_state)
+			var s = scramble_bit(boolToInt((in[ib]&im) != 0), &tx_lfsr_state)
 			if ib == 0 && im == 0x04 {
 				skipping = false
 			}
@@ -118,7 +118,7 @@ func il2p_descramble_block(in []byte) []byte {
 
 	for b := range in {
 		for m := byte(0x80); m != 0; m >>= 1 {
-			var d = descramble_bit(IfThenElse(((in[b]&m) != 0), 1, 0), &rx_lfsr_state)
+			var d = descramble_bit(boolToInt((in[b]&m) != 0), &rx_lfsr_state)
 			if d != 0 {
 				out[b] |= m
 			}

--- a/src/ptt.go
+++ b/src/ptt.go
@@ -326,7 +326,7 @@ func export_gpio(ch int, ot int, invert bool, direction int) {
 				dw_printf("    PTT GPIOD  gpiochip0  %s\n", stemp)
 				dw_printf("You can get a list of gpio chip names and corresponding I/O lines with \"gpioinfo\" command.\n")
 			}
-			exit(1)
+			os.Exit(1)
 		}
 		*/
 	}
@@ -425,7 +425,7 @@ func export_gpio(ch int, ot int, invert bool, direction int) {
 	} else {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("ERROR! Could not find Path for gpio number %d.n", gpio_num)
-		exit(1)
+		os.Exit(1)
 	}
 
 	/*

--- a/src/ptt.go
+++ b/src/ptt.go
@@ -680,7 +680,7 @@ func ptt_init(audio_config_p *audio_s) {
 				if audio_config_p.achan[ch].octrl[ot].ptt_method == PTT_METHOD_GPIOD {
 					var chip_name = audio_config_p.achan[ch].octrl[ot].out_gpio_name
 					var line_number = audio_config_p.achan[ch].octrl[ot].out_gpio_num
-					var initialState = IfThenElse(audio_config_p.achan[ch].octrl[ot].ptt_invert, 1, 0) // Using "invert" as initial state means we always start "off"
+					var initialState = boolToInt(audio_config_p.achan[ch].octrl[ot].ptt_invert) // Using "invert" as initial state means we always start "off"
 
 					var line, lineErr = RequestGPIODLine(chip_name, line_number, initialState)
 					if lineErr != nil {

--- a/src/telemetry.go
+++ b/src/telemetry.go
@@ -742,7 +742,10 @@ func t_data_process(pm *t_metadata_s, seq int, araw [T_NUM_ANALOG]float64, ndp [
 				pm.coeff[n][C_B]*araw[n] +
 				pm.coeff[n][C_C]
 
-			var z = IfThenElse(pm.coeff_ndp[n][C_A] == 0, 0, pm.coeff_ndp[n][C_A]+ndp[n]+ndp[n])
+			var z = 0
+			if pm.coeff_ndp[n][C_A] != 0 {
+				z = pm.coeff_ndp[n][C_A] + ndp[n] + ndp[n]
+			}
 			fndp = max(z, max(pm.coeff_ndp[n][C_B]+ndp[n], pm.coeff_ndp[n][C_C]))
 
 			var val_str = fval_to_str(fval, fndp)

--- a/src/util.go
+++ b/src/util.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"os"
 	"runtime"
 	"time"
 )
@@ -39,10 +38,6 @@ func dw_printf(format string, a ...any) (int, error) {
 	// Can't call variadic functions through cgo, so let's define our own!
 	// Fortunately dw_printf doesn't do much
 	return fmt.Printf(format, a...)
-}
-
-func exit(x int) {
-	os.Exit(x)
 }
 
 // #define ACHAN2ADEV(n) ((n)>>1)

--- a/src/util.go
+++ b/src/util.go
@@ -17,13 +17,12 @@ func SLEEP_SEC(s int) {
 	SLEEP_MS(s * 1000)
 }
 
-// Because sometimes it's really convenient to have C's ternary ?:
-func IfThenElse[T any](x bool, a T, b T) T { //nolint:ireturn
-	if x {
-		return a
-	} else {
-		return b
+func boolToInt(b bool) int {
+	if b {
+		return 1
 	}
+
+	return 0
 }
 
 // MAX_NET_CLIENTS is used for both KISS and AGWPE


### PR DESCRIPTION
## Summary
- Fix `strconv.ParseFloat`/`Atoi` error swallowing in `samoyed-ll2utm`/`samoyed-utm2ll`: bad input now prints the parse error + usage instead of silently becoming 0.
- Remove six write-only `//nolint:unused` igate stats counters (`stats_failed_connect`, `stats_connects`, `stats_connect_at`, `stats_rf_recv_packets`, `stats_uplink_bytes`, `stats_downlink_bytes`) — never read anywhere.
- Delete the generic `IfThenElse` ternary helper (evaluated both arms unconditionally) and inline all ~47 call sites via a small `boolToInt`/`printableOrDot` helper or plain if/else.
- Delete the `exit()` wrapper around `os.Exit` so all exit sites are directly `os.Exit`-grep-able.

Each item lands as its own commit per repo convention. This covers all of TODO.md §0 "Quick wins" (checkboxes ticked in that file).

## Test plan
- [x] `make fix`, `make check`, `make test` after each commit
- [x] `make all` at the end
- [x] Manually ran `ll2utm`/`utm2ll` with bad args to confirm new error messages
- [x] `grep -rn IfThenElse src/` / `grep -rn '\bexit(' src/` both empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)