### PR TITLE
fix: Synchronize KISS TCP client_sock/kf access with a mutex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@
 ## Concurrency
 
 * For a goroutine that loops on `select { case <-stop: ...; case <-ticker.C: ... }` and reads/writes a resource (socket, buffer) also torn down elsewhere: don't rely on `stop` being closed to prevent the ticker branch from running one more time after teardown starts — `select` picks randomly among ready cases. Instead, have teardown nil the resource under the same mutex the goroutine locks before touching it, and re-check for nil inside that locked section before using it.
+* If a mutex-guarded struct exposes one accessor per field, and a caller ever needs two of those fields together (e.g. a connection and its paired decoder/session state), add a combined accessor that locks once and returns both. Two separately-locked calls can straddle another goroutine's update, handing back a pair that never coexisted under the lock.
 
 ## Licensing
 

--- a/src/kiss_frame.go
+++ b/src/kiss_frame.go
@@ -64,6 +64,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 )
 
 const KISS_CMD_DATA_FRAME = 0
@@ -138,10 +139,88 @@ type kissport_status_s struct {
 	channel int // Radio channel for this tcp port.
 	// -1 for all.
 
+	// mu guards client_sock and kf below, which are read and written from
+	// connectListenThread (accepting new connections), listenThread/get
+	// (reading from a connected client and detecting disconnection), and
+	// SendRecPacket/Copy (writing to connected clients). Once those
+	// goroutines are running, always go through the kissport_status_s
+	// methods below rather than touching these fields directly. The one
+	// exception is initOne, which sets them directly during single-threaded
+	// startup, before any goroutine that shares mu exists.
+	mu sync.Mutex
+
 	client_sock [MAX_NET_CLIENTS]net.Conn
 
 	kf [MAX_NET_CLIENTS]*KISSFrame
 	/* Accumulated KISS frame and state of decoder. */
+}
+
+// clientConn returns the currently connected socket for client, or nil if
+// not connected.
+func (kps *kissport_status_s) clientConn(client int) net.Conn {
+	kps.mu.Lock()
+	defer kps.mu.Unlock()
+
+	return kps.client_sock[client]
+}
+
+// attachClient installs conn as client's socket, along with a freshly reset
+// decoder state, atomically with respect to clientConn/detachClientIfCurrent.
+// This ensures listenThread can never observe a "live" socket for client
+// paired with decoder state left over from a previous connection, or from
+// another client's slot.
+func (kps *kissport_status_s) attachClient(client int, conn net.Conn) {
+	kps.mu.Lock()
+	defer kps.mu.Unlock()
+
+	kps.kf[client] = new(KISSFrame)
+	kps.client_sock[client] = conn
+}
+
+// detachClientIfCurrent clears client's socket, but only if it still equals
+// conn. This guards against a goroutine which detected an error/EOF on a
+// now-stale conn racing with, and clobbering, a newer connection that
+// connectListenThread has already installed in the same slot. Returns
+// whether it cleared the slot.
+func (kps *kissport_status_s) detachClientIfCurrent(client int, conn net.Conn) bool {
+	kps.mu.Lock()
+	defer kps.mu.Unlock()
+
+	if kps.client_sock[client] != conn {
+		return false
+	}
+
+	kps.client_sock[client] = nil
+
+	return true
+}
+
+// findFreeClient returns the index of the first client slot with no
+// connected socket, or -1 if all are in use.
+func (kps *kissport_status_s) findFreeClient() int {
+	kps.mu.Lock()
+	defer kps.mu.Unlock()
+
+	for c := range MAX_NET_CLIENTS {
+		if kps.client_sock[c] == nil {
+			return c
+		}
+	}
+
+	return -1
+}
+
+// connAndFrame returns client's currently connected socket (or nil) together
+// with its decoder state, fetched under a single lock/unlock. Callers that
+// need to pair a connection with its decoder state (e.g. before reading a
+// byte from it) must use this rather than clientConn/frame separately: two
+// independently-locked calls could observe an attachClient in between them,
+// pairing a conn with a *KISSFrame that belongs to a different connection.
+func (kps *kissport_status_s) connAndFrame(client int) (net.Conn, *KISSFrame) {
+	kps.mu.Lock()
+	defer kps.mu.Unlock()
+
+	return kps.client_sock[client], kps.kf[client]
 }
 
 var KISSUTIL = false // Dynamic replacement for the old #define

--- a/src/kissnet.go
+++ b/src/kissnet.go
@@ -254,7 +254,8 @@ func (kns *KissNetService) SendRecPacket(channel int, kiss_cmd int, fbuf []byte,
 		if onlykps == nil || kps == onlykps {
 			for client := range MAX_NET_CLIENTS {
 				if onlyclient == -1 || client == onlyclient {
-					if kps.client_sock[client] != nil {
+					var conn = kps.clientConn(client)
+					if conn != nil {
 						var kiss_buff []byte
 
 						if flen < 0 {
@@ -312,12 +313,12 @@ func (kns *KissNetService) SendRecPacket(channel int, kiss_cmd int, fbuf []byte,
 							}
 						}
 
-						var _, err = kps.client_sock[client].Write(kiss_buff)
+						var _, err = conn.Write(kiss_buff)
 						if err != nil {
 							text_color_set(DW_COLOR_ERROR)
 							dw_printf("\nError %s sending message to KISS client application %d on port %d.  Closing connection.\n\n", err, client, kps.tcp_port)
-							kps.client_sock[client].Close()
-							kps.client_sock[client] = nil
+							conn.Close()
+							kps.detachClientIfCurrent(client, conn)
 						}
 					} // frame length >= 0
 				} // if all clients or the one specifie
@@ -367,7 +368,8 @@ func (kns *KissNetService) Copy(_msg []byte, channel int, cmd int, from_kps *kis
 			for client := range MAX_NET_CLIENTS {
 				// To all but origin.
 				if !(kps == from_kps && client == from_client) {
-					if kps.client_sock[client] != nil {
+					var conn = kps.clientConn(client)
+					if conn != nil {
 						if kps.channel == -1 || kps.channel == channel {
 							// Two different cases here:
 							//  - The TCP port allows all channels, or
@@ -386,12 +388,12 @@ func (kns *KissNetService) Copy(_msg []byte, channel int, cmd int, from_kps *kis
 								kiss_debug_print(TO_CLIENT, "", kiss_buff)
 							}
 
-							var _, err = kps.client_sock[client].Write(kiss_buff)
+							var _, err = conn.Write(kiss_buff)
 							if err != nil {
 								text_color_set(DW_COLOR_ERROR)
 								dw_printf("\nError %s copying message to KISS TCP port %d client %d application.  Closing connection.\n\n", err, kps.tcp_port, client)
-								kps.client_sock[client].Close()
-								kps.client_sock[client] = nil
+								conn.Close()
+								kps.detachClientIfCurrent(client, conn)
 							}
 						} // Channel is allowed on this port.
 					} // socket is open
@@ -419,17 +421,18 @@ func (kns *KissNetService) Copy(_msg []byte, channel int, cmd int, from_kps *kis
 
 /* Return one byte (value 0 - 255) */
 
-func (kns *KissNetService) get(kps *kissport_status_s, client int) byte {
+func (kns *KissNetService) get(kps *kissport_status_s, client int) (byte, *KISSFrame) {
 	for {
-		for kps.client_sock[client] == nil {
+		var conn, frame = kps.connAndFrame(client)
+		for conn == nil {
 			SLEEP_SEC(1) /* Not connected.  Try again later. */
+			conn, frame = kps.connAndFrame(client)
 		}
 
 		/* Just get one byte at a time. */
 
-		var c = kps.client_sock[client]
 		var ch = make([]byte, 1)
-		var n, _ = c.Read(ch)
+		var n, _ = conn.Read(ch)
 
 		if n == 1 {
 			/* TODO KG
@@ -447,14 +450,19 @@ func (kns *KissNetService) get(kps *kissport_status_s, client int) byte {
 				    if (ch == FEND) fflush (log_fp);
 			#endif
 			*/
-			return (ch[0])
+			return ch[0], frame
 		}
 
-		text_color_set(DW_COLOR_ERROR)
-		dw_printf("\nKISS client application %d on TCP port %d has gone away.\n\n", client, kps.tcp_port)
-		c.Close()
+		conn.Close()
 
-		kps.client_sock[client] = nil
+		// Only clear the slot if conn is still the current connection for
+		// this client. If it isn't, connectListenThread has already
+		// accepted a newer connection here (e.g. the client reconnected)
+		// and we must not clobber it out from under that newer connection.
+		if kps.detachClientIfCurrent(client, conn) {
+			text_color_set(DW_COLOR_ERROR)
+			dw_printf("\nKISS client application %d on TCP port %d has gone away.\n\n", client, kps.tcp_port)
+		}
 	}
 }
 
@@ -480,8 +488,8 @@ func (kns *KissNetService) listenThread(kps *kissport_status_s, client int) {
 	// "Simply KISS" as some call it.
 
 	for {
-		var ch = kns.get(kps, client)
-		KissRecByte(kps.kf[client], ch, kns.debug, kps, client, kns.SendRecPacket)
+		var ch, frame = kns.get(kps, client)
+		KissRecByte(frame, ch, kns.debug, kps, client, kns.SendRecPacket)
 	}
 } /* end listenThread */
 
@@ -575,12 +583,7 @@ func (kns *KissNetService) connectListenThread(kps *kissport_status_s) {
 	*/
 
 	for {
-		var client = -1
-		for c := 0; c < MAX_NET_CLIENTS && client < 0; c++ {
-			if kps.client_sock[c] == nil {
-				client = c
-			}
-		}
+		var client = kps.findFreeClient()
 
 		if client >= 0 {
 			text_color_set(DW_COLOR_INFO)
@@ -597,19 +600,17 @@ func (kns *KissNetService) connectListenThread(kps *kissport_status_s) {
 				continue
 			}
 
-			// Reset this client's frame decoder state and buffer before
-			// publishing the connection via client_sock. Previously this
-			// reset (a) happened after client_sock was set, so a fast
-			// sender's bytes could reach listenThread's read loop and
-			// start building a frame in the old *KISSFrame before this
-			// goroutine swapped it out from under it, silently corrupting
-			// the frame, and (b) reset every client's slot rather than
-			// just the one that (re)connected, which could just as easily
-			// clobber a frame already in progress on another attached
-			// client.
-			kps.kf[client] = new(KISSFrame)
-
-			kps.client_sock[client] = conn
+			// Atomically install this client's connection along with a
+			// freshly reset frame decoder state. Previously these were two
+			// separate, unsynchronized steps: client_sock was published
+			// before kf was reset, so a fast sender's bytes could reach
+			// listenThread's read loop and start building a frame in the
+			// old *KISSFrame before this goroutine swapped it out from
+			// under it, silently corrupting the frame. And the reset
+			// touched every client's slot rather than just the one that
+			// (re)connected, which could just as easily clobber a frame
+			// already in progress on another attached client.
+			kps.attachClient(client, conn)
 
 			text_color_set(DW_COLOR_INFO)
 


### PR DESCRIPTION
## Summary

🤖 Follow-up to #567, addressing [Copilot's review comment](https://github.com/doismellburning/samoyed/pull/567#discussion_r3650900683) on that PR (stacked on top of it — base branch is `worktree-fix-udp-audio-kissnet-race`, not `main`).

#567 fixed one specific, reliably reproducible race (a fast-sending KISS client's frame getting silently corrupted right after connect) by reordering two unsynchronized field writes in `connectListenThread`. Review correctly pointed out that reordering alone still leaves a genuine Go data race — `kissport_status_s.client_sock` and `.kf` are read/written from multiple goroutines with no synchronization at all — plus a further, distinct hazard: `get()` detecting a dead connection could clear `client_sock[client]` for a *stale* connection right after `connectListenThread` had already installed a newer one in the same slot, silently dropping the new connection.

## Changes

- Add a `sync.Mutex` to `kissport_status_s`.
- Add accessor methods (`clientConn`, `attachClient`, `detachClientIfCurrent`, `findFreeClient`, `frame`) that are the only way `client_sock`/`kf` are touched from here on:
  - `attachClient` publishes a new connection together with its freshly reset decoder state atomically.
  - `detachClientIfCurrent` only clears a slot if it still holds the exact connection the caller observed, so a stale disconnect can never clobber a connection that has since replaced it.
- Updated `connectListenThread`, `get`, `listenThread`, `SendRecPacket`, and `Copy` to go through these accessors instead of touching the fields directly.

## Test plan

- [x] `go build -race ./cmd/samoyed-direwolf/` + `check-udp-audio-connect`: no data races reported in `kissnet.go`/`kiss_frame.go` (some pre-existing, unrelated races in `audio.go`/`xmit.go` are reported; the race build's overhead also makes the test's fixed 30s deadlines too tight to reliably pass, so this isn't wired up as a CI configuration)
- [x] `test-scripts/check-udp-audio-connect` passes consistently (5/5) on the normal build
- [x] `make fix`
- [x] `make check`
- [x] `make test`