### PR TITLE
fix: Report an error instead of a silent no-op waypoint sender

### DIFF
--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -771,7 +771,13 @@ x = Silence FX.25 information.`)
 	 */
 	dwgps_init(misc_config, d_g_opt)
 
-	waypointSender = NewWaypointSender(misc_config)
+	var waypointErr error
+	waypointSender, waypointErr = NewWaypointSender(misc_config)
+	if waypointErr != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("%v\n", waypointErr)
+		os.Exit(1)
+	}
 	waypointSender.SetDebug(d_w_opt)
 
 	/*

--- a/src/waypoint.go
+++ b/src/waypoint.go
@@ -52,7 +52,7 @@ type WaypointSender struct {
  *
  *---------------------------------------------------------------*/
 
-func NewWaypointSender(mc *misc_config_s) *WaypointSender {
+func NewWaypointSender(mc *misc_config_s) (*WaypointSender, error) {
 	/* TODO KG
 	#if DEBUG
 		text_color_set (DW_COLOR_DEBUG);
@@ -62,7 +62,10 @@ func NewWaypointSender(mc *misc_config_s) *WaypointSender {
 	*/
 	var ws = &WaypointSender{} //nolint:exhaustruct
 
-	if mc.waypoint_udp_portnum > 0 {
+	var udpRequested = mc.waypoint_udp_portnum > 0
+	var serialRequested = mc.waypoint_serial_port != ""
+
+	if udpRequested {
 		var addr = net.JoinHostPort(mc.waypoint_udp_hostname, strconv.Itoa(mc.waypoint_udp_portnum))
 
 		var conn, err = net.Dial("udp", addr)
@@ -80,7 +83,7 @@ func NewWaypointSender(mc *misc_config_s) *WaypointSender {
 	 * First try to get fd if they have same device name.
 	 * If that fails, do own serial port open.
 	 */
-	if mc.waypoint_serial_port != "" {
+	if serialRequested {
 		ws.serialPortFd = dwgpsnmea_get_fd(mc.waypoint_serial_port, 4800)
 
 		if ws.serialPortFd == nil {
@@ -96,6 +99,21 @@ func NewWaypointSender(mc *misc_config_s) *WaypointSender {
 		}
 	}
 
+	// If the user asked for waypoint output but every destination they
+	// asked for failed to open, don't hand back a sender that will
+	// silently do nothing on every SendSentence/SendAIS call.
+	if (udpRequested || serialRequested) && ws.udpSock == nil && ws.serialPortFd == nil {
+		var requested []string
+		if udpRequested {
+			requested = append(requested, fmt.Sprintf("UDP %s", net.JoinHostPort(mc.waypoint_udp_hostname, strconv.Itoa(mc.waypoint_udp_portnum))))
+		}
+		if serialRequested {
+			requested = append(requested, fmt.Sprintf("serial port %s", mc.waypoint_serial_port))
+		}
+
+		return nil, fmt.Errorf("waypoint output requested but no destination could be opened (%s)", strings.Join(requested, ", "))
+	}
+
 	// Set default formats if user did not specify any.
 
 	ws.formats = mc.waypoint_formats
@@ -107,7 +125,7 @@ func NewWaypointSender(mc *misc_config_s) *WaypointSender {
 		ws.formats |= WPL_FORMAT_NMEA_GENERIC /* See explanation below. */
 	}
 
-	return ws
+	return ws, nil
 }
 
 func (ws *WaypointSender) SetDebug(n int) {

--- a/src/waypoint_impl_test.go
+++ b/src/waypoint_impl_test.go
@@ -162,7 +162,8 @@ func setupUDPWaypoint(t *testing.T, formats int) (*WaypointSender, net.PacketCon
 		waypoint_udp_portnum:  udpPort(t, listener),
 		waypoint_formats:      formats,
 	}
-	var ws = NewWaypointSender(&mc)
+	var ws, sendErr = NewWaypointSender(&mc)
+	require.NoError(t, sendErr)
 
 	t.Cleanup(func() {
 		ws.Close()
@@ -313,7 +314,8 @@ func TestWaypointDefaultFormats(t *testing.T) {
 		waypoint_udp_portnum:  udpPort(t, listener),
 		waypoint_formats:      0, // let NewWaypointSender pick defaults
 	}
-	var ws = NewWaypointSender(&mc)
+	var ws, sendErr = NewWaypointSender(&mc)
+	require.NoError(t, sendErr)
 
 	t.Cleanup(func() {
 		ws.Close()
@@ -334,7 +336,8 @@ func TestWaypointGarminImpliesNMEAGeneric(t *testing.T) {
 		waypoint_udp_portnum:  udpPort(t, listener),
 		waypoint_formats:      WPL_FORMAT_GARMIN,
 	}
-	var ws = NewWaypointSender(&mc)
+	var ws, sendErr = NewWaypointSender(&mc)
+	require.NoError(t, sendErr)
 
 	t.Cleanup(func() {
 		ws.Close()
@@ -358,10 +361,37 @@ func TestWaypointTermClearsState(t *testing.T) {
 		waypoint_udp_portnum:  udpPort(t, listener),
 		waypoint_formats:      WPL_FORMAT_KENWOOD,
 	}
-	var ws = NewWaypointSender(&mc)
+	var ws, sendErr = NewWaypointSender(&mc)
+	require.NoError(t, sendErr)
 	require.NotNil(t, ws.udpSock, "socket should be open after NewWaypointSender")
 
 	ws.Close()
 	assert.Nil(t, ws.udpSock, "socket should be nil after Close")
 	assert.Nil(t, ws.serialPortFd, "serial port fd should be nil after Close")
+}
+
+// TestNewWaypointSenderNoDestRequested verifies that not asking for any waypoint
+// destination is not an error.
+func TestNewWaypointSenderNoDestRequested(t *testing.T) {
+	var mc = misc_config_s{} //nolint: exhaustruct
+
+	var ws, err = NewWaypointSender(&mc)
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+	assert.Nil(t, ws.udpSock)
+	assert.Nil(t, ws.serialPortFd)
+}
+
+// TestNewWaypointSenderUDPFailureReturnsError verifies that NewWaypointSender
+// reports an error when the only requested destination (UDP) fails to open.
+func TestNewWaypointSenderUDPFailureReturnsError(t *testing.T) {
+	var mc = misc_config_s{ //nolint: exhaustruct
+		waypoint_udp_hostname: "\x7f invalid host",
+		waypoint_udp_portnum:  12345,
+	}
+
+	var ws, err = NewWaypointSender(&mc)
+	require.Error(t, err, "should report an error rather than a silently useless sender")
+	assert.Nil(t, ws)
+	assert.Contains(t, err.Error(), "12345", "error should identify the destination that failed to open")
 }


### PR DESCRIPTION
## Summary
- `NewWaypointSender` used to print an error via `dw_printf` when the UDP socket or serial port failed to open, but always returned a `*WaypointSender` anyway. If every destination the user configured failed, the returned sender was silently a no-op — `SendSentence`/`SendAIS` would just return early forever, with nothing to signal the failure beyond a log line easily missed in scrolling startup output.
- `NewWaypointSender` now returns `(*WaypointSender, error)` and returns an error when the caller requested waypoint output (UDP and/or serial) but none of the requested destinations could be opened. `direwolf.go` now checks this at startup and exits with the error, matching the existing pattern of other fatal config-driven init failures in that file.
- Partial success (e.g. UDP works but serial doesn't, or vice versa) is unaffected — that degraded-but-functional case still just logs and continues, as before.

## Test plan
- [x] Added `TestNewWaypointSenderUDPFailureReturnsError`, which reproduces the original bug (fails without the fix, since `NewWaypointSender` used to swallow the failure) and passes with the fix.
- [x] Added `TestNewWaypointSenderNoDestRequested` to confirm not configuring any waypoint destination remains a no-op success, not an error.
- [x] Updated existing `waypoint_impl_test.go` call sites for the new two-value return.
- [x] `make fix`
- [x] `make check`
- [x] `make test`