### PR TITLE
fix: Suppress shellcheck SC2317 false positive in runall

### DIFF
--- a/test-scripts/runall
+++ b/test-scripts/runall
@@ -8,6 +8,7 @@ shopt -s nullglob
 logdir=$(mktemp --directory)
 pids=()
 
+# shellcheck disable=SC2317 # cleanup is invoked indirectly via trap
 cleanup() {
 	for pid in "${pids[@]}"; do
 		kill "$pid" 2> /dev/null || true


### PR DESCRIPTION
## Summary
- Fixes the failing shellcheck CI check on #549.
- `test-scripts/runall`'s `cleanup()` function is only called via `trap ... EXIT INT TERM`, which shellcheck can't trace, so it flags the whole function body as unreachable (SC2317).
- Added a `# shellcheck disable=SC2317` comment above the function, matching the standard idiom for trap-only functions.

## Test plan
- [x] `shellcheck --external-sources --exclude SC1091 test-scripts/runall` passes
- [x] `make check` passes
- [x] `make all` (build) succeeds
- [x] `./test-scripts/runall` still runs all 14 scripts and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)