### PR TITLE
refactor: Delete exit() wrapper, call os.Exit directly at call sites

### DIFF
--- a/src/audio.go
+++ b/src/audio.go
@@ -1491,7 +1491,7 @@ func audio_get_real(a int) int {
 				if errors.Is(err, io.EOF) {
 					text_color_set(DW_COLOR_INFO)
 					dw_printf("\nEnd of file on stdin.  Exiting.\n")
-					exit(0)
+					os.Exit(0)
 				}
 
 				text_color_set(DW_COLOR_ERROR)

--- a/src/config.go
+++ b/src/config.go
@@ -1371,7 +1371,7 @@ func handleADEVICE(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file: Missing name of audio device for ADEVICE command on line %d.\n", ps.line)
 		rtfm()
-		exit(1)
+		os.Exit(1)
 	}
 
 	// Do not allow same adevice to be defined more than once.

--- a/src/demod.go
+++ b/src/demod.go
@@ -12,6 +12,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"os"
 	"strings"
 	"unicode"
 )
@@ -949,7 +950,7 @@ func demod_process_sample(channel int, subchan int, sam int) {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Invalid combination of options.  Exiting.\n")
 			// Would probably work but haven't thought about it or tested yet.
-			exit(1)
+			os.Exit(1)
 		} else {
 			demod_psk_process_sample(channel, subchan, sam, D)
 		}

--- a/src/demod_afsk.go
+++ b/src/demod_afsk.go
@@ -22,6 +22,7 @@ package direwolf
 
 import (
 	"math"
+	"os"
 )
 
 var DCD_CONFIG_AFSK = GenericDCDConfig()
@@ -250,7 +251,7 @@ func demod_afsk_init(_samples_per_sec int, _baud int, mark_freq int,
 	default:
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Invalid AFSK demodulator profile = %c\n", profile)
-		exit(1)
+		os.Exit(1)
 	}
 
 	TUNE("TUNE_PRE_BAUD", D.prefilter_baud, "prefilter_baud", "%.3f")

--- a/src/demod_psk.go
+++ b/src/demod_psk.go
@@ -60,6 +60,7 @@ package direwolf
 
 import (
 	"math"
+	"os"
 	"unicode"
 )
 
@@ -449,7 +450,7 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
 		dw_printf("Decrease the audio sample rate or increase the baud rate or\n")
 		dw_printf("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 			MAX_FILTER_SIZE)
-		exit(1)
+		os.Exit(1)
 	}
 
 	if D.u.psk.delay_line_taps > MAX_FILTER_SIZE {
@@ -458,7 +459,7 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
 		dw_printf("Decrease the audio sample rate or increase the baud rate or\n")
 		dw_printf("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 			MAX_FILTER_SIZE)
-		exit(1)
+		os.Exit(1)
 	}
 
 	if D.u.psk.lp_filter_taps > MAX_FILTER_SIZE {
@@ -467,7 +468,7 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
 		dw_printf("Decrease the audio sample rate or increase the baud rate or\n")
 		dw_printf("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 			MAX_FILTER_SIZE)
-		exit(1)
+		os.Exit(1)
 	}
 
 	/*

--- a/src/fx25_init.go
+++ b/src/fx25_init.go
@@ -39,6 +39,7 @@ package direwolf
 
 import (
 	"math/bits"
+	"os"
 )
 
 const EXIT_FAILURE = 1
@@ -154,7 +155,7 @@ func fx25_init(debug_level int) {
 		if fx25Tab[i].rs == nil {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("FX.25 internal error: init_rs_char failed!\n")
-			exit(EXIT_FAILURE)
+			os.Exit(EXIT_FAILURE)
 		}
 	}
 

--- a/src/il2p_init.go
+++ b/src/il2p_init.go
@@ -1,6 +1,8 @@
 //nolint:gochecknoglobals
 package direwolf
 
+import "os"
+
 // Interesting related stuff:
 // https://www.kernel.org/doc/html/v4.15/core-api/librs.html
 // https://berthub.eu/articles/posts/reed-solomon-for-programmers/
@@ -49,7 +51,7 @@ func il2p_init(il2p_debug int) {
 		if Tab[i].rs == nil {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("IL2P internal error: init_rs_char failed!\n")
-			exit(1)
+			os.Exit(1)
 		}
 	}
 } // end il2p_init

--- a/src/ptt.go
+++ b/src/ptt.go
@@ -326,7 +326,7 @@ func export_gpio(ch int, ot int, invert bool, direction int) {
 				dw_printf("    PTT GPIOD  gpiochip0  %s\n", stemp)
 				dw_printf("You can get a list of gpio chip names and corresponding I/O lines with \"gpioinfo\" command.\n")
 			}
-			exit(1)
+			os.Exit(1)
 		}
 		*/
 	}
@@ -425,7 +425,7 @@ func export_gpio(ch int, ot int, invert bool, direction int) {
 	} else {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("ERROR! Could not find Path for gpio number %d.n", gpio_num)
-		exit(1)
+		os.Exit(1)
 	}
 
 	/*

--- a/src/util.go
+++ b/src/util.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"os"
 	"runtime"
 	"time"
 )
@@ -40,10 +39,6 @@ func dw_printf(format string, a ...any) (int, error) {
 	// Can't call variadic functions through cgo, so let's define our own!
 	// Fortunately dw_printf doesn't do much
 	return fmt.Printf(format, a...)
-}
-
-func exit(x int) {
-	os.Exit(x)
 }
 
 // #define ACHAN2ADEV(n) ((n)>>1)


### PR DESCRIPTION
exit() just forwarded to os.Exit, obscuring the real exit sites from
a grep for os.Exit. Call os.Exit directly at all 9 former call sites.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
