### PR TITLE
style: Enable whitespace linter and fix flagged issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
     - "prealloc"  # One day, but not now
     - "testpackage"  # Noble intent, but right now we're doing all sorts of juggling with packages, so let's save this for later
     - "varnamelen"  # Noble intent, but we're inheriting lots of short variable names, and I'd like to stay close to upstream at first
-    - "whitespace"  # I do not have the energy to deal with extraneous leading/trailing newlines right now
     - "wrapcheck"  # Error wrapping is the least of my concerns
     - "wsl"  # Avoid deprecation warning from enabling all
     - "wsl_v5"  # KG 2026-02-26 I don't have concrete data but it feels like wsl is giving me spurious edits/breakages - it might not be wsl, it might be something else, but it only started being an issue once I enabled wsl, so I'm disabling it again for the foreseeable

--- a/src/ax25_link.go
+++ b/src/ax25_link.go
@@ -1020,7 +1020,6 @@ func dl_disconnect_request(E *dlq_item_t) {
 		STOP_T3(S)
 		START_T1(S)
 		enter_new_state(S, state_2_awaiting_release)
-
 	}
 } /* end dl_disconnect_request */
 
@@ -1876,7 +1875,6 @@ func lm_seize_confirm(E *dlq_item_t) {
 
 				// Erratum: The original spec had LM-SEIZE request here, for state 4, which didn't seem right.
 				// The 2006 revision has LM-RELEASE Request so states 3 & 4 are the same.
-
 			}
 		}
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -4396,7 +4396,6 @@ func handleTTMACRO(ps *parseState) bool {
 	tmp = strings.TrimSpace(tmp)
 
 	for len(tmp) != 0 {
-
 		if strings.HasPrefix(tmp, "AC{") {
 			// Convert to fixed length 10 digit callsign.
 			tmp = tmp[3:]
@@ -4423,7 +4422,6 @@ func handleTTMACRO(ps *parseState) bool {
 				tt_error++
 			}
 		} else if strings.HasPrefix(tmp, "AA{") {
-
 			// Convert to object name.
 
 			tmp = tmp[3:]
@@ -4455,7 +4453,6 @@ func handleTTMACRO(ps *parseState) bool {
 				tt_error++
 			}
 		} else if strings.HasPrefix(tmp, "AB{") {
-
 			// Attempt conversion from description to symbol code.
 
 			tmp = tmp[3:]
@@ -4491,7 +4488,6 @@ func handleTTMACRO(ps *parseState) bool {
 				tt_error++
 			}
 		} else if strings.HasPrefix(tmp, "CA{") {
-
 			// Convert to enhanced comment that can contain any ASCII character.
 
 			tmp = tmp[3:]
@@ -4700,7 +4696,6 @@ func handleTTOBJ(ps *parseState) bool {
 
 	t = split("", false)
 	if t != "" {
-
 		if check_via_path(t) >= 0 {
 			ps.tt.obj_xmit_via = t
 		} else {

--- a/src/demod.go
+++ b/src/demod.go
@@ -750,7 +750,6 @@ func demod_init(pa *audio_s) int {
 					D.quick_attack = D.agc_fast_attack * 0.2
 					D.sluggish_decay = D.agc_slow_decay * 0.2
 				}
-
 			} /* switch on modulation type. */
 		} /* if channel medium is radio */
 
@@ -962,7 +961,6 @@ func demod_process_sample(channel int, subchan int, sam int) {
 		  case MODEM_AIS:
 		*/
 		demod_9600_process_sample(channel, sam, save_audio_config_p.achan[channel].upsample, D)
-
 	} /* switch modem_type */
 } /* end demod_process_sample */
 

--- a/src/demod_psk.go
+++ b/src/demod_psk.go
@@ -282,7 +282,6 @@ func demod_psk_init(modem_type modem_t, v26_alt v26_e, _samples_per_sec int, bps
 
 			D.pll_locked_inertia = 0.925
 			D.pll_searching_inertia = 0.50
-
 		}
 
 		D.u.psk.delay_line_width_sym = 1.25 // Delay line > 13/12 * symbol period

--- a/src/digipeater_direwolf_test.go
+++ b/src/digipeater_direwolf_test.go
@@ -354,5 +354,4 @@ func Test_Digipeater(t *testing.T) {
 		dw_printf("ERROR - %d digipeater tests failed.\n", digipeaterTestFailed)
 		t.Fail()
 	}
-
 } /* end main */

--- a/src/gpiod_linux.go
+++ b/src/gpiod_linux.go
@@ -5,6 +5,5 @@ import (
 )
 
 func RequestGPIODLine(chipName string, lineNumber int, initialState int) (*gpiocdev.Line, error) {
-
 	return gpiocdev.RequestLine(chipName, lineNumber, gpiocdev.AsOutput(initialState))
 }

--- a/src/gpiod_notlinux.go
+++ b/src/gpiod_notlinux.go
@@ -18,6 +18,5 @@ func (*dummyGpiodOutputLine) Close() error {
 }
 
 func RequestGPIODLine(chipName string, lineNumber int, initialState int) (*dummyGpiodOutputLine, error) {
-
 	return nil, errors.New("GPIOD not supported on non-Linux operating systems")
 }

--- a/src/il2p_codec.go
+++ b/src/il2p_codec.go
@@ -42,7 +42,6 @@ import (
  *--------------------------------------------------------------*/
 
 func il2p_encode_frame(pp *packet_t, max_fec int, crc ...bool) ([]byte, int) {
-
 	var appendCRC = len(crc) > 0 && crc[0]
 
 	// Can a type 1 header be used?

--- a/src/il2p_rec.go
+++ b/src/il2p_rec.go
@@ -277,6 +277,5 @@ func il2p_rec_bit(channel int, subchannel int, slice int, dbit int) {
 		}
 
 		F.state = IL2P_SEARCHING
-
 	} // end of switch
 }

--- a/src/server.go
+++ b/src/server.go
@@ -1588,6 +1588,5 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("--- Unexpected Command from application %d using AGW protocol:\n", client)
 		debug_print(FROM_CLIENT, client, cmd)
-
 	}
 } /* end handleClientCommand */


### PR DESCRIPTION
## Summary
- Enable the `whitespace` golangci-lint linter (previously disabled)
- Fix all 15 flagged issues via `golangci-lint run --fix`, removing extraneous leading/trailing blank lines

## Test plan
- [x] `make check` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)