### PR TITLE
pfilter: Return errors instead of printing to stdout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 * Prefer to declare variables as `var foo = bar` and not `foo := bar`, unless necessary e.g. with a `for` loop variable
 * As this started as a port from C (Dire Wolf) there are a lot of things that aren't idiomatic Go yet - new things should be, but we don't need to change existing things if not necessary
 * Prefer to use `new(Foo)` over `&Foo{}` - the latter makes the exhaustruct linter grumble
+* Code paths that can run during config-file validation (before the rest of startup init has run, e.g. `pfilter_validate` from `handleFILTER`/`handleCFILTER`) must not assume other subsystems' global config pointers (e.g. `save_igate_config_p`) are non-nil - guard with a nil check and a safe default
 
 ### Test Callsigns
 

--- a/src/cdigipeater.go
+++ b/src/cdigipeater.go
@@ -222,7 +222,13 @@ func cdigipeat_match(from_chan int, pp *packet_t, mycall_rec string, mycall_xmit
 	 * But here we only have to do it once.
 	 */
 	if cfilter_str != "" {
-		if pfilter(from_chan, to_chan, cfilter_str, pp, false) != 1 {
+		var result, err = pfilter(from_chan, to_chan, cfilter_str, pp, false)
+		if err != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("%s\n", err)
+		}
+
+		if result != 1 {
 			return (nil)
 		}
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -3543,6 +3543,14 @@ func handleFILTER(ps *parseState) bool {
 		t = " " /* Empty means permit nothing. */
 	}
 
+	var err = pfilter_validate(from_chan, to_chan, t, true)
+	if err != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: Invalid FILTER expression:\n%s\n", ps.line, err)
+
+		return true
+	}
+
 	if ps.digi.filter_str[from_chan][to_chan] != "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file, line %d: Replacing previous filter for same from/to pair:\n        %s\n", ps.line, ps.digi.filter_str[from_chan][to_chan])
@@ -3551,7 +3559,6 @@ func handleFILTER(ps *parseState) bool {
 
 	ps.digi.filter_str[from_chan][to_chan] = t
 
-	// TODO:  Do a test run to see errors now instead of waiting.
 	return false
 }
 
@@ -3626,9 +3633,16 @@ func handleCFILTER(ps *parseState) bool {
 		t = " " /* Empty means permit nothing. */
 	}
 
+	var err = pfilter_validate(from_chan, to_chan, t, false)
+	if err != nil {
+		text_color_set(DW_COLOR_ERROR)
+		dw_printf("Config file, line %d: Invalid CFILTER expression:\n%s\n", ps.line, err)
+
+		return true
+	}
+
 	ps.cdigi.cfilter_str[from_chan][to_chan] = t
 
-	// TODO1.2:  Do a test run to see errors now instead of waiting.
 	return false
 }
 

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -427,6 +427,103 @@ func Test_config_init_modem_directive(t *testing.T) {
 	}
 }
 
+// --- config_init FILTER / CFILTER syntax validation ---
+
+func Test_config_init_filter_syntax_validation(t *testing.T) {
+	var tests = []struct {
+		name          string
+		configContent string
+		wantSet       bool
+	}{
+		{
+			name:          "valid FILTER expression is stored",
+			configContent: "FILTER 0 0 t/p\n",
+			wantSet:       true,
+		},
+		{
+			name:          "FILTER with unrecognized filter type is rejected",
+			configContent: "FILTER 0 0 x/\n",
+			wantSet:       false,
+		},
+		{
+			name:          "FILTER with unbalanced parentheses is rejected",
+			configContent: "FILTER 0 0 t/w & ( t/w | t/w \n",
+			wantSet:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tmpFile, err = os.CreateTemp(t.TempDir(), "direwolf*.conf")
+			require.NoError(t, err)
+			_, err = tmpFile.WriteString(tt.configContent)
+			require.NoError(t, err)
+			require.NoError(t, tmpFile.Close())
+
+			var audioConfig = new(audio_s)
+			var digiConfig digi_config_s
+			var cdigiConfig cdigi_config_s
+			var ttConfig tt_config_s
+			var igateConfig igate_config_s
+			var miscConfig misc_config_s
+
+			config_init(tmpFile.Name(), audioConfig, &digiConfig, &cdigiConfig,
+				&ttConfig, &igateConfig, &miscConfig)
+
+			if tt.wantSet {
+				assert.NotEmpty(t, digiConfig.filter_str[0][0])
+			} else {
+				assert.Empty(t, digiConfig.filter_str[0][0])
+			}
+		})
+	}
+}
+
+func Test_config_init_cfilter_syntax_validation(t *testing.T) {
+	var tests = []struct {
+		name          string
+		configContent string
+		wantSet       bool
+	}{
+		{
+			name:          "valid CFILTER expression is stored",
+			configContent: "CFILTER 0 0 b/Q1TEST\n",
+			wantSet:       true,
+		},
+		{
+			name:          "CFILTER with a filter type only valid for APRS is rejected",
+			configContent: "CFILTER 0 0 t/p\n",
+			wantSet:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tmpFile, err = os.CreateTemp(t.TempDir(), "direwolf*.conf")
+			require.NoError(t, err)
+			_, err = tmpFile.WriteString(tt.configContent)
+			require.NoError(t, err)
+			require.NoError(t, tmpFile.Close())
+
+			var audioConfig = new(audio_s)
+			var digiConfig digi_config_s
+			var cdigiConfig cdigi_config_s
+			var ttConfig tt_config_s
+			var igateConfig igate_config_s
+			var miscConfig misc_config_s
+
+			config_init(tmpFile.Name(), audioConfig, &digiConfig, &cdigiConfig,
+				&ttConfig, &igateConfig, &miscConfig)
+
+			if tt.wantSet {
+				assert.NotEmpty(t, cdigiConfig.cfilter_str[0][0])
+			} else {
+				assert.Empty(t, cdigiConfig.cfilter_str[0][0])
+			}
+		})
+	}
+}
+
 // --- config_init ADEVICE multi-digit suffix ---
 
 func Test_config_init_adevice_multi_digit_suffix(t *testing.T) {

--- a/src/digipeater.go
+++ b/src/digipeater.go
@@ -293,7 +293,13 @@ func digipeat_match(
 	 * First check if filtering has been configured.
 	 */
 	if filter_str != "" {
-		if pfilter(from_chan, to_chan, filter_str, pp, true) != 1 {
+		var result, err = pfilter(from_chan, to_chan, filter_str, pp, true)
+		if err != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("%s\n", err)
+		}
+
+		if result != 1 {
 			return (nil)
 		}
 	}

--- a/src/igate.go
+++ b/src/igate.go
@@ -483,7 +483,13 @@ func igate_send_rec_packet(channel int, recv_pp *packet_t) {
 
 	if channel >= 0 && channel < MAX_TOTAL_CHANS && // in radio channel range
 		save_digi_config_p.filter_str[channel][MAX_TOTAL_CHANS] != "" {
-		if pfilter(channel, MAX_TOTAL_CHANS, save_digi_config_p.filter_str[channel][MAX_TOTAL_CHANS], recv_pp, true) != 1 {
+		var result, err = pfilter(channel, MAX_TOTAL_CHANS, save_digi_config_p.filter_str[channel][MAX_TOTAL_CHANS], recv_pp, true)
+		if err != nil {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("%s\n", err)
+		}
+
+		if result != 1 {
 			// Is this useful troubleshooting information or just distracting noise?
 			// Originally this was always printed but there was a request to add a "quiet" option to suppress this.
 			// version 1.4: Instead, make the default off and activate it only with the debug igate option.
@@ -1362,7 +1368,13 @@ func maybe_xmit_packet_from_igate(message []byte, to_chan int) {
 
 	if !msp_special_case {
 		if save_digi_config_p.filter_str[MAX_TOTAL_CHANS][to_chan] != "" {
-			if pfilter(MAX_TOTAL_CHANS, to_chan, save_digi_config_p.filter_str[MAX_TOTAL_CHANS][to_chan], pp3, true) != 1 {
+			var result, err = pfilter(MAX_TOTAL_CHANS, to_chan, save_digi_config_p.filter_str[MAX_TOTAL_CHANS][to_chan], pp3, true)
+			if err != nil {
+				text_color_set(DW_COLOR_ERROR)
+				dw_printf("%s\n", err)
+			}
+
+			if result != 1 {
 				// Previously there was a debug message here about the packet being dropped by filtering.
 				// This is now handled better by the "-df" command line option for filtering details.
 				AX25Delete(pp3)

--- a/src/pfilter.go
+++ b/src/pfilter.go
@@ -153,15 +153,12 @@ func bool2text(val int) string {
  *
  *--------------------------------------------------------------------*/
 
-func pfilter(from_chan int, to_chan int, filter string, pp *packet_t, is_aprs bool) int {
+func pfilter(from_chan int, to_chan int, filter string, pp *packet_t, is_aprs bool) (int, error) {
 	Assert(from_chan >= 0 && from_chan <= MAX_TOTAL_CHANS)
 	Assert(to_chan >= 0 && to_chan <= MAX_TOTAL_CHANS)
 
 	if pp == nil {
-		text_color_set(DW_COLOR_ERROR)
-		dw_printf("INTERNAL ERROR in pfilter: nil packet pointer. Please report this!\n")
-
-		return (-1)
+		return -1, fmt.Errorf("INTERNAL ERROR in pfilter: nil packet pointer, please report this")
 	}
 
 	var pfstate pfstate_t
@@ -192,16 +189,18 @@ func pfilter(from_chan int, to_chan int, filter string, pp *packet_t, is_aprs bo
 	next_token(&pfstate)
 
 	var result int
+	var err error
 	if pfstate.token_type == TOKEN_EOL {
 		/* Empty filter means reject all. */
 		result = 0
 	} else {
-		result = parse_expr(&pfstate)
+		result, err = parse_expr(&pfstate)
 
-		if pfstate.token_type != TOKEN_AND &&
+		if err == nil &&
+			pfstate.token_type != TOKEN_AND &&
 			pfstate.token_type != TOKEN_OR &&
 			pfstate.token_type != TOKEN_EOL {
-			print_error(&pfstate, "Expected logical operator or end of line here.")
+			err = newFilterError(&pfstate, "Expected logical operator or end of line here.")
 
 			result = -1
 		}
@@ -221,7 +220,7 @@ func pfilter(from_chan int, to_chan int, filter string, pp *packet_t, is_aprs bo
 		}
 	}
 
-	return (result)
+	return result, err
 } /* end pfilter */
 
 /*-------------------------------------------------------------------
@@ -333,105 +332,107 @@ func next_token(pf *pfstate_t) {
  *
  *--------------------------------------------------------------------*/
 
-func parse_expr(pf *pfstate_t) int {
+func parse_expr(pf *pfstate_t) (int, error) {
 	return parse_or_expr(pf)
 }
 
 /* or_expr::	and_expr [ | and_expr ] ... */
 
-func parse_or_expr(pf *pfstate_t) int {
-	var result = parse_and_expr(pf)
-	if result < 0 {
-		return (-1)
+func parse_or_expr(pf *pfstate_t) (int, error) {
+	var result, err = parse_and_expr(pf)
+	if err != nil {
+		return -1, err
 	}
 
 	for pf.token_type == TOKEN_OR {
 		next_token(pf)
-		var e = parse_and_expr(pf)
+		var e, eerr = parse_and_expr(pf)
 
 		if pfilter_debug >= 3 {
 			text_color_set(DW_COLOR_DEBUG)
 			dw_printf("  %s | %s\n", bool2text(result), bool2text(e))
 		}
 
-		if e < 0 {
-			return (-1)
+		if eerr != nil {
+			return -1, eerr
 		}
 
 		result |= e
 	}
 
-	return (result)
+	return result, nil
 }
 
 /* and_expr::	primary [ & primary ] ... */
 
-func parse_and_expr(pf *pfstate_t) int {
-	var result = parse_primary(pf)
-	if result < 0 {
-		return (-1)
+func parse_and_expr(pf *pfstate_t) (int, error) {
+	var result, err = parse_primary(pf)
+	if err != nil {
+		return -1, err
 	}
 
 	for pf.token_type == TOKEN_AND {
 		next_token(pf)
-		var e = parse_primary(pf)
+		var e, eerr = parse_primary(pf)
 
 		if pfilter_debug >= 3 {
 			text_color_set(DW_COLOR_DEBUG)
 			dw_printf("  %s & %s\n", bool2text(result), bool2text(e))
 		}
 
-		if e < 0 {
-			return (-1)
+		if eerr != nil {
+			return -1, eerr
 		}
 
 		result &= e
 	}
 
-	return (result)
+	return result, nil
 }
 
 /* primary::	( expr )	*/
 /* 		! primary	*/
 /*		filter_spec	*/
 
-func parse_primary(pf *pfstate_t) int {
+func parse_primary(pf *pfstate_t) (int, error) {
 	var result int
+	var err error
 
 	if pf.token_type == TOKEN_LPAREN { //nolint:staticcheck
 		next_token(pf)
-		result = parse_expr(pf)
+		result, err = parse_expr(pf)
 
 		if pf.token_type == TOKEN_RPAREN {
 			next_token(pf)
-		} else {
-			print_error(pf, "Expected \")\" here.\n")
+		} else if err == nil {
+			err = newFilterError(pf, "Expected \")\" here.")
 
 			result = -1
 		}
 	} else if pf.token_type == TOKEN_NOT {
 		next_token(pf)
-		var e = parse_primary(pf)
+		var e, eerr = parse_primary(pf)
 
 		if pfilter_debug >= 3 {
 			text_color_set(DW_COLOR_DEBUG)
 			dw_printf("  ! %s\n", bool2text(e))
 		}
 
-		if e < 0 {
+		if eerr != nil {
 			result = -1
+			err = eerr
 		} else {
 			result = 1 - e
 		}
 	} else if pf.token_type == TOKEN_FILTER_SPEC {
-		result = parse_filter_spec(pf)
+		result, err = parse_filter_spec(pf)
 	} else {
-		print_error(pf, "Expected filter specification, (, or ! here.")
+		err = newFilterError(pf, "Expected filter specification, (, or ! here.")
 
 		result = -1
 	}
 
-	return (result)
+	return result, err
 }
 
 /*-------------------------------------------------------------------
@@ -456,18 +457,19 @@ func parse_primary(pf *pfstate_t) int {
  *
  *--------------------------------------------------------------------*/
 
-func parse_filter_spec(pf *pfstate_t) int {
+func parse_filter_spec(pf *pfstate_t) (int, error) {
 	// Yes this is always assigned over, but that requires a fair bit of reading to be sure of, so let's have an explicit default
 	var result = -1 //nolint:ineffassign,wastedassign
+	var err error
 
 	if (!pf.is_aprs) && !strings.ContainsRune("01bdvu", rune(pf.token_str[0])) {
-		print_error(pf, "Only b, d, v, and u specifications are allowed for connected mode digipeater filtering.")
+		err = newFilterError(pf, "Only b, d, v, and u specifications are allowed for connected mode digipeater filtering.")
 
 		result = -1
 
 		next_token(pf)
 
-		return (result)
+		return result, err
 	}
 
 	/* undocumented: can use 0 or 1 for testing. */
@@ -483,7 +485,7 @@ func parse_filter_spec(pf *pfstate_t) int {
 		/* Budlist - AX.25 source address */
 		/* Could be different than source encapsulated by 3rd party header. */
 		var addr = ax25_get_addr_with_ssid(pf.pp, AX25_SOURCE)
-		result = filt_bodgu(pf, addr)
+		result, err = filt_bodgu(pf, addr)
 
 		if pfilter_debug >= 2 {
 			text_color_set(DW_COLOR_DEBUG)
@@ -491,7 +493,7 @@ func parse_filter_spec(pf *pfstate_t) int {
 		}
 	} else if pf.token_str[0] == 'o' && unicode.IsPunct(rune(pf.token_str[1])) {
 		/* o - object or item name */
-		result = filt_bodgu(pf, pf.decoded.g_name)
+		result, err = filt_bodgu(pf, pf.decoded.g_name)
 
 		if pfilter_debug >= 2 {
 			text_color_set(DW_COLOR_DEBUG)
@@ -501,11 +503,11 @@ func parse_filter_spec(pf *pfstate_t) int {
 		/* d - was digipeated by */
 		// Loop on all AX.25 digipeaters.
 		result = 0
-		for n := AX25_REPEATER_1; result == 0 && n < ax25_get_num_addr(pf.pp); n++ {
+		for n := AX25_REPEATER_1; result == 0 && err == nil && n < ax25_get_num_addr(pf.pp); n++ {
 			// Consider only those with the H (has-been-used) bit set.
 			if ax25_get_h(pf.pp, n) > 0 {
 				var addr = ax25_get_addr_with_ssid(pf.pp, n)
-				result = filt_bodgu(pf, addr)
+				result, err = filt_bodgu(pf, addr)
 			}
 		}
 
@@ -523,12 +525,12 @@ func parse_filter_spec(pf *pfstate_t) int {
 		/* v - via not used */
 		// loop on all AX.25 digipeaters (mnemonic Via)
 		result = 0
-		for n := AX25_REPEATER_1; result == 0 && n < ax25_get_num_addr(pf.pp); n++ {
+		for n := AX25_REPEATER_1; result == 0 && err == nil && n < ax25_get_num_addr(pf.pp); n++ {
 			// This is different than the previous "d" filter.
 			// Consider only those where the the H (has-been-used) bit is NOT set.
 			if ax25_get_h(pf.pp, n) == 0 {
 				var addr = ax25_get_addr_with_ssid(pf.pp, n)
-				result = filt_bodgu(pf, addr)
+				result, err = filt_bodgu(pf, addr)
 			}
 		}
 
@@ -550,7 +552,7 @@ func parse_filter_spec(pf *pfstate_t) int {
 			pf.decoded.g_message_subtype == message_subtype_bulletin ||
 			pf.decoded.g_message_subtype == message_subtype_nws ||
 			pf.decoded.g_message_subtype == message_subtype_directed_query {
-			result = filt_bodgu(pf, pf.decoded.g_addressee)
+			result, err = filt_bodgu(pf, pf.decoded.g_addressee)
 
 			if pfilter_debug >= 2 {
 				text_color_set(DW_COLOR_DEBUG)
@@ -570,7 +572,7 @@ func parse_filter_spec(pf *pfstate_t) int {
 		/* because destination is used for part of location. */
 		if ax25_get_dti(pf.pp) != '\'' && ax25_get_dti(pf.pp) != '`' {
 			var addr = ax25_get_addr_with_ssid(pf.pp, AX25_DESTINATION)
-			result = filt_bodgu(pf, addr)
+			result, err = filt_bodgu(pf, addr)
 
 			if pfilter_debug >= 2 {
 				text_color_set(DW_COLOR_DEBUG)
@@ -586,7 +588,7 @@ func parse_filter_spec(pf *pfstate_t) int {
 		}
 	} else if pf.token_str[0] == 't' && unicode.IsPunct(rune(pf.token_str[1])) {
 		/* t - packet type: position, weather, telemetry, etc. */
-		result = filt_t(pf)
+		result, err = filt_t(pf)
 
 		if pfilter_debug >= 2 {
 			var infop = AX25GetInfo(pf.pp)
@@ -603,7 +605,7 @@ func parse_filter_spec(pf *pfstate_t) int {
 		/* r - range */
 		/* range */
 		var sdist string
-		result, sdist = filt_r(pf)
+		result, sdist, err = filt_r(pf)
 
 		if pfilter_debug >= 2 {
 			text_color_set(DW_COLOR_DEBUG)
@@ -611,7 +613,7 @@ func parse_filter_spec(pf *pfstate_t) int {
 		}
 	} else if pf.token_str[0] == 's' && unicode.IsPunct(rune(pf.token_str[1])) {
 		/* s - symbol */
-		result = filt_s(pf)
+		result, err = filt_s(pf)
 
 		if pfilter_debug >= 2 {
 			text_color_set(DW_COLOR_DEBUG)
@@ -627,7 +629,7 @@ func parse_filter_spec(pf *pfstate_t) int {
 	} else if pf.token_str[0] == 'i' && unicode.IsPunct(rune(pf.token_str[1])) {
 		/* i - IGate messaging default */
 		/* IGatge messaging */
-		result = filt_i(pf)
+		result, err = filt_i(pf)
 
 		if pfilter_debug >= 2 {
 			text_color_set(DW_COLOR_DEBUG)
@@ -640,14 +642,14 @@ func parse_filter_spec(pf *pfstate_t) int {
 		}
 	} else {
 		/* unrecognized filter type */
-		print_error(pf, fmt.Sprintf("Unrecognized filter type '%c'", pf.token_str[0]))
+		err = newFilterError(pf, fmt.Sprintf("Unrecognized filter type '%c'", pf.token_str[0]))
 
 		result = -1
 	}
 
 	next_token(pf)
 
-	return (result)
+	return result, err
 }
 
 /*------------------------------------------------------------------------------
@@ -679,7 +681,7 @@ func parse_filter_spec(pf *pfstate_t) int {
  *
  *------------------------------------------------------------------------------*/
 
-func filt_bodgu(pf *pfstate_t, arg string) int {
+func filt_bodgu(pf *pfstate_t, arg string) (int, error) {
 	var result = 0
 	var str = pf.token_str
 	var sep = str[1]
@@ -691,8 +693,7 @@ func filt_bodgu(pf *pfstate_t, arg string) int {
 		if idx != -1 {
 			/* Wildcarding.  Should have single * on end. */
 			if idx != (len(part) - 1) {
-				print_error(pf, "Any wildcard * must be at the end of pattern.\n")
-				return (-1)
+				return -1, newFilterError(pf, "Any wildcard * must be at the end of pattern.")
 			}
 
 			if strings.HasPrefix(arg, part[:idx]) {
@@ -706,7 +707,7 @@ func filt_bodgu(pf *pfstate_t, arg string) int {
 		}
 	}
 
-	return (result)
+	return result, nil
 }
 
 /*------------------------------------------------------------------------------
@@ -732,7 +733,7 @@ func filt_bodgu(pf *pfstate_t, arg string) int {
  *
  *------------------------------------------------------------------------------*/
 
-func filt_t(pf *pfstate_t) int {
+func filt_t(pf *pfstate_t) (int, error) {
 	// TODO KG Why was this here? var src = ax25_get_addr_with_ssid(pf.pp, AX25_SOURCE)
 	var infop = AX25GetInfo(pf.pp)
 
@@ -742,58 +743,58 @@ func filt_t(pf *pfstate_t) int {
 		switch f {
 		case 'p': /* Position */
 			if pf.decoded.g_packet_type == packet_type_position {
-				return (1)
+				return 1, nil
 			}
 
 		case 'o': /* Object */
 			if pf.decoded.g_packet_type == packet_type_object {
-				return (1)
+				return 1, nil
 			}
 
 		case 'i': /* Item */
 			if pf.decoded.g_packet_type == packet_type_item {
-				return (1)
+				return 1, nil
 			}
 
 		case 'm': // Any "message."
 			if pf.decoded.g_packet_type == packet_type_message {
-				return (1)
+				return 1, nil
 			}
 
 		case 'q': /* Query */
 			if pf.decoded.g_packet_type == packet_type_query {
-				return (1)
+				return 1, nil
 			}
 
 		case 'c': /* station Capabilities - my extension */
 			/* Most often used for IGate statistics. */
 			if pf.decoded.g_packet_type == packet_type_capabilities {
-				return (1)
+				return 1, nil
 			}
 
 		case 's': /* Status */
 			if pf.decoded.g_packet_type == packet_type_status {
-				return (1)
+				return 1, nil
 			}
 
 		case 't': /* Telemetry data or metadata */
 			if pf.decoded.g_packet_type == packet_type_telemetry {
-				return (1)
+				return 1, nil
 			}
 
 		case 'u': /* User-defined */
 			if pf.decoded.g_packet_type == packet_type_userdefined {
-				return (1)
+				return 1, nil
 			}
 
 		case 'h': /* has third party Header - my extension */
 			if pf.decoded.g_has_thirdparty_header {
-				return (1)
+				return 1, nil
 			}
 
 		case 'w': /* Weather */
 			if pf.decoded.g_packet_type == packet_type_weather {
-				return (1)
+				return 1, nil
 			}
 
 			/* Positions !=/@  with symbol code _ are weather. */
@@ -802,21 +803,20 @@ func filt_t(pf *pfstate_t) int {
 
 			if (pf.decoded.g_packet_type == packet_type_position ||
 				pf.decoded.g_packet_type == packet_type_object) && pf.decoded.g_symbol_code == '_' {
-				return (1)
+				return 1, nil
 			}
 
 		case 'n': /* NWS format */
 			if pf.decoded.g_packet_type == packet_type_nws {
-				return (1)
+				return 1, nil
 			}
 
 		default:
-			print_error(pf, "Invalid letter in t/ filter.\n")
-			return (-1)
+			return -1, newFilterError(pf, "Invalid letter in t/ filter.")
 		}
 	}
 
-	return (0) /* Didn't match anything.  Reject */
+	return 0, nil /* Didn't match anything.  Reject */
 } /* end filt_t */
 
 /*------------------------------------------------------------------------------
@@ -845,9 +845,9 @@ func filt_t(pf *pfstate_t) int {
  *
  *------------------------------------------------------------------------------*/
 
-func filt_r(pf *pfstate_t) (int, string) {
+func filt_r(pf *pfstate_t) (int, string, error) {
 	if pf.decoded.g_lat == G_UNKNOWN || pf.decoded.g_lon == G_UNKNOWN {
-		return 0, ""
+		return 0, "", nil
 	}
 
 	var str = pf.token_str
@@ -857,36 +857,44 @@ func filt_r(pf *pfstate_t) (int, string) {
 	var parts = strings.Split(cp, sep)
 
 	if len(parts) < 1 {
-		print_error(pf, "Missing latitude for Range filter.")
-		return -1, ""
+		return -1, "", newFilterError(pf, "Missing latitude for Range filter.")
 	}
-	var dlat, _ = strconv.ParseFloat(parts[0], 64)
+	var dlat, dlatErr = strconv.ParseFloat(parts[0], 64)
+
+	if dlatErr != nil {
+		return -1, "", newFilterError(pf, "Invalid latitude for Range filter.")
+	}
 
 	if len(parts) < 2 {
-		print_error(pf, "Missing longitude for Range filter.")
-		return -1, ""
+		return -1, "", newFilterError(pf, "Missing longitude for Range filter.")
 	}
-	var dlon, _ = strconv.ParseFloat(parts[1], 64)
+	var dlon, dlonErr = strconv.ParseFloat(parts[1], 64)
+
+	if dlonErr != nil {
+		return -1, "", newFilterError(pf, "Invalid longitude for Range filter.")
+	}
 
 	if len(parts) < 3 {
-		print_error(pf, "Missing distance for Range filter.")
-		return -1, ""
+		return -1, "", newFilterError(pf, "Missing distance for Range filter.")
 	}
-	var ddist, _ = strconv.ParseFloat(parts[2], 64)
+	var ddist, ddistErr = strconv.ParseFloat(parts[2], 64)
+
+	if ddistErr != nil {
+		return -1, "", newFilterError(pf, "Invalid distance for Range filter.")
+	}
 
 	if len(parts) > 3 {
-		print_error(pf, "Too many parts for Range filter.")
-		return -1, ""
+		return -1, "", newFilterError(pf, "Too many parts for Range filter.")
 	}
 
 	var km = ll_distance_km(dlat, dlon, float64(pf.decoded.g_lat), float64(pf.decoded.g_lon))
 	var sdist = fmt.Sprintf("%.2f km", km)
 
 	if km <= ddist {
-		return 1, sdist
+		return 1, sdist, nil
 	}
 
-	return 0, sdist
+	return 0, sdist, nil
 }
 
 /*------------------------------------------------------------------------------
@@ -954,7 +962,7 @@ func filt_r(pf *pfstate_t) (int, string) {
  *
  *------------------------------------------------------------------------------*/
 
-func filt_s(pf *pfstate_t) int {
+func filt_s(pf *pfstate_t) (int, error) {
 	var str = pf.token_str
 	var sep = string(str[1])
 	var cp = str[2:]
@@ -974,8 +982,7 @@ func filt_s(pf *pfstate_t) int {
 		// Zero length is acceptable if alternate symbol(s) specified.  Will check that later.
 
 		if strings.ContainsFunc(pri, unacceptableChar) {
-			print_error(pf, "Symbol filter, primary must be printable ASCII character(s) other than | or ~.")
-			return (-1)
+			return -1, newFilterError(pf, "Symbol filter, primary must be printable ASCII character(s) other than | or ~.")
 		}
 
 		if len(parts) > 1 {
@@ -984,13 +991,11 @@ func filt_s(pf *pfstate_t) int {
 			// Zero length after second / would be pointless.
 
 			if len(alt) == 0 {
-				print_error(pf, "Nothing specified for alternate symbol table.")
-				return (-1)
+				return -1, newFilterError(pf, "Nothing specified for alternate symbol table.")
 			}
 
 			if strings.ContainsFunc(alt, unacceptableChar) {
-				print_error(pf, "Symbol filter, alternate must be printable ASCII character(s) other than | or ~.")
-				return (-1)
+				return -1, newFilterError(pf, "Symbol filter, alternate must be printable ASCII character(s) other than | or ~.")
 			}
 
 			if len(parts) > 2 {
@@ -1001,32 +1006,28 @@ func filt_s(pf *pfstate_t) int {
 				if strings.ContainsFunc(over, func(r rune) bool {
 					return !(unicode.IsUpper(r) || unicode.IsDigit(r) || r == '\\')
 				}) {
-					print_error(pf, "Symbol filter, overlay must be upper case letter, digit, or \\.")
-					return (-1)
+					return -1, newFilterError(pf, "Symbol filter, overlay must be upper case letter, digit, or \\.")
 				}
 
 				if len(parts) > 3 {
-					print_error(pf, "More than 3 delimiter characters in Symbol filter.")
-					return (-1)
+					return -1, newFilterError(pf, "More than 3 delimiter characters in Symbol filter.")
 				}
 			}
 		} else {
 			// No alt part is OK if at least one primary symbol was specified.
 			if len(pri) == 0 {
-				print_error(pf, "No symbols specified for Symbol filter.")
-				return (-1)
+				return -1, newFilterError(pf, "No symbols specified for Symbol filter.")
 			}
 		}
 	} else {
-		print_error(pf, "Missing arguments for Symbol filter.")
-		return (-1)
+		return -1, newFilterError(pf, "Missing arguments for Symbol filter.")
 	}
 
 	// This applies only for Position, Object, Item.
 	// decode_aprs() should set symbol code to space to mean undefined.
 
 	if pf.decoded.g_symbol_code == ' ' {
-		return (0)
+		return 0, nil
 	}
 
 	// Look for Primary symbols.
@@ -1034,15 +1035,15 @@ func filt_s(pf *pfstate_t) int {
 	if pf.decoded.g_symbol_table == '/' {
 		if len(pri) > 0 {
 			if strings.Contains(pri, string(rune(pf.decoded.g_symbol_code))) {
-				return 1
+				return 1, nil
 			} else {
-				return 0
+				return 0, nil
 			}
 		}
 	}
 
 	if alt == "" {
-		return (0)
+		return 0, nil
 	}
 
 	//printf ("alt=\"%s\"  sym='%c'\n", alt, pf.decoded.g_symbol_code);
@@ -1057,30 +1058,30 @@ func filt_s(pf *pfstate_t) int {
 				// Non-zero length overlay part was specified.
 				// Need to match one of them.
 				if strings.Contains(over, string(rune(pf.decoded.g_symbol_table))) {
-					return 1
+					return 1, nil
 				} else {
-					return 0
+					return 0, nil
 				}
 			} else {
 				// Zero length overlay part was specified.
 				// We must have no overlay, i.e.  table is \.
 				if pf.decoded.g_symbol_table == '\\' {
-					return 1
+					return 1, nil
 				} else {
-					return 0
+					return 0, nil
 				}
 			}
 		} else {
 			// No check of overlay part.  Just make sure it is not primary table.
 			if pf.decoded.g_symbol_table != '/' {
-				return 1
+				return 1, nil
 			} else {
-				return 0
+				return 0, nil
 			}
 		}
 	}
 
-	return (0)
+	return 0, nil
 } /* end filt_s */
 
 /*------------------------------------------------------------------------------
@@ -1174,7 +1175,7 @@ func filt_s(pf *pfstate_t) int {
  *
  *------------------------------------------------------------------------------*/
 
-func filt_i(pf *pfstate_t) int {
+func filt_i(pf *pfstate_t) (int, error) {
 	// http://lists.tapr.org/pipermail/aprssig_lists.tapr.org/2020-July/048656.html
 	// Default of 3 hours should be good.
 	// One might question why to have a time limit at all.  Messages are very rare
@@ -1183,8 +1184,11 @@ func filt_i(pf *pfstate_t) int {
 	// TODO: Should produce a warning if a user specified filter does not include "i".
 	// 3 hours * 60 min/hr = 180 minutes
 	// TODO KG: This was unused in the original C, but I think that was accidental given all the context here
-	var heardtime = 180                             //nolint:ineffassign,wastedassign
-	var maxhops = save_igate_config_p.max_digi_hops // from IGTXVIA config.
+	var heardtime = 180 //nolint:ineffassign,wastedassign
+	var maxhops = 0     // from IGTXVIA config.
+	if save_igate_config_p != nil {
+		maxhops = save_igate_config_p.max_digi_hops
+	}
 	var dlat float64 = G_UNKNOWN
 	var dlon float64 = G_UNKNOWN
 	var km float64 = G_UNKNOWN
@@ -1204,41 +1208,61 @@ func filt_i(pf *pfstate_t) int {
 	// Get parameters or defaults.
 
 	if len(parts) > 0 && len(parts[0]) > 0 {
-		heardtime, _ = strconv.Atoi(parts[0])
+		var heardtimeErr error
+		heardtime, heardtimeErr = strconv.Atoi(parts[0])
+
+		if heardtimeErr != nil {
+			return -1, newFilterError(pf, "Invalid time limit for IGate message filter.")
+		}
 	} else {
-		print_error(pf, "Missing time limit for IGate message filter.")
-		return (-1)
+		return -1, newFilterError(pf, "Missing time limit for IGate message filter.")
 	}
 
 	if len(parts) > 1 {
 		if len(parts[1]) > 0 {
-			maxhops, _ = strconv.Atoi(parts[1])
+			var maxhopsErr error
+			maxhops, maxhopsErr = strconv.Atoi(parts[1])
+
+			if maxhopsErr != nil {
+				return -1, newFilterError(pf, "Invalid max digipeater hops for IGate message filter.")
+			}
 		} else {
-			print_error(pf, "Missing max digipeater hops for IGate message filter.")
-			return (-1)
+			return -1, newFilterError(pf, "Missing max digipeater hops for IGate message filter.")
 		}
 
 		if len(parts) > 2 && len(parts[2]) > 0 {
-			dlat, _ = strconv.ParseFloat(parts[2], 64)
+			var dlatErr error
+			dlat, dlatErr = strconv.ParseFloat(parts[2], 64)
+
+			if dlatErr != nil {
+				return -1, newFilterError(pf, "Invalid latitude for IGate message filter.")
+			}
 
 			if len(parts) > 3 && len(parts[3]) > 0 {
-				dlon, _ = strconv.ParseFloat(parts[3], 64)
+				var dlonErr error
+				dlon, dlonErr = strconv.ParseFloat(parts[3], 64)
+
+				if dlonErr != nil {
+					return -1, newFilterError(pf, "Invalid longitude for IGate message filter.")
+				}
 			} else {
-				print_error(pf, "Missing longitude for IGate message filter.")
-				return (-1)
+				return -1, newFilterError(pf, "Missing longitude for IGate message filter.")
 			}
 
 			if len(parts) > 4 && len(parts[4]) > 0 {
-				km, _ = strconv.ParseFloat(parts[4], 64)
+				var kmErr error
+				km, kmErr = strconv.ParseFloat(parts[4], 64)
+
+				if kmErr != nil {
+					return -1, newFilterError(pf, "Invalid distance, in km, for IGate message filter.")
+				}
 			} else {
-				print_error(pf, "Missing distance, in km, for IGate message filter.")
-				return (-1)
+				return -1, newFilterError(pf, "Missing distance, in km, for IGate message filter.")
 			}
 		}
 
 		if len(parts) > 5 {
-			print_error(pf, "Something unexpected after distance for IGate message filter.")
-			return (-1)
+			return -1, newFilterError(pf, "Something unexpected after distance for IGate message filter.")
 		}
 	}
 
@@ -1247,11 +1271,11 @@ func filt_i(pf *pfstate_t) int {
 	 * Addressee has already been extracted into pf.decoded.g_addressee.
 	 */
 	if pf.decoded.g_packet_type != packet_type_message {
-		return (0)
+		return 0, nil
 	}
 
 	if pftest_running {
-		return (1) // Replacement for old #ifdef PFTEST
+		return 1, nil // Replacement for old #ifdef PFTEST
 	}
 
 	/* TODO KG Is this still needed? Digipeater tests still seem to pass fine without it...
@@ -1276,7 +1300,7 @@ func filt_i(pf *pfstate_t) int {
 	var was_heard = mheardDB.WasRecentlyNearby("addressee", pf.decoded.g_addressee, heardtime, maxhops, dlat, dlon, km)
 
 	if was_heard {
-		return (0)
+		return 0, nil
 	}
 
 	/*
@@ -1299,10 +1323,10 @@ func filt_i(pf *pfstate_t) int {
 	was_heard = mheardDB.WasRecentlyNearby("source", pf.decoded.g_src, 1, 0, G_UNKNOWN, G_UNKNOWN, G_UNKNOWN)
 
 	if was_heard {
-		return (0)
+		return 0, nil
 	}
 
-	return (1)
+	return 1, nil
 
 	// #endif
 } /* end filt_i */
@@ -1311,15 +1335,15 @@ func filt_i(pf *pfstate_t) int {
  *
  * Name:   	print_error
  *
- * Purpose:     Print error message with context so someone can figure out what caused it.
+ * Purpose:     Build an error with context so someone can figure out what caused it.
  *
  * Inputs:	pf	- Pointer to current state information.
  *
- *		str	- Specific error message.
+ *		msg	- Specific error message.
  *
  *--------------------------------------------------------------------*/
 
-func print_error(pf *pfstate_t, msg string) {
+func newFilterError(pf *pfstate_t, msg string) error {
 	var intro string
 
 	if pf.from_chan == MAX_TOTAL_CHANS {
@@ -1336,9 +1360,53 @@ func print_error(pf *pfstate_t, msg string) {
 		}
 	}
 
-	text_color_set(DW_COLOR_ERROR)
+	return fmt.Errorf("%s%s\n%*s\n%s", intro, pf.filter_str, len(intro)+pf.tokeni+1, "^", msg)
+}
 
-	dw_printf("%s%s\n", intro, pf.filter_str)
-	dw_printf("%*s\n", (len(intro) + pf.tokeni + 1), "^")
-	dw_printf("%s\n", msg)
+// pfilterDummyMonitorLine is a synthetic packet with a known position, symbol
+// and addressee used to exercise as much of the filter grammar as possible
+// during config-time syntax validation.
+//
+// This lives here, not in a _test.go file, because pfilter_validate() is a
+// runtime dependency of config.go (handleFILTER/handleCFILTER), not just
+// something exercised by tests: it needs a real *packet_t to drive the
+// parser/evaluator against when checking FILTER/CFILTER syntax at config
+// load time, and this constant is that fixture.
+const pfilterDummyMonitorLine = "WB2OSZ-5>APDW12,WIDE1-1,WIDE2-1:!4237.14NS07120.83W#PHG7140Chelmsford MA"
+
+/*-------------------------------------------------------------------
+ *
+ * Name:   	pfilter_validate
+ *
+ * Purpose:     Check a filter expression for syntax errors without needing
+ *		a real packet, so config file problems are caught at load
+ *		time rather than the first time a matching packet flows.
+ *
+ * Inputs:	from_chan, to_chan - Channel numbers this filter applies to, used
+ *			  only to give context in any error message.
+ *
+ *		filter	- Filter specification/expression from the config file.
+ *
+ *		is_aprs	- True for APRS digipeater/IGate filters, false for
+ *			  connected mode digipeater filters.
+ *
+ * Returns:	nil if the filter is syntactically valid, otherwise an error
+ *		describing the problem.
+ *
+ *--------------------------------------------------------------------*/
+
+func pfilter_validate(from_chan int, to_chan int, filter string, is_aprs bool) error {
+	var pp = AX25FromText(pfilterDummyMonitorLine, true)
+	if pp == nil {
+		return fmt.Errorf("pfilter_validate: failed to construct synthetic packet from %q", pfilterDummyMonitorLine)
+	}
+	defer AX25Delete(pp)
+
+	var saved_pftest_running = pftest_running
+	pftest_running = true
+	defer func() { pftest_running = saved_pftest_running }()
+
+	var _, err = pfilter(from_chan, to_chan, filter, pp, is_aprs)
+
+	return err
 }

--- a/src/pfilter_direwolf_test.go
+++ b/src/pfilter_direwolf_test.go
@@ -247,9 +247,19 @@ func pftest(t *testing.T, test_num int, filter string, monitor string, expected 
 	var pp = AX25FromText(monitor, true)
 	assert.NotNil(t, pp)
 
-	var result = pfilter(0, 0, filter, pp, true)
+	var result, err = pfilter(0, 0, filter, pp, true)
 	if !assert.Equal(t, expected, result, "Unexpected result for test number %d", test_num) {
 		pftest_error_count++
+	}
+
+	if expected == -1 {
+		if !assert.Error(t, err, "Expected an error for test number %d", test_num) { //nolint:testifylint
+			pftest_error_count++
+		}
+	} else {
+		if !assert.NoError(t, err, "Unexpected error for test number %d", test_num) { //nolint:testifylint
+			pftest_error_count++
+		}
 	}
 
 	AX25Delete(pp)

--- a/src/pfilter_test.go
+++ b/src/pfilter_test.go
@@ -1,0 +1,44 @@
+package direwolf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_pfilter_validate(t *testing.T) {
+	var p_igate_config igate_config_s
+	p_igate_config.max_digi_hops = 2
+	pfilter_init(&p_igate_config, 0)
+
+	t.Run("valid APRS filter returns no error", func(t *testing.T) {
+		assert.NoError(t, pfilter_validate(0, 0, "t/p & b/Q1TEST", true))
+	})
+
+	t.Run("valid connected-mode filter returns no error", func(t *testing.T) {
+		assert.NoError(t, pfilter_validate(0, 0, "b/Q1TEST", false))
+	})
+
+	t.Run("bad wildcard placement returns an error", func(t *testing.T) {
+		assert.Error(t, pfilter_validate(0, 0, "b/Q1TEST*Q2TEST", true))
+	})
+
+	t.Run("unrecognized filter type returns an error", func(t *testing.T) {
+		assert.Error(t, pfilter_validate(0, 0, "x/", true))
+	})
+
+	t.Run("filter type not allowed in connected mode returns an error", func(t *testing.T) {
+		assert.Error(t, pfilter_validate(0, 0, "t/p", false))
+	})
+
+	t.Run("unbalanced parentheses returns an error", func(t *testing.T) {
+		assert.Error(t, pfilter_validate(0, 0, "t/w & ( t/w | t/w ", true))
+	})
+
+	t.Run("error message reflects the real from/to channels", func(t *testing.T) {
+		var err = pfilter_validate(1, 2, "x/", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "filter[1,2]")
+	})
+}


### PR DESCRIPTION
🤖
## Summary
- `pfilter.go`'s parser/evaluator chain (`pfilter`, `parse_expr`/`parse_or_expr`/`parse_and_expr`/`parse_primary`/`parse_filter_spec`, `filt_bodgu`/`filt_t`/`filt_r`/`filt_s`/`filt_i`) now returns `(int, error)` instead of printing directly via `dw_printf`/`text_color_set`.
- Runtime callers (`digipeater.go`, `cdigipeater.go`, `igate.go` x2) unpack the returned error and print it themselves, preserving the existing stdout behaviour when a bad filter is actually evaluated against a packet.
- New `pfilter_validate(filter string, is_aprs bool) error` builds a synthetic packet and runs it through the filter parser purely to check syntax.
- `handleFILTER`/`handleCFILTER` in `config.go` now call `pfilter_validate` before storing the filter string, so a malformed `FILTER`/`CFILTER` expression in the config file is rejected loudly at config-load time instead of silently being stored and only failing (or worse, allowing everything through) the first time a matching packet flows.

## Test plan
- [x] `make fix`
- [x] `make check`
- [x] `make test`
- [x] Added `Test_pfilter_validate` covering valid/invalid APRS and connected-mode filter syntax
- [x] Added `Test_config_init_filter_syntax_validation` / `Test_config_init_cfilter_syntax_validation` verifying bad `FILTER`/`CFILTER` config lines are rejected and not stored
- [x] Existing `Test_pfilter` table (including its `-1`-expecting cases) extended to also assert an error is/isn't returned

Generated with [Claude Code](https://claude.com/claude-code)