### PR TITLE
style: Remove trailing C-style function-name comments

### DIFF
--- a/cmd/samoyed-appserver/agwlib.go
+++ b/cmd/samoyed-appserver/agwlib.go
@@ -297,7 +297,7 @@ func process_from_tnc(cmd *AGWPECommand) {
 		agw_cb_Y_outstanding_frames_for_station(cmd.Header.Portx, cmd.Header.CallFrom, cmd.Header.CallTo, frameCount)
 	default:
 	}
-} // end process_from_tnc
+}
 
 /*-------------------------------------------------------------------
  *

--- a/cmd/samoyed-appserver/main.go
+++ b/cmd/samoyed-appserver/main.go
@@ -218,7 +218,7 @@ func poll_timing_test() {
 			session[s].tt_count = 0 // all done.
 		}
 	}
-} // end poll_timing_test
+}
 
 /*-------------------------------------------------------------------
  *

--- a/src/ais.go
+++ b/src/ais.go
@@ -554,7 +554,7 @@ func AISCheckLength(aisType int, length int) int {
 		//dw_printf("AIS ERROR: message type %d is invalid.\n", aisType);
 		return (-1) // Invalid type.
 	}
-} // end AISCheckLength
+}
 
 /*-------------------------------------------------------------------
  *

--- a/src/ax25_link.go
+++ b/src/ax25_link.go
@@ -1537,7 +1537,7 @@ func dl_outstanding_frames_request(E *dlq_item_t) {
 	} else {
 		server_outstanding_frames_reply(S.channel, S.client, S.addrs[OWNCALL], S.addrs[PEERCALL], count1+count2)
 	}
-} // end dl_outstanding_frames_request
+}
 
 /*------------------------------------------------------------------------------
  *

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -1553,7 +1553,7 @@ func aprs_mic_e(A *decode_aprs_t, pp *packet_t, info []byte) {
 	}
 
 	process_comment(A, []byte(trimmed))
-} // end aprs_mic_e
+}
 
 /*------------------------------------------------------------------
  *

--- a/src/demod_psk.go
+++ b/src/demod_psk.go
@@ -624,7 +624,7 @@ func phase_shift_to_symbol(phase_shift float64, bits_per_symbol int, bit_quality
 	}
 
 	return (result)
-} // end phase_shift_to_symbol
+}
 
 /*-------------------------------------------------------------------
  *

--- a/src/deviceid.go
+++ b/src/deviceid.go
@@ -195,7 +195,7 @@ func NewDeviceIDData() *DeviceIDData {
 	})
 
 	return d
-} // end NewDeviceIDData
+}
 
 /*------------------------------------------------------------------
  *
@@ -253,7 +253,7 @@ func (d *DeviceIDData) deviceid_decode_dest(dest string) string {
 
 	// Not found in table.
 	return "UNKNOWN vendor/model"
-} // end deviceid_decode_dest
+}
 
 /*------------------------------------------------------------------
  *

--- a/src/fx25_rec.go
+++ b/src/fx25_rec.go
@@ -186,7 +186,7 @@ func fx25_rec_busy(channel int) bool {
 	}
 
 	return false
-} // end fx25_rec_busy
+}
 
 /***********************************************************************************
  *
@@ -290,7 +290,7 @@ func process_rs_block(channel int, subchannel int, slice int, F *fx_context_s) {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("FX.25[%d.%d]: FEC failed.  Too many errors.\n", channel, slice)
 	}
-} // process_rs_block
+}
 
 /***********************************************************************************
  *
@@ -391,4 +391,4 @@ func my_unstuff(channel int, subchannel int, slice int, pin []byte, ilen int) []
 	fx_hex_dump(pin[:ilen])
 
 	return nil // Should never fall off the end.
-} // my_unstuff
+}

--- a/src/hdlc_rec.go
+++ b/src/hdlc_rec.go
@@ -261,7 +261,7 @@ func eas_rec_bit(channel int, subchannel int, slice int, raw int, future_use int
 		multi_modem_process_rec_frame(channel, subchannel, slice, H.frame_buf[:H.frame_len], alevel, 0, 0)
 		H.eas_gathering = false
 	}
-} // end eas_rec_bit
+}
 
 /*
 

--- a/src/il2p_codec.go
+++ b/src/il2p_codec.go
@@ -262,6 +262,6 @@ func il2p_decode_header_payload(uhdr []byte, epayload []byte, symbols_corrected 
 
 		return (pp)
 	}
-} // end il2p_decode_header_payload
+}
 
 // end il2p_codec.c

--- a/src/il2p_direwolf_test.go
+++ b/src/il2p_direwolf_test.go
@@ -75,7 +75,7 @@ func test_scramble(t *testing.T) {
 
 	var scramout = il2p_scramble_block(scramin1)
 	assert.Equal(t, scramout1, scramout)
-} // end test_scramble.
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -261,7 +261,7 @@ func test_payload(t *testing.T) {
 			assert.Equal(t, original_payload[:payload_length], extracted)
 		}
 	}
-} // end test_payload
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -518,7 +518,7 @@ func test_example_headers(t *testing.T) {
 	AX25Delete(pp)
 
 	dw_printf("Example 3 with info OK\n")
-} // end test_example_headers
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -731,7 +731,7 @@ func all_frame_types(t *testing.T) {
 			AX25Delete(pp)
 		}
 	}
-} // end all_frame_types
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/il2p_header.go
+++ b/src/il2p_header.go
@@ -601,7 +601,7 @@ func il2p_decode_header_type_1(hdr []byte, num_sym_changed int) *packet_t {
 
 		return (ax25_i_frame(addrs, num_addr, cr, modulo, nr, ns, pf, axpid, pinfo))
 	}
-} // end
+}
 
 /*--------------------------------------------------------------------------------
  *

--- a/src/il2p_init.go
+++ b/src/il2p_init.go
@@ -54,7 +54,7 @@ func il2p_init(il2p_debug int) {
 			os.Exit(1)
 		}
 	}
-} // end il2p_init
+}
 
 func il2p_get_debug() int {
 	return g_il2p_debug

--- a/src/il2p_payload.go
+++ b/src/il2p_payload.go
@@ -85,7 +85,7 @@ func il2p_payload_compute(payload_size int, max_fec int) (*il2p_payload_properti
 
 	return p, (p.small_block_count*(p.small_block_size+p.parity_symbols_per_block) +
 		p.large_block_count*(p.large_block_size+p.parity_symbols_per_block))
-} // end il2p_payload_compute
+}
 
 /*--------------------------------------------------------------------------------
  *
@@ -164,7 +164,7 @@ func il2p_encode_payload(payload []byte, max_fec int) ([]byte, int) {
 	}
 
 	return pout, encoded_length
-} // end il2p_encode_payload
+}
 
 /*--------------------------------------------------------------------------------
  *
@@ -271,4 +271,4 @@ func il2p_decode_payload(received []byte, payload_size int, max_fec int, symbols
 	}
 
 	return pout, decoded_length
-} // end il2p_decode_payload
+}

--- a/src/il2p_rec.go
+++ b/src/il2p_rec.go
@@ -279,4 +279,4 @@ func il2p_rec_bit(channel int, subchannel int, slice int, dbit int) {
 		F.state = IL2P_SEARCHING
 
 	} // end of switch
-} // end il2p_rec_bit
+}

--- a/src/nettnc.go
+++ b/src/nettnc.go
@@ -47,7 +47,7 @@ func nettnc_init(pa *audio_s) {
 			}
 		}
 	}
-} // end nettnc_init
+}
 
 /*-------------------------------------------------------------------
  *
@@ -110,7 +110,7 @@ func nettnc_attach(channel int, host string, port int) int {
 	//	}
 
 	return (0)
-} // end nettnc_attach
+}
 
 /*-------------------------------------------------------------------
  *
@@ -172,7 +172,7 @@ func nettnc_listen_thread(channel int) {
 			}
 		} // s_tnc_sock != -1
 	} // while (1)
-} // end nettnc_listen_thread
+}
 
 /*-------------------------------------------------------------------
  *


### PR DESCRIPTION
## Summary
- Removes leftover `} // funcname` / `} // end funcname` trailing comments on closing braces — a habit carried over from the Dire Wolf C port that has little purpose nowadays

## Test plan
- [x] `make fix`
- [x] `make check`
- [x] `make test`