### PR TITLE
fix: Report ll2utm/utm2ll argument parse errors instead of silently using zero

### DIFF
--- a/cmd/samoyed-ll2utm/main.go
+++ b/cmd/samoyed-ll2utm/main.go
@@ -23,8 +23,19 @@ func main() {
 		return
 	}
 
-	var lat, _ = strconv.ParseFloat(os.Args[1], 64)
-	var lon, _ = strconv.ParseFloat(os.Args[2], 64)
+	var lat, latErr = strconv.ParseFloat(os.Args[1], 64)
+	if latErr != nil {
+		fmt.Printf("Invalid latitude: %s\n\n", latErr)
+		usage()
+		os.Exit(1)
+	}
+
+	var lon, lonErr = strconv.ParseFloat(os.Args[2], 64)
+	if lonErr != nil {
+		fmt.Printf("Invalid longitude: %s\n\n", lonErr)
+		usage()
+		os.Exit(1)
+	}
 
 	var latlng = s2.LatLng{
 		Lat: s1.Angle(D2R(lat)),

--- a/cmd/samoyed-utm2ll/main.go
+++ b/cmd/samoyed-utm2ll/main.go
@@ -31,7 +31,11 @@ func main() {
 		}
 		zlet = unicode.ToUpper(zlet)
 
-		var zone, _ = strconv.Atoi(zoneStr)
+		var zone, zoneErr = strconv.Atoi(zoneStr)
+		if zoneErr != nil {
+			fmt.Printf("Invalid zone: %s\n\n", zoneErr)
+			usage()
+		}
 
 		var hemisphere coordconv.Hemisphere
 		if zlet == 0 {
@@ -49,8 +53,17 @@ func main() {
 			}
 		}
 
-		var easting, _ = strconv.ParseFloat(os.Args[2], 64)
-		var northing, _ = strconv.ParseFloat(os.Args[3], 64)
+		var easting, eastingErr = strconv.ParseFloat(os.Args[2], 64)
+		if eastingErr != nil {
+			fmt.Printf("Invalid easting: %s\n\n", eastingErr)
+			usage()
+		}
+
+		var northing, northingErr = strconv.ParseFloat(os.Args[3], 64)
+		if northingErr != nil {
+			fmt.Printf("Invalid northing: %s\n\n", northingErr)
+			usage()
+		}
 
 		var utmCoord = coordconv.UTMCoord{
 			Zone:       zone,


### PR DESCRIPTION
strconv.ParseFloat/Atoi errors on the coordinate arguments were being
discarded, so a bad latitude/longitude/zone silently became 0 instead
of failing. Print the parse error and usage on bad input.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
