### PR TITLE
style: Enable godot linter and fix comment punctuation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - "funlen"  # We have inherited lots of long lines
     - "gocyclo"  # One day
     - "godoclint"  # There's lots to be done with documentation formatting, but not right now
-    - "godot"  # Implicit full stops are ok
     - "godox"  # There will be TODOs
     - "intrange" # Another thing that I like in theory, but am not prioritising right now
     - "lll"  # We have inherited lots of long lines

--- a/cmd/samoyed-appserver/main.go
+++ b/cmd/samoyed-appserver/main.go
@@ -372,7 +372,7 @@ func (s *session) pollTimingTest() {
  *
  *--------------------------------------------------------------------*/
 
-// old void agw_cb_C_connection_received (int chan, char *call_from, char *call_to, int data_len, char *data)
+// old void agw_cb_C_connection_received (int chan, char *call_from, char *call_to, int data_len, char *data).
 func on_C_connection_received(channel byte, call_from Callsign, call_to Callsign, incoming bool, data []byte) { //nolint:unparam
 	srv.getOrCreateSession(channel, call_from)
 
@@ -631,7 +631,7 @@ func agw_cb_Y_outstanding_frames_for_station(channel byte, call_from Callsign, c
 	s.txQueueLen = frame_count
 } /* end agw_cb_Y_outstanding_frames_for_station */
 
-// strings.Cut for []bytes
+// strings.Cut for []bytes.
 func BytesCut(s []byte, b byte) ([]byte, []byte, bool) { //nolint:unparam
 	var i = bytes.Index(s, []byte{b})
 

--- a/cmd/samoyed-kissutil/main.go
+++ b/cmd/samoyed-kissutil/main.go
@@ -591,7 +591,7 @@ func kissutil_kiss_process_msg(kiss_msg []byte) {
 	}
 } /* end kiss_process_msg */
 
-// Used as both CLI help message and in-usage error reminder
+// Used as both CLI help message and in-usage error reminder.
 func usage2() {
 	fmt.Printf("\n")
 	fmt.Printf("Input, starting with upper case letter or digit, is assumed\n")
@@ -638,7 +638,7 @@ func usage2() {
  *		so it's probably not worth the effort to add another
  *		option.
  *
- *---------------------------------------------------------------*/
+ *---------------------------------------------------------------.*/
 func timestamp_filename() string {
 	var t = time.Now()
 

--- a/cmd/samoyed-log2gpx/main_test.go
+++ b/cmd/samoyed-log2gpx/main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TODO Break down log2gpx into something easier to test...!
-// TODO Use a much less brittle test than "compare with exact Dire Wolf output"
+// TODO Use a much less brittle test than "compare with exact Dire Wolf output".
 func Test_log2gpx(t *testing.T) {
 	// Save original stdin/stdout
 	var oldStdin = os.Stdin

--- a/src/ax25_link_direwolf_test.go
+++ b/src/ax25_link_direwolf_test.go
@@ -130,7 +130,7 @@ func Test_AX25_Link(t *testing.T) {
 	TestAX25LinkFrameCountStats(t)
 }
 
-// Helper to set up a fresh test environment
+// Helper to set up a fresh test environment.
 func setupTestEnv(t *testing.T) {
 	t.Helper()
 
@@ -153,7 +153,7 @@ func setupTestEnv(t *testing.T) {
 	reg_callsign_list = nil // Clear registered callsigns
 }
 
-// Helper to set up environment with v2.2 support enabled
+// Helper to set up environment with v2.2 support enabled.
 func setupTestEnvV22(t *testing.T) {
 	t.Helper()
 
@@ -176,7 +176,7 @@ func setupTestEnvV22(t *testing.T) {
 	reg_callsign_list = nil // Clear registered callsigns
 }
 
-// Helper to initiate a connect request
+// Helper to initiate a connect request.
 func initiateConnect(t *testing.T, myCall, theirCall string, channel int) {
 	t.Helper()
 
@@ -190,7 +190,7 @@ func initiateConnect(t *testing.T, myCall, theirCall string, channel int) {
 	dl_connect_request(E)
 }
 
-// Helper to simulate receiving a frame
+// Helper to simulate receiving a frame.
 func receiveFrame(t *testing.T, pp *packet_t, channel int) {
 	t.Helper()
 
@@ -201,7 +201,7 @@ func receiveFrame(t *testing.T, pp *packet_t, channel int) {
 	lm_data_indication(E)
 }
 
-// Helper to establish a connection (SABM/UA exchange)
+// Helper to establish a connection (SABM/UA exchange).
 func establishConnection(t *testing.T, myCall, theirCall string, channel int) *ax25_dlsm_t { //nolint:unparam
 	t.Helper()
 
@@ -227,7 +227,7 @@ func establishConnection(t *testing.T, myCall, theirCall string, channel int) *a
 // ============================================================================
 
 // SABM/UA Exchange (Modulo 8)
-// Pokes at some of the state machine API in the style of recv_process from recv.go
+// Pokes at some of the state machine API in the style of recv_process from recv.go.
 func TestAX25LinkConnectedBasic(t *testing.T) {
 	t.Helper()
 
@@ -275,7 +275,7 @@ func TestAX25LinkConnectedBasic(t *testing.T) {
 	assert.Equal(t, ax25_modulo_t(8), list_head.modulo, "Should be modulo 8")
 }
 
-// SABME/UA Exchange (Modulo 128)
+// SABME/UA Exchange (Modulo 128).
 func TestAX25LinkSABMEConnection(t *testing.T) {
 	t.Helper()
 
@@ -306,7 +306,7 @@ func TestAX25LinkSABMEConnection(t *testing.T) {
 	assert.Equal(t, ax25_modulo_t(128), list_head.modulo, "Should be modulo 128 for v2.2")
 }
 
-// Connection Rejected with DM
+// Connection Rejected with DM.
 func TestAX25LinkConnectionRejectedWithDM(t *testing.T) {
 	t.Helper()
 
@@ -332,7 +332,7 @@ func TestAX25LinkConnectionRejectedWithDM(t *testing.T) {
 	assert.Equal(t, state_0_disconnected, list_head.state, "Should be disconnected after DM")
 }
 
-// Normal DISC/UA Exchange
+// Normal DISC/UA Exchange.
 func TestAX25LinkDISCDisconnection(t *testing.T) {
 	t.Helper()
 
@@ -372,7 +372,7 @@ func TestAX25LinkDISCDisconnection(t *testing.T) {
 	assert.Equal(t, state_0_disconnected, S.state)
 }
 
-// DISC in Disconnected State
+// DISC in Disconnected State.
 func TestAX25LinkDISCInDisconnectedState(t *testing.T) {
 	t.Helper()
 
@@ -408,7 +408,7 @@ func TestAX25LinkDISCInDisconnectedState(t *testing.T) {
 // Information Transfer Tests
 // ============================================================================
 
-// I-Frame Reception
+// I-Frame Reception.
 func TestAX25LinkIFrameExchange(t *testing.T) {
 	t.Helper()
 
@@ -435,7 +435,7 @@ func TestAX25LinkIFrameExchange(t *testing.T) {
 	assert.True(t, S.acknowledge_pending, "Acknowledge should be pending")
 }
 
-// RR Acknowledgement
+// RR Acknowledgement.
 func TestAX25LinkRRResponse(t *testing.T) {
 	t.Helper()
 
@@ -460,7 +460,7 @@ func TestAX25LinkRRResponse(t *testing.T) {
 	assert.Equal(t, state_3_connected, S.state)
 }
 
-// RNR Flow Control
+// RNR Flow Control.
 func TestAX25LinkRNRFlowControl(t *testing.T) {
 	t.Helper()
 
@@ -497,7 +497,7 @@ func TestAX25LinkRNRFlowControl(t *testing.T) {
 // ============================================================================
 
 // REJ Reception handling
-// Note: Full retransmission testing requires having sent I-frames first
+// Note: Full retransmission testing requires having sent I-frames first.
 func TestAX25LinkREJErrorRecovery(t *testing.T) {
 	t.Helper()
 
@@ -527,7 +527,7 @@ func TestAX25LinkREJErrorRecovery(t *testing.T) {
 // State Machine Transition Tests
 // ============================================================================
 
-// SABM Reception in Disconnected (incoming connection)
+// SABM Reception in Disconnected (incoming connection).
 func TestAX25LinkIncomingSABM(t *testing.T) {
 	t.Helper()
 
@@ -566,7 +566,7 @@ func TestAX25LinkIncomingSABM(t *testing.T) {
 	}
 }
 
-// State variable management
+// State variable management.
 func TestAX25LinkStateVariables(t *testing.T) {
 	t.Helper()
 
@@ -618,7 +618,7 @@ func TestAX25LinkStateVariables(t *testing.T) {
 // Additional Information Transfer Tests
 // ============================================================================
 
-// Multiple sequential I-frame reception with V(R) tracking
+// Multiple sequential I-frame reception with V(R) tracking.
 func TestAX25LinkMultipleIFrames(t *testing.T) {
 	t.Helper()
 
@@ -648,7 +648,7 @@ func TestAX25LinkMultipleIFrames(t *testing.T) {
 	assert.True(t, S.acknowledge_pending, "Acknowledge should be pending")
 }
 
-// Out-of-sequence I-frame sets reject_exception flag
+// Out-of-sequence I-frame sets reject_exception flag.
 func TestAX25LinkOutOfSequenceIFrame(t *testing.T) {
 	t.Helper()
 
@@ -679,7 +679,7 @@ func TestAX25LinkOutOfSequenceIFrame(t *testing.T) {
 	assert.True(t, S.reject_exception, "Reject exception should be set")
 }
 
-// I-frame with piggybacked acknowledgement updates V(A)
+// I-frame with piggybacked acknowledgement updates V(A).
 func TestAX25LinkIFrameWithAck(t *testing.T) {
 	t.Helper()
 
@@ -710,7 +710,7 @@ func TestAX25LinkIFrameWithAck(t *testing.T) {
 // Additional State Machine Tests
 // ============================================================================
 
-// DISC reception while connected causes transition to disconnected
+// DISC reception while connected causes transition to disconnected.
 func TestAX25LinkDISCWhileConnected(t *testing.T) {
 	t.Helper()
 
@@ -734,7 +734,7 @@ func TestAX25LinkDISCWhileConnected(t *testing.T) {
 	assert.Equal(t, state_0_disconnected, S.state)
 }
 
-// SABM while connected causes link reset
+// SABM while connected causes link reset.
 func TestAX25LinkSABMWhileConnected(t *testing.T) {
 	t.Helper()
 
@@ -765,7 +765,7 @@ func TestAX25LinkSABMWhileConnected(t *testing.T) {
 	assert.Equal(t, 0, S.va, "V(A) should be reset to 0")
 }
 
-// DM response also terminates awaiting release state
+// DM response also terminates awaiting release state.
 func TestAX25LinkDMAfterDISC(t *testing.T) {
 	t.Helper()
 
@@ -799,7 +799,7 @@ func TestAX25LinkDMAfterDISC(t *testing.T) {
 	assert.Equal(t, state_0_disconnected, S.state)
 }
 
-// SABM collision - receive SABM while in awaiting connection state
+// SABM collision - receive SABM while in awaiting connection state.
 func TestAX25LinkSABMCollision(t *testing.T) {
 	t.Helper()
 
@@ -836,7 +836,7 @@ func TestAX25LinkSABMCollision(t *testing.T) {
 	assert.Equal(t, state_3_connected, list_head.state)
 }
 
-// Timer recovery state entry on receiving poll
+// Timer recovery state entry on receiving poll.
 func TestAX25LinkTimerRecoveryState(t *testing.T) {
 	t.Helper()
 
@@ -867,7 +867,7 @@ func TestAX25LinkTimerRecoveryState(t *testing.T) {
 // SREJ Tests (Selective Reject)
 // ============================================================================
 
-// SREJ frame handling
+// SREJ frame handling.
 func TestAX25LinkSREJFrame(t *testing.T) {
 	t.Helper()
 
@@ -907,7 +907,7 @@ func TestAX25LinkSREJFrame(t *testing.T) {
 // Window Size Tests
 // ============================================================================
 
-// Window size check function
+// Window size check function.
 func TestAX25LinkWindowSize(t *testing.T) {
 	t.Helper()
 
@@ -944,7 +944,7 @@ func TestAX25LinkWindowSize(t *testing.T) {
 	assert.False(t, WITHIN_WINDOW_SIZE(S), "At window limit with wrap")
 }
 
-// Modulo 128 window size
+// Modulo 128 window size.
 func TestAX25LinkWindowSizeMod128(t *testing.T) {
 	t.Helper()
 
@@ -984,7 +984,7 @@ func TestAX25LinkWindowSizeMod128(t *testing.T) {
 // FRMR Handling Tests
 // ============================================================================
 
-// FRMR reception causes fallback to v2.0
+// FRMR reception causes fallback to v2.0.
 func TestAX25LinkFRMRResponse(t *testing.T) {
 	t.Helper()
 
@@ -1019,7 +1019,7 @@ func TestAX25LinkFRMRResponse(t *testing.T) {
 // P/F Bit Tests
 // ============================================================================
 
-// Poll bit in I-frame requires response with F bit
+// Poll bit in I-frame requires response with F bit.
 func TestAX25LinkPollResponse(t *testing.T) {
 	t.Helper()
 
@@ -1045,7 +1045,7 @@ func TestAX25LinkPollResponse(t *testing.T) {
 	assert.Equal(t, state_3_connected, S.state)
 }
 
-// RR command with P=1 should get response
+// RR command with P=1 should get response.
 func TestAX25LinkRRPoll(t *testing.T) {
 	t.Helper()
 
@@ -1073,7 +1073,7 @@ func TestAX25LinkRRPoll(t *testing.T) {
 // is_good_nr Tests
 // ============================================================================
 
-// Test N(R) validation function
+// Test N(R) validation function.
 func TestAX25LinkIsGoodNR(t *testing.T) {
 	t.Helper()
 
@@ -1121,7 +1121,7 @@ func TestAX25LinkIsGoodNR(t *testing.T) {
 // Timer Tests
 // ============================================================================
 
-// T1 timer start/stop
+// T1 timer start/stop.
 func TestAX25LinkT1Timer(t *testing.T) {
 	t.Helper()
 
@@ -1145,7 +1145,7 @@ func TestAX25LinkT1Timer(t *testing.T) {
 	assert.False(t, IS_T1_RUNNING(S), "T1 should not be running after STOP_T1")
 }
 
-// T3 timer start/stop
+// T3 timer start/stop.
 func TestAX25LinkT3Timer(t *testing.T) {
 	t.Helper()
 
@@ -1166,7 +1166,7 @@ func TestAX25LinkT3Timer(t *testing.T) {
 	assert.True(t, S.t3_exp.IsZero(), "T3 should not be running after STOP_T3")
 }
 
-// T1 pause/resume for channel busy
+// T1 pause/resume for channel busy.
 func TestAX25LinkT1PauseResume(t *testing.T) {
 	t.Helper()
 
@@ -1191,7 +1191,7 @@ func TestAX25LinkT1PauseResume(t *testing.T) {
 	assert.True(t, IS_T1_RUNNING(S), "T1 should still be running")
 }
 
-// Timer expiry functions can be called directly
+// Timer expiry functions can be called directly.
 func TestAX25LinkT1Expiry(t *testing.T) {
 	t.Helper()
 
@@ -1213,7 +1213,7 @@ func TestAX25LinkT1Expiry(t *testing.T) {
 	assert.Equal(t, 1, S.rc, "RC should increment on T1 expiry")
 }
 
-// T3 expiry triggers poll
+// T3 expiry triggers poll.
 func TestAX25LinkT3Expiry(t *testing.T) {
 	t.Helper()
 
@@ -1236,7 +1236,7 @@ func TestAX25LinkT3Expiry(t *testing.T) {
 // Collision Tests
 // ============================================================================
 
-// SABM/DISC collision
+// SABM/DISC collision.
 func TestAX25LinkSABMDISCCollision(t *testing.T) {
 	t.Helper()
 
@@ -1263,7 +1263,7 @@ func TestAX25LinkSABMDISCCollision(t *testing.T) {
 	assert.Equal(t, state_1_awaiting_connection, list_head.state)
 }
 
-// Unexpected UA in connected state triggers link reset
+// Unexpected UA in connected state triggers link reset.
 func TestAX25LinkUnexpectedUA(t *testing.T) {
 	t.Helper()
 
@@ -1295,7 +1295,7 @@ func TestAX25LinkUnexpectedUA(t *testing.T) {
 // XID Parameter Negotiation Tests
 // ============================================================================
 
-// XID frame parsing
+// XID frame parsing.
 func TestAX25LinkXIDParse(t *testing.T) {
 	t.Helper()
 
@@ -1310,7 +1310,7 @@ func TestAX25LinkXIDParse(t *testing.T) {
 	assert.Equal(t, 1, status, "Minimal XID should parse successfully")
 }
 
-// XID frame encoding
+// XID frame encoding.
 func TestAX25LinkXIDEncode(t *testing.T) {
 	t.Helper()
 
@@ -1333,7 +1333,7 @@ func TestAX25LinkXIDEncode(t *testing.T) {
 	assert.Equal(t, byte(GI_Group_Identifier), info[1])
 }
 
-// XID roundtrip (encode then parse)
+// XID roundtrip (encode then parse).
 func TestAX25LinkXIDRoundtrip(t *testing.T) {
 	t.Helper()
 
@@ -1363,7 +1363,7 @@ func TestAX25LinkXIDRoundtrip(t *testing.T) {
 	assert.Equal(t, original.retries, parsed.retries)
 }
 
-// XID frame reception in connected state
+// XID frame reception in connected state.
 func TestAX25LinkXIDFrameConnected(t *testing.T) {
 	t.Helper()
 
@@ -1410,7 +1410,7 @@ func TestAX25LinkXIDFrameConnected(t *testing.T) {
 // C/R Bit Encoding Tests
 // ============================================================================
 
-// Command frame has correct C/R bits
+// Command frame has correct C/R bits.
 func TestAX25LinkCommandFrameEncoding(t *testing.T) {
 	t.Helper()
 
@@ -1427,7 +1427,7 @@ func TestAX25LinkCommandFrameEncoding(t *testing.T) {
 	assert.Equal(t, cr_cmd, cr, "SABM should be a command")
 }
 
-// Response frame has correct C/R bits
+// Response frame has correct C/R bits.
 func TestAX25LinkResponseFrameEncoding(t *testing.T) {
 	t.Helper()
 
@@ -1444,7 +1444,7 @@ func TestAX25LinkResponseFrameEncoding(t *testing.T) {
 	assert.Equal(t, cr_res, cr, "UA should be a response")
 }
 
-// I-frame as command
+// I-frame as command.
 func TestAX25LinkIFrameAsCommand(t *testing.T) {
 	t.Helper()
 
@@ -1460,7 +1460,7 @@ func TestAX25LinkIFrameAsCommand(t *testing.T) {
 	assert.Equal(t, frame_type_I, ftype)
 }
 
-// S-frame as command and response
+// S-frame as command and response.
 func TestAX25LinkSFrameCommandResponse(t *testing.T) {
 	t.Helper()
 
@@ -1489,7 +1489,7 @@ func TestAX25LinkSFrameCommandResponse(t *testing.T) {
 // Sequence Number Tests
 // ============================================================================
 
-// Modulo 8 wrap-around
+// Modulo 8 wrap-around.
 func TestAX25LinkModulo8WrapAround(t *testing.T) {
 	t.Helper()
 
@@ -1511,7 +1511,7 @@ func TestAX25LinkModulo8WrapAround(t *testing.T) {
 	assert.Equal(t, 0, S.vr, "V(R) should wrap from 7 to 0")
 }
 
-// Modulo 128 wrap-around
+// Modulo 128 wrap-around.
 func TestAX25LinkModulo128WrapAround(t *testing.T) {
 	t.Helper()
 
@@ -1538,7 +1538,7 @@ func TestAX25LinkModulo128WrapAround(t *testing.T) {
 	assert.Equal(t, 0, S.vs, "V(S) should wrap from 127 to 0")
 }
 
-// N(S) in window check
+// N(S) in window check.
 func TestAX25LinkNSInWindow(t *testing.T) {
 	t.Helper()
 
@@ -1567,7 +1567,7 @@ func TestAX25LinkNSInWindow(t *testing.T) {
 // Segmenter/Reassembler Tests
 // ============================================================================
 
-// Reassembler initial state
+// Reassembler initial state.
 func TestAX25LinkReassemblerInitialState(t *testing.T) {
 	t.Helper()
 
@@ -1583,7 +1583,7 @@ func TestAX25LinkReassemblerInitialState(t *testing.T) {
 	assert.Nil(t, S.ra_buff, "Reassembler buffer should be nil initially")
 }
 
-// First segment with flag set
+// First segment with flag set.
 func TestAX25LinkFirstSegmentFlag(t *testing.T) {
 	t.Helper()
 
@@ -1681,7 +1681,7 @@ func TestAX25LinkV22SegmentationDataContent(t *testing.T) {
 // Link Multiplexer Tests
 // ============================================================================
 
-// Multiple concurrent links
+// Multiple concurrent links.
 func TestAX25LinkMultipleConcurrentLinks(t *testing.T) {
 	t.Helper()
 
@@ -1722,7 +1722,7 @@ func TestAX25LinkMultipleConcurrentLinks(t *testing.T) {
 	assert.NotEqual(t, link1, link2)
 }
 
-// Link isolation - action on one link doesn't affect another
+// Link isolation - action on one link doesn't affect another.
 func TestAX25LinkIsolation(t *testing.T) {
 	t.Helper()
 
@@ -1759,7 +1759,7 @@ func TestAX25LinkIsolation(t *testing.T) {
 	assert.Equal(t, 0, link1.vr)
 }
 
-// Channel busy handling
+// Channel busy handling.
 func TestAX25LinkChannelBusy(t *testing.T) {
 	t.Helper()
 
@@ -1788,7 +1788,7 @@ func TestAX25LinkChannelBusy(t *testing.T) {
 // Edge Cases and Error Conditions
 // ============================================================================
 
-// Frame type parsing
+// Frame type parsing.
 func TestAX25LinkFrameTypeParsing(t *testing.T) {
 	t.Helper()
 
@@ -1829,7 +1829,7 @@ func TestAX25LinkFrameTypeParsing(t *testing.T) {
 	}
 }
 
-// S-frame type parsing
+// S-frame type parsing.
 func TestAX25LinkSFrameTypeParsing(t *testing.T) {
 	t.Helper()
 
@@ -1858,7 +1858,7 @@ func TestAX25LinkSFrameTypeParsing(t *testing.T) {
 	assert.Equal(t, frame_type_S_SREJ, parsedType)
 }
 
-// I-frame type parsing
+// I-frame type parsing.
 func TestAX25LinkIFrameTypeParsing(t *testing.T) {
 	t.Helper()
 
@@ -1888,7 +1888,7 @@ func TestAX25LinkIFrameTypeParsing(t *testing.T) {
 	assert.Equal(t, 50, ns)
 }
 
-// Invalid N(R) triggers error
+// Invalid N(R) triggers error.
 func TestAX25LinkInvalidNR(t *testing.T) {
 	t.Helper()
 
@@ -1916,7 +1916,7 @@ func TestAX25LinkInvalidNR(t *testing.T) {
 // Exception Condition Tests
 // ============================================================================
 
-// Clear exception conditions
+// Clear exception conditions.
 func TestAX25LinkClearExceptionConditions(t *testing.T) {
 	t.Helper()
 
@@ -1943,7 +1943,7 @@ func TestAX25LinkClearExceptionConditions(t *testing.T) {
 	assert.False(t, S.acknowledge_pending)
 }
 
-// Reject exception flag behavior
+// Reject exception flag behavior.
 func TestAX25LinkRejectExceptionFlag(t *testing.T) {
 	t.Helper()
 
@@ -1983,7 +1983,7 @@ func TestAX25LinkRejectExceptionFlag(t *testing.T) {
 // Retry Counter Tests
 // ============================================================================
 
-// Retry counter management
+// Retry counter management.
 func TestAX25LinkRetryCounter(t *testing.T) {
 	t.Helper()
 
@@ -2010,7 +2010,7 @@ func TestAX25LinkRetryCounter(t *testing.T) {
 // Version Negotiation Tests
 // ============================================================================
 
-// Set version 2.0
+// Set version 2.0.
 func TestAX25LinkSetVersion20(t *testing.T) {
 	t.Helper()
 
@@ -2028,7 +2028,7 @@ func TestAX25LinkSetVersion20(t *testing.T) {
 	assert.Equal(t, ax25_modulo_t(8), S.modulo)
 }
 
-// Set version 2.2
+// Set version 2.2.
 func TestAX25LinkSetVersion22(t *testing.T) {
 	t.Helper()
 
@@ -2057,7 +2057,7 @@ func TestAX25LinkSetVersion22(t *testing.T) {
 // Data Link Queue Tests
 // ============================================================================
 
-// Connect request handling
+// Connect request handling.
 func TestAX25LinkConnectRequestTypes(t *testing.T) {
 	t.Helper()
 
@@ -2080,7 +2080,7 @@ func TestAX25LinkConnectRequestTypes(t *testing.T) {
 	assert.Equal(t, state_1_awaiting_connection, list_head.state)
 }
 
-// Disconnect request handling
+// Disconnect request handling.
 func TestAX25LinkDisconnectRequestTypes(t *testing.T) {
 	t.Helper()
 
@@ -2110,7 +2110,7 @@ func TestAX25LinkDisconnectRequestTypes(t *testing.T) {
 // TEST Frame Tests
 // ============================================================================
 
-// TEST frame handling
+// TEST frame handling.
 func TestAX25LinkTESTFrame(t *testing.T) {
 	t.Helper()
 
@@ -2138,7 +2138,7 @@ func TestAX25LinkTESTFrame(t *testing.T) {
 // UI Frame Tests
 // ============================================================================
 
-// UI frame handling in connected state
+// UI frame handling in connected state.
 func TestAX25LinkUIFrameConnected(t *testing.T) {
 	t.Helper()
 
@@ -2165,7 +2165,7 @@ func TestAX25LinkUIFrameConnected(t *testing.T) {
 // Statistics Tests
 // ============================================================================
 
-// Frame count statistics
+// Frame count statistics.
 func TestAX25LinkFrameCountStats(t *testing.T) {
 	t.Helper()
 

--- a/src/ax25_pad.go
+++ b/src/ax25_pad.go
@@ -326,7 +326,7 @@ var ax25_new_count = 0
 var ax25_delete_count = 0
 var last_seq_num int = 0
 
-// DECODE_APRS_UTIL is a runtime replacement for DECAMAIN define
+// DECODE_APRS_UTIL is a runtime replacement for DECAMAIN define.
 var DECODE_APRS_UTIL = false
 
 func CLEAR_LAST_ADDR_FLAG(this_p *packet_t) {

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -2702,7 +2702,7 @@ func aprs_positionless_weather_report(A *decode_aprs_t, info []byte) {
  *
  *------------------------------------------------------------------*/
 
-// Returns value, newWPP, found=True, or G_UNKNOWN, wpp, found=False
+// Returns value, newWPP, found=True, or G_UNKNOWN, wpp, found=False.
 func getwdata(wpp []byte, id rune, dlen int) (float64, []byte, bool) {
 	Assert(dlen >= 2 && dlen <= 6)
 

--- a/src/dtmf.go
+++ b/src/dtmf.go
@@ -363,7 +363,7 @@ func dtmf_send(channel int, str string, speed int, txdelay int, txtail int) int 
  *
  *----------------------------------------------------------------*/
 
-// test_mode
+// test_mode.
 var push_button_result string
 
 func push_button_raw(channel int, button rune, ms int, test_mode bool) {

--- a/src/fx25.go
+++ b/src/fx25.go
@@ -9,7 +9,7 @@ const FX25_MAX_DATA = 239   // i.e. RS(255,239)
 const FX25_MAX_CHECK = 64   // e.g. RS(255, 191)
 const FX25_BLOCK_SIZE = 255 // Block size always 255 for 8 bit symbols.
 
-/* Reed-Solomon codec control block */
+/* Reed-Solomon codec control block. */
 type rs_t struct {
 	mm       uint   /* Bits per symbol */
 	nn       uint   /* Symbols per block (= (1<<mm)-1) */

--- a/src/gen_packets.go
+++ b/src/gen_packets.go
@@ -89,7 +89,7 @@ var g_noise_level float64 = 0
 
 var genPacketsOutFile *os.File
 
-// Created in audio_file_open, used for audio_put_fake, flushed in audio_file_close
+// Created in audio_file_open, used for audio_put_fake, flushed in audio_file_close.
 var genPacketsOutBuf *bufio.Writer
 
 var byte_count int /* Number of data bytes written to file. Will be written to header when file is closed. */
@@ -99,7 +99,7 @@ var gen_header wav_header
 var genPacketsRandSeed int32 = 1
 
 // Although the tests in `test-scripts` all call `atest` with an acceptable *range* of packets, the only way I could get them all to pass was by reimplementing this exact PRNG from Dire Wolf's gen_packets.c - all my attempts to use Go's `math/rand` resulted in decodes that would fall outside of the acceptable range. It's far from impossible that I somehow screwed up my use of `math/rand`, but I think it more likely that the tests depend on this exact PRNG implementation, which I should address at some point. /KG
-// Yep, if seed is 1, tests pass; if seed is 2, test96f64 decodes 68 not 71+; if seed is 3 then test96f16 decodes 62 not 63+ /KG
+// Yep, if seed is 1, tests pass; if seed is 2, test96f64 decodes 68 not 71+; if seed is 3 then test96f16 decodes 62 not 63+ /KG.
 func genPacketsRand() int32 {
 	genPacketsRandSeed = int32((uint32(genPacketsRandSeed)*1103515245 + 12345) & MY_RAND_MAX)
 	return genPacketsRandSeed

--- a/src/igate.go
+++ b/src/igate.go
@@ -133,10 +133,10 @@ var ok_to_send = false
  * we need to reestablish the connection later.
  */
 
-// TODO KG static struct audio_s		*save_audio_config_p;
+// TODO KG static struct audio_s		*save_audio_config_p;.
 var save_igate_config_p *igate_config_s
 
-// TODO KG static struct digi_config_s 	*save_digi_config_p;
+// TODO KG static struct digi_config_s 	*save_digi_config_p;.
 var s_debug int
 
 /*

--- a/src/il2p_spec_test.go
+++ b/src/il2p_spec_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Convenience function for turning example packets from the spec PDF into Go byte arrays to work with
-// Example input: "26 57 4D 57 F1 D2 A8 F0 6A F2 7B AD 23 BD C0 7F 00 1D 2B"
+// Example input: "26 57 4D 57 F1 D2 A8 F0 6A F2 7B AD 23 BD C0 7F 00 1D 2B".
 func il2pDataStringToBytes(s string) []byte {
 	var data, err = hex.DecodeString(strings.ReplaceAll(s, " ", ""))
 	if err != nil {

--- a/src/latlong_test.go
+++ b/src/latlong_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLatitudeToNMEA tests conversion of latitude to NMEA format
+// TestLatitudeToNMEA tests conversion of latitude to NMEA format.
 func TestLatitudeToNMEA(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -82,7 +82,7 @@ func TestLatitudeToNMEA(t *testing.T) {
 	}
 }
 
-// TestLatitudeToNMEABounds tests latitude bounds checking
+// TestLatitudeToNMEABounds tests latitude bounds checking.
 func TestLatitudeToNMEABounds(t *testing.T) {
 	tests := []struct {
 		name string
@@ -103,7 +103,7 @@ func TestLatitudeToNMEABounds(t *testing.T) {
 	}
 }
 
-// TestLongitudeToNMEA tests conversion of longitude to NMEA format
+// TestLongitudeToNMEA tests conversion of longitude to NMEA format.
 func TestLongitudeToNMEA(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -176,7 +176,7 @@ func TestLongitudeToNMEA(t *testing.T) {
 	}
 }
 
-// TestLongitudeToNMEABounds tests longitude bounds checking
+// TestLongitudeToNMEABounds tests longitude bounds checking.
 func TestLongitudeToNMEABounds(t *testing.T) {
 	tests := []struct {
 		name string
@@ -197,7 +197,7 @@ func TestLongitudeToNMEABounds(t *testing.T) {
 	}
 }
 
-// TestLatitudeFromNMEA tests parsing NMEA latitude format
+// TestLatitudeFromNMEA tests parsing NMEA latitude format.
 func TestLatitudeFromNMEA(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -276,7 +276,7 @@ func TestLatitudeFromNMEA(t *testing.T) {
 	}
 }
 
-// TestLatitudeFromNMEAErrors tests error cases for NMEA latitude parsing
+// TestLatitudeFromNMEAErrors tests error cases for NMEA latitude parsing.
 func TestLatitudeFromNMEAErrors(t *testing.T) {
 	tests := []struct {
 		name string
@@ -306,7 +306,7 @@ func TestLatitudeFromNMEAErrors(t *testing.T) {
 	})
 }
 
-// TestLongitudeFromNMEA tests parsing NMEA longitude format
+// TestLongitudeFromNMEA tests parsing NMEA longitude format.
 func TestLongitudeFromNMEA(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -385,7 +385,7 @@ func TestLongitudeFromNMEA(t *testing.T) {
 	}
 }
 
-// TestLongitudeFromNMEAErrors tests error cases for NMEA longitude parsing
+// TestLongitudeFromNMEAErrors tests error cases for NMEA longitude parsing.
 func TestLongitudeFromNMEAErrors(t *testing.T) {
 	tests := []struct {
 		name string
@@ -414,7 +414,7 @@ func TestLongitudeFromNMEAErrors(t *testing.T) {
 	})
 }
 
-// TestNMEARoundTrip tests that converting to/from NMEA preserves values
+// TestNMEARoundTrip tests that converting to/from NMEA preserves values.
 func TestNMEARoundTrip(t *testing.T) {
 	tests := []struct {
 		name string
@@ -446,7 +446,7 @@ func TestNMEARoundTrip(t *testing.T) {
 	}
 }
 
-// TestGridSquareEdgeCases tests Maidenhead grid square conversion edge cases
+// TestGridSquareEdgeCases tests Maidenhead grid square conversion edge cases.
 func TestGridSquareEdgeCases(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -537,7 +537,7 @@ func TestGridSquareEdgeCases(t *testing.T) {
 	}
 }
 
-// TestCompressedFormatEdgeCases tests compressed format edge cases
+// TestCompressedFormatEdgeCases tests compressed format edge cases.
 func TestCompressedFormatEdgeCases(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -614,7 +614,7 @@ func TestCompressedFormatEdgeCases(t *testing.T) {
 	}
 }
 
-// TestCoordinateDistanceSymmetry tests that distance is symmetric
+// TestCoordinateDistanceSymmetry tests that distance is symmetric.
 func TestCoordinateDistanceSymmetry(t *testing.T) {
 	tests := []struct {
 		name string
@@ -638,7 +638,7 @@ func TestCoordinateDistanceSymmetry(t *testing.T) {
 	}
 }
 
-// TestBearingAntipodal tests bearing to antipodal points
+// TestBearingAntipodal tests bearing to antipodal points.
 func TestBearingAntipodal(t *testing.T) {
 	// Bearing from a point to its antipode (opposite side of Earth)
 	// should be consistent
@@ -659,7 +659,7 @@ func TestBearingAntipodal(t *testing.T) {
 	assert.Less(t, bearing, 360.0, "bearing should be < 360")
 }
 
-// TestDestinationZeroDistance tests that zero distance returns same point
+// TestDestinationZeroDistance tests that zero distance returns same point.
 func TestDestinationZeroDistance(t *testing.T) {
 	lat := 42.3601
 	lon := -71.0589
@@ -673,7 +673,7 @@ func TestDestinationZeroDistance(t *testing.T) {
 	assert.InDelta(t, lon, newLon, 0.0001, "zero distance should return same longitude")
 }
 
-// TestLatitudeBoundaryClamping tests that out-of-range values are clamped
+// TestLatitudeBoundaryClamping tests that out-of-range values are clamped.
 func TestLatitudeBoundaryClamping(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -696,7 +696,7 @@ func TestLatitudeBoundaryClamping(t *testing.T) {
 	}
 }
 
-// TestLongitudeBoundaryClamping tests that out-of-range values are clamped
+// TestLongitudeBoundaryClamping tests that out-of-range values are clamped.
 func TestLongitudeBoundaryClamping(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -719,7 +719,7 @@ func TestLongitudeBoundaryClamping(t *testing.T) {
 	}
 }
 
-// BenchmarkLatitudeConversions benchmarks latitude conversion functions
+// BenchmarkLatitudeConversions benchmarks latitude conversion functions.
 func BenchmarkLatitudeConversions(b *testing.B) {
 	lat := 42.3601
 
@@ -749,7 +749,7 @@ func BenchmarkLatitudeConversions(b *testing.B) {
 	})
 }
 
-// BenchmarkDistanceBearing benchmarks distance and bearing calculations
+// BenchmarkDistanceBearing benchmarks distance and bearing calculations.
 func BenchmarkDistanceBearing(b *testing.B) {
 	lat1, lon1 := 42.3601, -71.0589
 	lat2, lon2 := -33.8688, 151.2093
@@ -777,7 +777,7 @@ func BenchmarkDistanceBearing(b *testing.B) {
 	})
 }
 
-// TestHaversineFormulaAccuracy tests the accuracy of the haversine implementation
+// TestHaversineFormulaAccuracy tests the accuracy of the haversine implementation.
 func TestHaversineFormulaAccuracy(t *testing.T) {
 	// Test against known distances
 	tests := []struct {
@@ -827,7 +827,7 @@ func TestHaversineFormulaAccuracy(t *testing.T) {
 	}
 }
 
-// TestBearingCalculation tests bearing calculation accuracy
+// TestBearingCalculation tests bearing calculation accuracy.
 func TestBearingCalculation(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -885,7 +885,7 @@ func TestBearingCalculation(t *testing.T) {
 	}
 }
 
-// TestSmallAngles tests coordinate functions with very small angles
+// TestSmallAngles tests coordinate functions with very small angles.
 func TestSmallAngles(t *testing.T) {
 	// Test with very small differences in coordinates
 	lat1, lon1 := 42.0, -71.0
@@ -907,7 +907,7 @@ func TestSmallAngles(t *testing.T) {
 	assert.InDelta(t, lon2, newLon, 0.0001, "round trip longitude should match")
 }
 
-// TestAmbiguityLevels tests all ambiguity levels for latitude/longitude
+// TestAmbiguityLevels tests all ambiguity levels for latitude/longitude.
 func TestAmbiguityLevels(t *testing.T) {
 	lat := 42.3601
 	lon := -71.0589
@@ -949,7 +949,7 @@ func TestAmbiguityLevels(t *testing.T) {
 	}
 }
 
-// TestNaN tests that NaN inputs don't cause panics
+// TestNaN tests that NaN inputs don't cause panics.
 func TestNaN(t *testing.T) {
 	nan := math.NaN()
 

--- a/src/morse_decode_linux_test.go
+++ b/src/morse_decode_linux_test.go
@@ -39,7 +39,7 @@ func morseToFile(t *testing.T, filename string, message string) {
 	audio_file_close() // I just realised this all works on globals :s
 }
 
-// gen_packets will generate Morse, so let's test it and try to decode
+// gen_packets will generate Morse, so let's test it and try to decode.
 func Test_Morse_Generate_Decode(t *testing.T) {
 	// First, generate
 	var tmpdir = t.TempDir()

--- a/src/pfilter.go
+++ b/src/pfilter.go
@@ -30,7 +30,7 @@ import (
  * These are set by init function.
  */
 
-// TODO KG var save_igate_config_p *igate_config_s
+// TODO KG var save_igate_config_p *igate_config_s.
 var pfilter_debug = 0
 var pftest_running = false
 

--- a/src/util.go
+++ b/src/util.go
@@ -16,7 +16,7 @@ func SLEEP_SEC(s int) {
 	SLEEP_MS(s * 1000)
 }
 
-// Because sometimes it's really convenient to have C's ternary ?:
+// Because sometimes it's really convenient to have C's ternary ?:.
 func IfThenElse[T any](x bool, a T, b T) T { //nolint:ireturn
 	if x {
 		return a
@@ -25,7 +25,7 @@ func IfThenElse[T any](x bool, a T, b T) T { //nolint:ireturn
 	}
 }
 
-// MAX_NET_CLIENTS is used for both KISS and AGWPE
+// MAX_NET_CLIENTS is used for both KISS and AGWPE.
 const MAX_NET_CLIENTS = 3
 
 // There are several places where we deal with fixed-width byte arrays containing a string.
@@ -121,7 +121,7 @@ func R2D(r float64) float64 {
 	return r * 180 / math.Pi
 }
 
-// Can't be "assert" because of conflicts with stretchr/testify/assert, but otherwise, it's compatible enough
+// Can't be "assert" because of conflicts with stretchr/testify/assert, but otherwise, it's compatible enough.
 func Assert(t bool) {
 	if !t {
 		_, file, line, _ := runtime.Caller(1)


### PR DESCRIPTION
🤖 Enables the `godot` linter (previously disabled with "Implicit full stops are ok") and fixes all 111 flagged issues, all via `golangci-lint run --enable-only godot --fix`. Changes are comment-punctuation only — added trailing periods to non-sentence-ending doc/inline comments.

## Test plan
- [x] `make check` passes
- [x] `make test` passes