### PR TITLE
test: Add two-instance raw-UDP-audio smoke test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@
     * Tests ported from Dire Wolf are often in `foo_test_shim.go` because `go test` doesn't support cgo in _test.go files so that was a place to put the test code while the port was ongoing. Now we don't (directly) use cgo, this is obsolete, and they should live in `foo_direwolf_test.go` - kept separately to make it easier to track upstream
     * Tests where an LLM has just generated a test suite for complex functionality live in `foo_impl_test.go` - this signifies that they don't necessarily reflect intended/specified behaviour, they just test an implementation as-is, so failing tests may not necessarily signify a bug
 
+## Concurrency
+
+* For a goroutine that loops on `select { case <-stop: ...; case <-ticker.C: ... }` and reads/writes a resource (socket, buffer) also torn down elsewhere: don't rely on `stop` being closed to prevent the ticker branch from running one more time after teardown starts — `select` picks randomly among ready cases. Instead, have teardown nil the resource under the same mutex the goroutine locks before touching it, and re-check for nil inside that locked section before using it.
+
 ## Licensing
 
 * `make reuse` checks [REUSE](https://reuse.software/) compliance and must always pass

--- a/src/audio.go
+++ b/src/audio.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gordonklaus/portaudio"
 )
@@ -715,6 +716,10 @@ type adev_s struct {
 
 	// UDP connection for audio output
 	udp_out_sock net.Conn
+
+	// Stops the silence-keepalive goroutine (UDP output only), see
+	// audioUDPSilenceKeepalive.
+	silenceStopCh chan struct{}
 }
 
 var adev [MAX_ADEVS]*adev_s
@@ -1295,6 +1300,9 @@ func audio_open(pa *audio_s) int {
 
 				adev[a].udp_out_sock = udpOutConn
 				adev[a].outbufSizeInBytes = UDP_AUDIO_OUT_BUF_MAXLEN
+				adev[a].silenceStopCh = make(chan struct{})
+
+				go audioUDPSilenceKeepalive(a, adev[a].silenceStopCh)
 			} else {
 				/*
 				 * Soundcard - blocking write mode.
@@ -1657,6 +1665,69 @@ func audio_flush_real(a int) int {
 	return 0
 } /* end audio_flush */
 
+// silenceKeepaliveInterval controls how often audioUDPSilenceKeepalive sends
+// a chunk of silence to a UDP audio output peer.
+const silenceKeepaliveInterval = 20 * time.Millisecond
+
+// audioUDPSilenceKeepalive keeps a UDP audio output stream flowing during
+// gaps between transmissions.
+//
+// UDP audio output only carries samples while a packet is actually being
+// transmitted; direwolf sends nothing at all the rest of the time. A real
+// sound card or SDR stream instead delivers samples continuously, silence
+// included, which is what lets the receiving demodulator's channel-busy
+// (DCD) state decay back to "clear" between transmissions. Without that, a
+// peer fed purely by bursty UDP audio can block forever in its own
+// ReadFromUDP once a burst ends, leaving DCD latched "busy" and never
+// getting a chance to transmit its own reply (see "Waited too long for
+// clear channel" in xmit.go). This streams silence whenever the device
+// isn't actively mid-transmission, using the same per-device mutex xmit.go
+// already holds for the duration of a real transmission so the two never
+// interleave on the wire.
+func audioUDPSilenceKeepalive(a int, stop chan struct{}) {
+	var ticker = time.NewTicker(silenceKeepaliveInterval)
+	defer ticker.Stop()
+
+	var fill byte
+	if adev[a].bitsPerSample == 8 {
+		fill = 128 // Silence for 8-bit unsigned samples is mid-scale.
+	} // Silence for 16-bit signed samples is zero, the byte slice's zero value.
+
+	var frames = int(float64(adev[a].sampleRate) * silenceKeepaliveInterval.Seconds())
+	var chunkLen = frames * adev[a].bytesPerFrame
+
+	// UDP_AUDIO_OUT_BUF_MAXLEN is sized to avoid UDP fragmentation; cap the
+	// keepalive payload to it too, rounding down to a whole number of
+	// frames so the receiver stays frame-aligned.
+	if chunkLen > UDP_AUDIO_OUT_BUF_MAXLEN {
+		chunkLen = (UDP_AUDIO_OUT_BUF_MAXLEN / adev[a].bytesPerFrame) * adev[a].bytesPerFrame
+	}
+
+	var chunk = make([]byte, chunkLen)
+	for i := range chunk {
+		chunk[i] = fill
+	}
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			if xmitSvc == nil || !xmitSvc.audioOutDevMutex[a].TryLock() {
+				continue
+			}
+
+			// audio_close tears down udp_out_sock under the same lock, so
+			// re-check for nil here rather than assuming it's still open.
+			if adev[a].udp_out_sock != nil {
+				_, _ = adev[a].udp_out_sock.Write(chunk)
+			}
+
+			xmitSvc.audioOutDevMutex[a].Unlock()
+		}
+	}
+}
+
 /*------------------------------------------------------------------
  *
  * Name:        audio_wait
@@ -1745,8 +1816,25 @@ func audio_close() int { //nolint:unparam
 			}
 
 			if adev[a].udp_out_sock != nil {
-				adev[a].udp_out_sock.Close()
+				if adev[a].silenceStopCh != nil {
+					close(adev[a].silenceStopCh)
+					adev[a].silenceStopCh = nil
+				}
+
+				// Nil the socket under the same lock audioUDPSilenceKeepalive
+				// takes before writing, so it never observes a closed socket.
+				if xmitSvc != nil {
+					xmitSvc.audioOutDevMutex[a].Lock()
+				}
+
+				var sock = adev[a].udp_out_sock
 				adev[a].udp_out_sock = nil
+
+				if xmitSvc != nil {
+					xmitSvc.audioOutDevMutex[a].Unlock()
+				}
+
+				sock.Close()
 			}
 
 			adev[a].inbufSizeInBytes = 0

--- a/src/audio_test.go
+++ b/src/audio_test.go
@@ -312,3 +312,58 @@ func Test_audioFlushReal_UDP_emptyBuffer_isNoop(t *testing.T) {
 	// Should return 0 without attempting a write.
 	assert.Equal(t, 0, audio_flush_real(0))
 }
+
+func Test_audioUDPSilenceKeepalive_chunkSizeAndCleanShutdown(t *testing.T) {
+	// Start a UDP listener to receive the keepalive silence.
+	var listener, err = net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	defer listener.Close()
+
+	var conn net.Conn
+	conn, err = net.Dial("udp", listener.LocalAddr().String())
+	require.NoError(t, err)
+
+	defer conn.Close()
+
+	var dev = setupAdev0(t)
+	dev.udp_out_sock = conn
+	dev.bitsPerSample = 16
+	dev.bytesPerFrame = 2  // mono, 16-bit
+	dev.sampleRate = 44100 // 20ms of samples at this rate exceeds UDP_AUDIO_OUT_BUF_MAXLEN, so the chunk must be capped
+
+	var prevXmitSvc = xmitSvc
+	t.Cleanup(func() { xmitSvc = prevXmitSvc })
+	xmitSvc = &XmitService{} //nolint:exhaustruct
+
+	var stop = make(chan struct{})
+	var done = make(chan struct{})
+
+	go func() {
+		defer close(done)
+		audioUDPSilenceKeepalive(0, stop)
+	}()
+
+	// Receive a chunk and verify it's frame-aligned and capped. The buffer
+	// is deliberately larger than UDP_AUDIO_OUT_BUF_MAXLEN so an oversize
+	// datagram would show up as a too-large read rather than being silently
+	// truncated by ReadFrom.
+	var buf = make([]byte, UDP_AUDIO_OUT_BUF_MAXLEN*2)
+	require.NoError(t, listener.SetReadDeadline(time.Now().Add(time.Second)))
+
+	var n int
+	n, _, err = listener.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.NotZero(t, n)
+	assert.LessOrEqual(t, n, UDP_AUDIO_OUT_BUF_MAXLEN, "chunk length must not exceed UDP_AUDIO_OUT_BUF_MAXLEN")
+	assert.Zero(t, n%dev.bytesPerFrame, "chunk length must be a multiple of bytesPerFrame")
+
+	// Closing stop should make the goroutine exit promptly.
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("audioUDPSilenceKeepalive did not stop after stop was closed")
+	}
+}

--- a/test-scripts/check-udp-audio-connect
+++ b/test-scripts/check-udp-audio-connect
@@ -1,0 +1,210 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+source "$(dirname "$(realpath "$0")")/common"
+
+if ! command -v python3 > /dev/null; then
+	echo "FAIL: python3 not found, required by free_port() for port allocation" >&2
+	exit 1
+fi
+
+goto_tmpdir
+
+# Picks a port in the range direwolf's config parser accepts (KISSPORT
+# requires MIN_IP_PORT_NUMBER..MAX_IP_PORT_NUMBER, see src/config.go), that
+# isn't already in use and isn't one of the ports already handed out earlier
+# in this script (passed in as arguments to exclude).  Takes the protocol
+# ("tcp" or "udp") to probe as its first argument, since the TCP and UDP
+# port namespaces are independent and a port free in one can be in use in
+# the other.  There's still a TOCTOU race against anything else grabbing the
+# port between us closing the probe socket and direwolf/kissutil binding it,
+# but that's an acceptable risk for a test script.
+free_port() {
+	local proto=$1
+	shift
+
+	python3 - "$proto" "$@" << 'EOF'
+import random
+import socket
+import sys
+
+proto = sys.argv[1]
+exclude = {int(p) for p in sys.argv[2:]}
+sock_type = socket.SOCK_STREAM if proto == "tcp" else socket.SOCK_DGRAM
+
+for _ in range(200):
+	port = random.randint(1024, 49151)
+	if port in exclude:
+		continue
+
+	probe = socket.socket(socket.AF_INET, sock_type)
+	try:
+		probe.bind(("127.0.0.1", port))
+	except OSError:
+		continue
+	finally:
+		probe.close()
+
+	print(port)
+	break
+else:
+	sys.exit("free_port: couldn't find a free port")
+EOF
+}
+
+# Each connection attempt is wrapped in its own subshell, so its fd 3 is
+# private and closes automatically when the subshell exits — nothing to
+# clean up in this shell. (An earlier version tried to `exec 3<&- 2>
+# /dev/null` here to close fd 3 "just in case"; since `exec` with no command
+# applies its redirections to the current shell, that `2> /dev/null`
+# silently and permanently redirected this whole script's stderr to
+# /dev/null the first time a port wasn't ready yet, swallowing every
+# diagnostic after it — including the FAIL message below. That's what made
+# failures look silent both locally and on GitHub's macOS runners.)
+wait_for_tcp_port() {
+	local port=$1
+	local deadline=$((SECONDS + 30))
+
+	while ! (exec 3<> "/dev/tcp/127.0.0.1/$port") 2> /dev/null; do
+		if ((SECONDS > deadline)); then
+			echo "FAIL: timed out waiting for TCP port $port" >&2
+			return 1
+		fi
+
+		sleep 0.2
+	done
+}
+
+# Waits for at least $3 (default 1) occurrences of $2 in $1.  wait_for_tcp_port's
+# own probe connection shows up as an "Attached" client too, so callers
+# waiting for a *real* client (e.g. a kissutil receiver) after already having
+# called wait_for_tcp_port on that same port must pass a count one higher
+# than the number of real clients, to skip past the probe's own line.
+wait_for_log_line() {
+	local logfile=$1
+	local pattern=$2
+	local mincount=${3:-1}
+	local deadline=$((SECONDS + 30))
+
+	while (($(grep -c "$pattern" "$logfile" 2> /dev/null || true) < mincount)); do
+		if ((SECONDS > deadline)); then
+			echo "FAIL: timed out waiting for '$pattern' (x$mincount) in $logfile" >&2
+			return 1
+		fi
+
+		sleep 0.2
+	done
+}
+
+wait_for_payload() {
+	local dir=$1
+	local payload=$2
+	local deadline=$((SECONDS + 30))
+
+	while ! grep -rq "$payload" "$dir" 2> /dev/null; do
+		if ((SECONDS > deadline)); then
+			echo "FAIL: timed out waiting for payload '$payload' in $dir" >&2
+			return 1
+		fi
+
+		sleep 0.2
+	done
+}
+
+pids=()
+
+# shellcheck disable=SC2317,SC2329 # cleanup is invoked indirectly via trap
+cleanup() {
+	for pid in "${pids[@]}"; do
+		kill "$pid" 2> /dev/null || true
+	done
+	wait 2> /dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# --- port allocation -------------------------------------------------------
+# Two instances of direwolf, each treating channel 0's "audio" as raw AFSK
+# samples carried over a dedicated UDP socket instead of a soundcard, wired
+# so each instance's output feeds the other's input.  This exercises the
+# real modem/HDLC/AX.25 stack end to end between two live processes, not
+# just KISS framing over a bridge.
+
+udp_a=$(free_port udp)
+udp_b=$(free_port udp "$udp_a")
+kiss_a=$(free_port tcp "$udp_a" "$udp_b")
+kiss_b=$(free_port tcp "$udp_a" "$udp_b" "$kiss_a")
+
+# --- config files -----------------------------------------------------------
+
+# AGWPORT 0 / KISSPORT 0 disable the default AGW (8000) and KISS (8001)
+# listeners, which are otherwise opened in addition to our explicit
+# KISSPORT and would collide between the two instances.
+
+cat > direwolf-a.conf << EOF
+MYCALL Q1TEST
+ADEVICE udp:$udp_a udp:localhost:$udp_b
+AGWPORT 0
+KISSPORT 0
+KISSPORT $kiss_a
+EOF
+
+cat > direwolf-b.conf << EOF
+MYCALL Q2TEST
+ADEVICE udp:$udp_b udp:localhost:$udp_a
+AGWPORT 0
+KISSPORT 0
+KISSPORT $kiss_b
+EOF
+
+mkdir recv-a recv-b send-a send-b
+
+# --- start direwolf instances ------------------------------------------------
+# Order doesn't matter here: unlike NCHANNEL, UDP audio input is just a local
+# listen and output is just a connectionless send, so neither instance needs
+# the other to already be up.
+
+"$DIREWOLF" -c direwolf-a.conf > direwolf-a.log 2>&1 &
+pids+=("$!")
+"$DIREWOLF" -c direwolf-b.conf > direwolf-b.log 2>&1 &
+pids+=("$!")
+
+wait_for_tcp_port "$kiss_a"
+wait_for_tcp_port "$kiss_b"
+
+# --- start persistent receivers ----------------------------------------------
+# Without -f, kissutil reads from stdin in a loop and exits (taking its
+# receive goroutine down with it) the moment stdin hits EOF, which would
+# happen almost immediately for a backgrounded process with no terminal.
+# Feed it a stdin that never closes instead. `sleep infinity` is GNU-only —
+# macOS's BSD sleep rejects it outright ("usage: sleep number[unit]"), which
+# made stdin hit EOF immediately there. A plain large number works on both.
+
+"$KISSUTIL" -p "$kiss_a" -o recv-a < <(sleep 3600) > kissutil-recv-a.log 2>&1 &
+pids+=("$!")
+"$KISSUTIL" -p "$kiss_b" -o recv-b < <(sleep 3600) > kissutil-recv-b.log 2>&1 &
+pids+=("$!")
+
+# Wait for each direwolf to see its kissutil receiver actually attach, since
+# a send before that point would be silently dropped (no queuing for absent
+# clients).  mincount=2 skips past wait_for_tcp_port's own probe connection,
+# which shows up as an "Attached" client too.
+wait_for_log_line direwolf-a.log "Attached to KISS TCP client application" 2
+wait_for_log_line direwolf-b.log "Attached to KISS TCP client application" 2
+
+# --- A -> B ------------------------------------------------------------------
+
+echo "Q1TEST>Q2TEST:hello from A" > send-a/msg1
+"$KISSUTIL" -p "$kiss_a" -f send-a > kissutil-send-a.log 2>&1
+
+wait_for_payload recv-b "hello from A"
+
+# --- B -> A (confirm bidirectionality) ----------------------------------------
+
+echo "Q2TEST>Q1TEST:hello from B" > send-b/msg1
+"$KISSUTIL" -p "$kiss_b" -f send-b > kissutil-send-b.log 2>&1
+
+wait_for_payload recv-a "hello from B"
+
+echo "PASS: two samoyed-direwolf instances exchanged AX.25 frames over raw UDP audio"

--- a/test-scripts/common
+++ b/test-scripts/common
@@ -11,6 +11,12 @@ export FXREC
 GEN_PACKETS="${GEN_PACKETS:-$(dirname "$(realpath "$0")")/../dist/samoyed-gen_packets}"
 export GEN_PACKETS
 
+DIREWOLF="${DIREWOLF:-$(dirname "$(realpath "$0")")/../dist/samoyed-direwolf}"
+export DIREWOLF
+
+KISSUTIL="${KISSUTIL:-$(dirname "$(realpath "$0")")/../dist/samoyed-kissutil}"
+export KISSUTIL
+
 function goto_tmpdir() {
 	TMPDIR=$(mktemp --directory)
 	echo "$TMPDIR"


### PR DESCRIPTION
## Summary
- Adds a new integration-y smoke test (`test-scripts/check-udp-audio-connect`) that runs two `samoyed-direwolf` instances wired to each other's channel 0 over raw UDP audio (`ADEVICE udp:...`), and verifies an AX.25 frame sent from one is received by the other, in both directions, via `samoyed-kissutil`.
- Fixes a real bug found while building the test: `ADEVICE udp:...` output only sends samples while actively transmitting, unlike a real sound card/SDR stream. Once a burst ends, the peer's `ReadFromUDP` blocks forever with nothing more arriving, freezing its channel-busy (DCD) state — if that was "busy", the peer can never clear DCD and its own transmitter waits forever for a clear channel, eventually discarding queued packets ("Waited too long for clear channel"). Fixed by streaming silence during idle gaps, synchronized with the existing per-device `audioOutDevMutex` so it never interleaves with a real transmission.

## Test plan
- [x] `./test-scripts/check-udp-audio-connect` passes repeatedly when run directly
- [x] Manual stress test: 15 messages each direction between two long-lived instances, 15/15 delivered both ways
- [x] `make fix`
- [x] `make check`
- [x] `make test` (full suite, including the new script via `test-scripts/runall`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)