### PR TITLE
fix: Fix race that could drop a KISS client's in-flight frame on connect

### DIFF
--- a/src/kissnet.go
+++ b/src/kissnet.go
@@ -597,6 +597,18 @@ func (kns *KissNetService) connectListenThread(kps *kissport_status_s) {
 				continue
 			}
 
+			// Reset this client's frame decoder state and buffer before
+			// publishing the connection via client_sock. Previously this
+			// reset (a) happened after client_sock was set, so a fast
+			// sender's bytes could reach listenThread's read loop and
+			// start building a frame in the old *KISSFrame before this
+			// goroutine swapped it out from under it, silently corrupting
+			// the frame, and (b) reset every client's slot rather than
+			// just the one that (re)connected, which could just as easily
+			// clobber a frame already in progress on another attached
+			// client.
+			kps.kf[client] = new(KISSFrame)
+
 			kps.client_sock[client] = conn
 
 			text_color_set(DW_COLOR_INFO)
@@ -605,11 +617,6 @@ func (kns *KissNetService) connectListenThread(kps *kissport_status_s) {
 				dw_printf("\nAttached to KISS TCP client application %d on port %d ...\n\n", client, kps.tcp_port)
 			} else {
 				dw_printf("\nAttached to KISS TCP client application %d on port %d (radio channel %d) ...\n\n", client, kps.tcp_port, kps.channel)
-			}
-
-			// Reset the state and buffer.
-			for i := range len(kps.kf) {
-				kps.kf[i] = new(KISSFrame)
 			}
 		} else {
 			SLEEP_SEC(1) /* wait then check again if more clients allowed. */

--- a/test-scripts/check-udp-audio-connect
+++ b/test-scripts/check-udp-audio-connect
@@ -117,6 +117,17 @@ pids=()
 
 # shellcheck disable=SC2317,SC2329 # cleanup is invoked indirectly via trap
 cleanup() {
+	local status=$?
+
+	if ((status != 0)); then
+		echo "--- FAILURE: dumping logs from $PWD for diagnosis ---" >&2
+
+		for log in direwolf-a.log direwolf-b.log kissutil-recv-a.log kissutil-recv-b.log kissutil-send-a.log kissutil-send-b.log; do
+			echo "--- $log ---" >&2
+			cat "$log" >&2 2> /dev/null || echo "(missing)" >&2
+		done
+	fi
+
 	for pid in "${pids[@]}"; do
 		kill "$pid" 2> /dev/null || true
 	done


### PR DESCRIPTION
## Summary

🤖 `test-scripts/check-udp-audio-connect` (added in #566) was timing out consistently waiting for direwolf instance B to receive the second leg of a bidirectional AX.25 exchange over raw UDP audio.

Root cause: in `connectListenThread` (`src/kissnet.go`), a newly-accepted client's socket was published via `client_sock[client]` *before* that client's `*KISSFrame` decoder state was reset, and the reset cleared *every* client's `kf[]` slot rather than just the one that (re)connected.

A client that connects and starts sending immediately — like `kissutil -f` used by the test — could race `listenThread`'s read loop: bytes already being accumulated into a `*KISSFrame` could be silently swapped out from under it when `connectListenThread` cleared the slot, corrupting or losing the frame. The same reset could also clobber a frame already in progress on an unrelated, already-attached client (e.g. a persistent receiver mid-decode when a new client connects).

## Changes

- Reset only `kf[client]`, and do so *before* publishing `client_sock[client]`, so `listenThread` can't observe the socket as live until the fresh decoder state is already in place.
- `check-udp-audio-connect` now dumps the direwolf and kissutil logs on failure, since "timed out waiting for X" alone gave no way to tell where in the pipeline a frame went missing.

## Test plan

- [x] `test-scripts/check-udp-audio-connect` failed consistently (5/5) before the fix, passes consistently (5/5) after
- [x] `make fix`
- [x] `make check`
- [x] `make test`