### PR TITLE
fix: Parallelize test-scripts/runall

### DIFF
--- a/test-scripts/runall
+++ b/test-scripts/runall
@@ -1,12 +1,48 @@
 #!/bin/bash
 
-set -e
+set -eu
+set -o pipefail
 
-for script in ./test-scripts/check-*
-do
+shopt -s nullglob
+
+logdir=$(mktemp --directory)
+pids=()
+
+# shellcheck disable=SC2317,SC2329 # cleanup is invoked indirectly via trap
+cleanup() {
+	for pid in "${pids[@]}"; do
+		kill "$pid" 2> /dev/null || true
+	done
+	rm -rf "$logdir"
+}
+trap cleanup EXIT INT TERM
+
+scripts=(./test-scripts/check-*)
+
+for script in "${scripts[@]}"; do
+	name=$(basename "$script")
+	"$script" > "$logdir/$name.log" 2>&1 &
+	pids+=("$!")
+done
+
+failed=0
+
+for i in "${!scripts[@]}"; do
+	script="${scripts[$i]}"
+	name=$(basename "$script")
+
+	if wait "${pids[$i]}"; then
+		status="PASSED"
+	else
+		status="FAILED"
+		failed=1
+	fi
+
 	echo "************************"
-	echo "Running $script"
+	echo "$status: $script"
 	echo "************************"
 	echo ""
-	$script
+	cat "$logdir/$name.log"
 done
+
+exit $failed


### PR DESCRIPTION
## Summary
- `test-scripts/runall` ran all 14 `check-*` scripts fully sequentially. Each script is independent (its own temp dir via `goto_tmpdir`, no shared state), and the work is CPU-bound signal-decode processing, so a multi-core box was leaving most of its cores idle.
- Rewrote `runall` to launch all scripts in the background, `wait` on each, and print per-script output labeled `PASSED`/`FAILED`, preserving the existing pass/fail semantics (non-zero exit if any script fails).

## Result
On a 32-core machine: ~4m36s -> ~2m10s wall time. All 14 scripts still reported PASSED.

## Test plan
- [x] `./test-scripts/runall` — all 14 scripts PASSED, exit 0
- [x] `make check` (shellcheck, golangci-lint, reuse lint all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)