### PR TITLE
fix: Remove real-time sleeps from Test_Digipeater and Test_TTUser

### DIFF
--- a/src/digipeater_direwolf_test.go
+++ b/src/digipeater_direwolf_test.go
@@ -105,7 +105,7 @@ func digipeater_test(t *testing.T, in, out string) {
 func Test_Digipeater(t *testing.T) {
 	digipeaterTestMyCall = "WB2OSZ-9"
 
-	dedupeService = NewDedupeService(4 * time.Second)
+	dedupeService = NewDedupeService(100 * time.Millisecond)
 
 	/*
 	 * Compile the patterns.
@@ -219,7 +219,10 @@ func Test_Digipeater(t *testing.T) {
 	/*
 	 * Allow same thing after adequate time.
 	 */
-	time.Sleep(5 * time.Second)
+	time.Sleep(250 * time.Millisecond)
+
+	digipeater_test(t, "W1XYZ>TESTD,R3*,WIDE3-2:info1",
+		"W1XYZ>TESTD,R3,WB2OSZ-9*,WIDE3-1:info1")
 
 	digipeater_test(t, "W1XYZ>TEST,R3*,WIDE3-2:info1",
 		"W1XYZ>TEST,R3,WB2OSZ-9*,WIDE3-1:info1")

--- a/src/tt_user_direwolf_test.go
+++ b/src/tt_user_direwolf_test.go
@@ -51,13 +51,9 @@ func Test_TTUser(t *testing.T) {
 	//              double longitude, int ambiguity, char *freq, char *ctcss, char *comment, char mic_e, char *dao);
 
 	tt_user_heard("TEST1", 12, 'J', 'A', "", G_UNKNOWN, G_UNKNOWN, 0, "", "", "", ' ', "!T99!")
-	SLEEP_SEC(1)
 	tt_user_heard("TEST2", 12, 'J', 'A', "", G_UNKNOWN, G_UNKNOWN, 0, "", "", "", ' ', "!T99!")
-	SLEEP_SEC(1)
 	tt_user_heard("TEST3", 12, 'J', 'A', "", G_UNKNOWN, G_UNKNOWN, 0, "", "", "", ' ', "!T99!")
-	SLEEP_SEC(1)
 	tt_user_heard("TEST4", 12, 'J', 'A', "", G_UNKNOWN, G_UNKNOWN, 0, "", "", "", ' ', "!T99!")
-	SLEEP_SEC(1)
 	tt_user_heard("WB2OSZ", 12, 'J', 'A', "", G_UNKNOWN, G_UNKNOWN, 0, "", "", "", ' ', "!T99!")
 	tt_user_heard("K2H", 12, 'J', 'A', "", G_UNKNOWN, G_UNKNOWN, 0, "", "", "", ' ', "!T99!")
 	tt_user_dump()


### PR DESCRIPTION
## Summary
- `Test_TTUser` used four 1s sleeps purely to give `last_heard` timestamps distinct values for display. `tt_user_dump()` actually prints `last_heard` via `int(...Seconds())`, so sub-second sleeps could never have made it distinct anyway, and no assertion depends on the exact spacing — removed the sleeps entirely.
- `Test_Digipeater` used a real 5s sleep against a 4s dedupe window just to prove expired entries stop matching; shrunk both to a 250ms sleep / 100ms window, with enough margin over the per-call overhead of `digipeat_match` (string conversions, pack/unpack, several `dw_printf` calls) to avoid CI flakiness.
- Also fixed a latent bug in that same `Test_Digipeater` check: the post-sleep re-check used destination `TEST` rather than the `TESTD` used by the earlier duplicate-suppression cases, so — since the dedupe key includes the destination callsign — it was never actually re-testing an expired duplicate. Added a genuine re-send of the `TESTD` packet after the sleep so the expiry path is actually exercised, leaving the existing `TEST`-based sequence (which sets up the subsequent "differing info field" checks) untouched.

Together these cut ~9s off every `make test` run, without changing what either test verifies.

## Test plan
- [x] `go test -run Test_Digipeater ./src/...`
- [x] `go test -run Test_TTUser ./src/...`
- [x] `make fix`
- [x] `make check`
- [x] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)