### PR TITLE
feat: Enable the intrange linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - "godoclint"  # There's lots to be done with documentation formatting, but not right now
     - "godot"  # Implicit full stops are ok
     - "godox"  # There will be TODOs
-    - "intrange" # Another thing that I like in theory, but am not prioritising right now
     - "lll"  # We have inherited lots of long lines
     - "maintidx"  # One day...
     - "mnd"  # I do not like magic numbers, but there are plenty inherited from upstream, so let's roll with them for now

--- a/src/aprs_tt.go
+++ b/src/aprs_tt.go
@@ -1451,7 +1451,7 @@ func (g *TTGateway) findTTLocMatch(e string) (string, string, string, string, st
 	// debug dw_printf ("findTTLocMatch: e=%s\n", e);
 	var xstr, ystr, zstr, bstr, dstr string
 
-	for ipat := 0; ipat < len(g.config.ttlocs); ipat++ {
+	for ipat := range len(g.config.ttlocs) {
 		var pattern = g.config.ttlocs[ipat].pattern
 		var length = len(pattern) /* Length of pattern we are trying to match. */
 

--- a/src/atest.go
+++ b/src/atest.go
@@ -595,7 +595,7 @@ o = DCD output control
 
 		e_o_f = false
 		for !e_o_f {
-			for c := 0; c < (my_audio_config.adev[0].num_channels); c++ {
+			for c := range my_audio_config.adev[0].num_channels {
 				/* This reads either 1 or 2 bytes depending on */
 				/* bits per sample.  */
 				var audio_sample = demod_get_sample(ACHAN2ADEV(c))

--- a/src/ax25_link.go
+++ b/src/ax25_link.go
@@ -1524,7 +1524,7 @@ func dl_outstanding_frames_request(E *dlq_item_t) {
 
 	var count2 = 0
 
-	for k := 0; k < int(S.modulo); k++ {
+	for k := range S.modulo {
 		if S.txdata_by_ns[k] != nil {
 			count2++
 		}
@@ -1933,7 +1933,7 @@ func lm_data_indication(E *dlq_item_t) {
 
 	// Copy addresses from frame into event structure.
 
-	for n := 0; n < E.num_addr; n++ {
+	for n := range E.num_addr {
 		E.addrs[n] = ax25_get_addr_with_ssid(E.pp, n)
 	}
 

--- a/src/ax25_pad.go
+++ b/src/ax25_pad.go
@@ -1013,7 +1013,7 @@ func ax25_parse_addr(position int, in_addr string, strictness int) (string, int,
 func ax25_check_addresses(pp *packet_t) bool { //nolint:unparam
 	var all_ok = true
 
-	for n := 0; n < ax25_get_num_addr(pp); n++ {
+	for n := range ax25_get_num_addr(pp) {
 		var addr = ax25_get_addr_with_ssid(pp, n)
 
 		var _, _, _, ok = ax25_parse_addr(n, addr, 1)

--- a/src/ax25_pad2_direwolf_test.go
+++ b/src/ax25_pad2_direwolf_test.go
@@ -27,7 +27,7 @@ func Test_AX25_PAD2(t *testing.T) {
 	/* U frame */
 
 	for ftype := frame_type_U_SABME; ftype <= frame_type_U_TEST; ftype++ {
-		for pf := 0; pf <= 1; pf++ {
+		for pf := range 2 {
 			var cmin cmdres_t = 0
 			var cmax cmdres_t = 0
 
@@ -83,7 +83,7 @@ func Test_AX25_PAD2(t *testing.T) {
 	num_addr = 3
 
 	for ftype := frame_type_S_RR; ftype <= frame_type_S_SREJ; ftype++ {
-		for pf := 0; pf <= 1; pf++ {
+		for pf := range 2 {
 			var modulo = modulo_8
 			var nr = int(modulo/2 + 1)
 
@@ -120,7 +120,7 @@ func Test_AX25_PAD2(t *testing.T) {
 
 	var ftype = frame_type_S_SREJ
 
-	for pf := 0; pf <= 1; pf++ {
+	for pf := range 2 {
 		var modulo = modulo_128
 		var nr = 127
 		var cr = cr_res
@@ -141,7 +141,7 @@ func Test_AX25_PAD2(t *testing.T) {
 
 	info = []byte("The rain in Spain stays mainly on the plain.")
 
-	for pf := 0; pf <= 1; pf++ {
+	for pf := range 2 {
 		var modulo = modulo_8
 		var nr = 0x55 & int(modulo-1)
 		var ns = 0xaa & int(modulo-1)

--- a/src/beacon.go
+++ b/src/beacon.go
@@ -65,7 +65,7 @@ func NewBeaconService(pmodem *audio_s, pconfig *misc_config_s, pigate *igate_con
 	// optional, or not allowed for each beacon type.  Options which
 	// are not applicable are often silently ignored, causing confusion.
 
-	for j := 0; j < bs.miscConfig.num_beacons; j++ {
+	for j := range bs.miscConfig.num_beacons {
 		var channel = bs.miscConfig.beacon[j].sendto_chan
 
 		if channel < 0 {
@@ -186,7 +186,7 @@ func NewBeaconService(pmodem *audio_s, pconfig *misc_config_s, pigate *igate_con
 
 	var now = time.Now()
 
-	for j := 0; j < bs.miscConfig.num_beacons; j++ {
+	for j := range bs.miscConfig.num_beacons {
 		var bp = &(bs.miscConfig.beacon[j])
 		/* TODO KG
 		#if DEBUG
@@ -276,7 +276,7 @@ func (bs *BeaconService) SetDebug(level int) {
 func (bs *BeaconService) Start() {
 	var count = 0
 
-	for j := 0; j < bs.miscConfig.num_beacons; j++ {
+	for j := range bs.miscConfig.num_beacons {
 		if bs.miscConfig.beacon[j].btype != BEACON_IGNORE {
 			count++
 		}

--- a/src/config.go
+++ b/src/config.go
@@ -1239,7 +1239,7 @@ func config_init(fname string, p_audio_config *audio_s,
 
 				var b = 0
 
-				for k := 0; k < ps.misc.num_beacons; k++ {
+				for k := range ps.misc.num_beacons {
 					if ps.misc.beacon[k].sendto_chan == j {
 						b++
 					}
@@ -1271,7 +1271,7 @@ func config_init(fname string, p_audio_config *audio_s,
 
 				var b = 0
 
-				for k := 0; k < ps.misc.num_beacons; k++ {
+				for k := range ps.misc.num_beacons {
 					if ps.misc.beacon[k].sendto_chan == j {
 						b++
 					}
@@ -4360,7 +4360,7 @@ func handleTTMACRO(ps *parseState) bool {
 	var p_count [3]int
 	var tt_error = 0
 
-	for j := 0; j < len(t); j++ {
+	for j := range len(t) {
 		if !strings.ContainsRune("0123456789ABCDxyz", rune(t[j])) {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Line %d: TTMACRO pattern can contain only digits, A, B, C, D, and lower case x, y, or z.\n", ps.line)
@@ -4529,7 +4529,7 @@ func handleTTMACRO(ps *parseState) bool {
 	var d_count [3]int
 
 	var otempStr = otemp.String()
-	for j := 0; j < len(otempStr); j++ {
+	for j := range len(otempStr) {
 		if otempStr[j] >= 'x' && otempStr[j] <= 'z' {
 			d_count[otempStr[j]-'x']++
 		}

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -275,7 +275,7 @@ func decode_aprs(pp *packet_t, quiet bool, third_party_src string) *decode_aprs_
 
 	// Complain if obsolete WIDE or RELAY is found in via path.
 
-	for i := 0; i < ax25_get_num_repeaters(pp); i++ {
+	for i := range ax25_get_num_repeaters(pp) {
 		atemp = ax25_get_addr_no_ssid(pp, AX25_REPEATER_1+i)
 		if !quiet {
 			if atemp == "RELAY" || atemp == "WIDE" || atemp == "TRACE" {

--- a/src/demod.go
+++ b/src/demod.go
@@ -285,7 +285,7 @@ func demod_init(pa *audio_s) int {
 							channel, save_audio_config_p.achan[channel].num_freq)
 					}
 
-					for d := 0; d < save_audio_config_p.achan[channel].num_subchan; d++ {
+					for d := range save_audio_config_p.achan[channel].num_subchan {
 						Assert(d >= 0 && d < MAX_SUBCHANS)
 
 						var D = &demodulator_state[channel][d]
@@ -381,7 +381,7 @@ func demod_init(pa *audio_s) int {
 
 					save_audio_config_p.achan[channel].num_subchan = save_audio_config_p.achan[channel].num_freq
 
-					for d := 0; d < save_audio_config_p.achan[channel].num_freq; d++ {
+					for d := range save_audio_config_p.achan[channel].num_freq {
 						Assert(d >= 0 && d < MAX_SUBCHANS)
 
 						var D = &demodulator_state[channel][d]
@@ -477,7 +477,7 @@ func demod_init(pa *audio_s) int {
 
 				dw_printf(".\n")
 
-				for d := 0; d < save_audio_config_p.achan[channel].num_subchan; d++ {
+				for d := range save_audio_config_p.achan[channel].num_subchan {
 					Assert(d >= 0 && d < MAX_SUBCHANS)
 					var D = &demodulator_state[channel][d]
 					var profile = save_audio_config_p.achan[channel].profiles[d]
@@ -535,7 +535,7 @@ func demod_init(pa *audio_s) int {
 
 				dw_printf(".\n")
 
-				for d := 0; d < save_audio_config_p.achan[channel].num_subchan; d++ {
+				for d := range save_audio_config_p.achan[channel].num_subchan {
 					Assert(d >= 0 && d < MAX_SUBCHANS)
 					var D = &demodulator_state[channel][d]
 					var profile = save_audio_config_p.achan[channel].profiles[d]
@@ -588,7 +588,7 @@ func demod_init(pa *audio_s) int {
 
 				dw_printf(".\n")
 
-				for d := 0; d < save_audio_config_p.achan[channel].num_subchan; d++ {
+				for d := range save_audio_config_p.achan[channel].num_subchan {
 					Assert(d >= 0 && d < MAX_SUBCHANS)
 					var D = &demodulator_state[channel][d]
 					var profile = save_audio_config_p.achan[channel].profiles[d]

--- a/src/demod_9600.go
+++ b/src/demod_9600.go
@@ -259,7 +259,7 @@ func demod_9600_init(modem_type modem_t, original_sample_rate int, upsample int,
 	//
 
 	var k = 0
-	for i := 0; i < D.lp_filter_taps; i++ {
+	for i := range D.lp_filter_taps {
 		D.u.bb.lp_polyphase_1[i] = D.u.bb.lp_filter[k]
 
 		k++
@@ -438,7 +438,7 @@ func process_filtered_sample(channel int, fsam float64, D *demodulator_state_s) 
 		nudge_pll_9600(channel, subchannel, 0, demod_out, D)
 	} else {
 		/* Multiple slicers each feeding its own HDLC decoder. */
-		for slice := int(0); slice < D.num_slicers; slice++ {
+		for slice := range D.num_slicers {
 			demod_data = demod_out-slice_point[slice] > 0
 			nudge_pll_9600(channel, subchannel, slice, demod_out-slice_point[slice], D)
 		}

--- a/src/demod_afsk.go
+++ b/src/demod_afsk.go
@@ -568,7 +568,7 @@ func demod_afsk_process_sample(channel int, subchannel int, sam int, D *demodula
 				D.m_peak, D.m_valley, _ = agc(m_amp, D.agc_fast_attack, D.agc_slow_decay, D.m_peak, D.m_valley)
 				D.s_peak, D.s_valley, _ = agc(s_amp, D.agc_fast_attack, D.agc_slow_decay, D.s_peak, D.s_valley)
 
-				for slice := int(0); slice < D.num_slicers; slice++ {
+				for slice := range D.num_slicers {
 					var demod_out = m_amp - s_amp*afskSpaceGain[slice]
 
 					var amp = 0.5 * (D.m_peak - D.m_valley + (D.s_peak-D.s_valley)*afskSpaceGain[slice])
@@ -639,7 +639,7 @@ func demod_afsk_process_sample(channel int, subchannel int, sam int, D *demodula
 				//
 				// Assuming a 300 Hz shift, this would put slicing thresholds up
 				// to +-75 Hz from the center.
-				for slice := int(0); slice < D.num_slicers; slice++ {
+				for slice := range D.num_slicers {
 					var offset = -0.5 + float64(slice)*(1./float64(D.num_slicers-1))
 					var demod_out = norm_rate + offset
 

--- a/src/dtmf.go
+++ b/src/dtmf.go
@@ -443,7 +443,7 @@ func push_button_raw(channel int, button rune, ms int, test_mode bool) {
 	var dtmf float64 // Audio.  Sum of two sine waves.
 	var phasea, phaseb float64
 
-	for i := int(0); i < (ms*dd[channel].sample_rate)/1000; i++ {
+	for range (ms * dd[channel].sample_rate) / 1000 {
 		// This could be more efficient with a precomputed sine wave table
 		// but I'm not that worried about it.
 		// With a Raspberry Pi, model 2, default 1200 receiving takes about 14% of one CPU core.

--- a/src/fx25_extract.go
+++ b/src/fx25_extract.go
@@ -78,7 +78,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 	var count int
 
 	// form the syndromes; i.e., evaluate data(x) at roots of g(x)
-	for i = 0; i < nroots; i++ {
+	for i = range nroots {
 		s[i] = data[0]
 	}
 
@@ -94,7 +94,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 
 	// Convert syndromes to index form, checking for nonzero condition
 	synError = 0
-	for i = 0; i < nroots; i++ {
+	for i = range nroots {
 		synError |= int(s[i])
 		s[i] = rs.index_of[s[i]]
 	}
@@ -166,7 +166,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 
 	// for(i=0;i<NROOTS+1;i++)
 	//   b[i] = INDEX_OF[lambda[i]];
-	for i = 0; i < nroots+1; i++ {
+	for i = range nroots + 1 {
 		b[i] = rs.index_of[lambda[i]]
 	}
 
@@ -179,7 +179,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 		// Compute discrepancy at the r-th step in poly-form
 		discrR = 0
 
-		for i = 0; i < r; i++ {
+		for i = range r {
 			if lambda[i] != 0 && int(s[r-i-1]) != A0 {
 				discrR ^= rs.alpha_to[modnn(rs, int(rs.index_of[lambda[i]])+int(s[r-i-1]))]
 			}
@@ -195,7 +195,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 			// 7 lines below: T(x) <-- lambda(x) - discr_r*x*b(x)
 			t[0] = lambda[0]
 
-			for i = 0; i < nroots; i++ {
+			for i = range nroots {
 				if int(b[i]) != A0 {
 					t[i+1] = lambda[i+1] ^ rs.alpha_to[modnn(rs, int(discrR)+int(b[i]))]
 				} else {
@@ -206,7 +206,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 			if 2*el <= r+no_eras-1 {
 				el = r + no_eras - el
 				// 2 lines below: B(x) <-- inv(discr_r) * lambda(x)
-				for i = 0; i <= nroots; i++ {
+				for i = range nroots + 1 {
 					if lambda[i] == 0 {
 						b[i] = byte(A0)
 					} else {
@@ -227,7 +227,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 	// Convert lambda to index form and compute deg(lambda(x))
 	degLambda = 0
 
-	for i = 0; i < nroots+1; i++ {
+	for i = range nroots + 1 {
 		lambda[i] = rs.index_of[lambda[i]]
 		if int(lambda[i]) != A0 {
 			degLambda = i
@@ -276,7 +276,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 	// x**NROOTS). in index form. Also find deg(omega).
 	degOmega = 0
 
-	for i = 0; i < nroots; i++ {
+	for i = range nroots {
 		tmp = 0
 
 		j = min(degLambda, i)
@@ -334,7 +334,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 
 finish:
 	if eras_pos != nil {
-		for i = 0; i < count; i++ {
+		for i = range count {
 			eras_pos[i] = loc[i]
 		}
 	}

--- a/src/fx25_init.go
+++ b/src/fx25_init.go
@@ -378,7 +378,7 @@ func init_rs_char(symsize uint, gfpoly uint, fcr uint, prim uint, nroots uint) *
 	rs.alpha_to[rs.nn] = 0       // alpha**-inf = 0
 
 	var sr = 1
-	for i := 0; i < int(rs.nn); i++ {
+	for i := range rs.nn {
 		rs.index_of[sr] = byte(i)
 		rs.alpha_to[i] = byte(sr)
 

--- a/src/fx25_rec.go
+++ b/src/fx25_rec.go
@@ -341,7 +341,7 @@ func my_unstuff(channel int, subchannel int, slice int, pin []byte, ilen int) []
 	}
 
 	var frame_buf []byte
-	for i := 0; i < ilen; i++ {
+	for i := range ilen {
 		for imask := byte(0x01); imask != 0; imask <<= 1 {
 			var dbit = byte(IfThenElse((pin[i]&imask) != 0, 1, 0))
 

--- a/src/gen_packets.go
+++ b/src/gen_packets.go
@@ -858,7 +858,7 @@ func send_packet(str string) {
 
 		// If stereo, put same thing in each channel.
 
-		for c := 0; c < modem.adev[0].num_channels; c++ {
+		for c := range modem.adev[0].num_channels {
 			var samples_per_symbol int
 
 			// Insert random amount of quiet time.

--- a/src/gen_tone.go
+++ b/src/gen_tone.go
@@ -702,11 +702,11 @@ func GenToneMain() {
 	gen_tone_init(&my_audio_config, 100, false)
 
 	for range 2 {
-		for n := 0; n < my_audio_config.achan[0].baud*2; n++ {
+		for range my_audio_config.achan[0].baud * 2 {
 			tone_gen_put_bit(chan1, 1)
 		}
 
-		for n := 0; n < my_audio_config.achan[0].baud*2; n++ {
+		for range my_audio_config.achan[0].baud * 2 {
 			tone_gen_put_bit(chan1, 0)
 		}
 	}
@@ -724,19 +724,19 @@ func GenToneMain() {
 	gen_tone_init(&my_audio_config, 100, false)
 
 	for range 4 {
-		for n := 0; n < my_audio_config.achan[0].baud*2; n++ {
+		for range my_audio_config.achan[0].baud * 2 {
 			tone_gen_put_bit(chan1, 1)
 		}
 
-		for n := 0; n < my_audio_config.achan[0].baud*2; n++ {
+		for range my_audio_config.achan[0].baud * 2 {
 			tone_gen_put_bit(chan1, 0)
 		}
 
-		for n := 0; n < my_audio_config.achan[1].baud*2; n++ {
+		for range my_audio_config.achan[1].baud * 2 {
 			tone_gen_put_bit(chan2, 1)
 		}
 
-		for n := 0; n < my_audio_config.achan[1].baud*2; n++ {
+		for range my_audio_config.achan[1].baud * 2 {
 			tone_gen_put_bit(chan2, 0)
 		}
 	}

--- a/src/hdlc_rec.go
+++ b/src/hdlc_rec.go
@@ -132,7 +132,7 @@ func NewHDLCReceiver(pa *audio_s) *HDLCReceiver {
 
 			Assert(r.numSubchannel[ch] >= 1 && r.numSubchannel[ch] <= MAX_SUBCHANS)
 
-			for sub := 0; sub < r.numSubchannel[ch]; sub++ {
+			for sub := range r.numSubchannel[ch] {
 				for slice := range MAX_SLICERS {
 					r.slicer[ch][sub][slice] = newHDLCState(r, ch, sub, slice, pa.achan[ch].modem_type == MODEM_SCRAMBLE)
 				}
@@ -756,7 +756,7 @@ func (r *HDLCReceiver) DCDChange(channel int, subchannel int, slice int, state i
 func (r *HDLCReceiver) DataDetectAny(channel int) int {
 	Assert(channel >= 0 && channel < MAX_RADIO_CHANS)
 
-	for sc := 0; sc < r.numSubchannel[channel]; sc++ {
+	for sc := range r.numSubchannel[channel] {
 		if slices.Contains(r.compositeDCD[channel][sc][:], true) {
 			return (1)
 		}

--- a/src/hdlc_rec2.go
+++ b/src/hdlc_rec2.go
@@ -324,7 +324,7 @@ func try_to_fix_quick_now(block *rrbb_t, channel int, subchan int, slice int, al
 	retry_cfg.retry = RETRY_INVERT_SINGLE
 	retry_cfg.contig.nr_bits = 1
 
-	for i := 0; i < length; i++ {
+	for i := range length {
 		/* Set the index of the bit to swap */
 		retry_cfg.contig.bit_idx = i
 
@@ -350,7 +350,7 @@ func try_to_fix_quick_now(block *rrbb_t, channel int, subchan int, slice int, al
 	retry_cfg.retry = RETRY_INVERT_DOUBLE
 	retry_cfg.contig.nr_bits = 2
 
-	for i := 0; i < length-1; i++ {
+	for i := range length - 1 {
 		retry_cfg.contig.bit_idx = i
 
 		var ok = try_decode(block, channel, subchan, slice, alevel, retry_cfg, false)
@@ -375,7 +375,7 @@ func try_to_fix_quick_now(block *rrbb_t, channel int, subchan int, slice int, al
 	retry_cfg.retry = RETRY_INVERT_TRIPLE
 	retry_cfg.contig.nr_bits = 3
 
-	for i := 0; i < length-2; i++ {
+	for i := range length - 2 {
 		retry_cfg.contig.bit_idx = i
 
 		var ok = try_decode(block, channel, subchan, slice, alevel, retry_cfg, false)
@@ -412,7 +412,7 @@ func try_to_fix_quick_now(block *rrbb_t, channel int, subchan int, slice int, al
 	#endif
 	*/
 	length = rrbb_get_len(block)
-	for i := 0; i < length-2; i++ {
+	for i := range length - 2 {
 		retry_cfg.sep.bit_idx_a = i
 
 		var ok = false

--- a/src/igate.go
+++ b/src/igate.go
@@ -513,7 +513,7 @@ func igate_send_rec_packet(channel int, recv_pp *packet_t) {
 	 * Third party frames require special handling to unwrap payload.
 	 */
 	for ax25_get_dti(pp) == '}' {
-		for n := 0; n < ax25_get_num_repeaters(pp); n++ {
+		for n := range ax25_get_num_repeaters(pp) {
 			/* includes ssid. Do we want to ignore it? */
 			var via = ax25_get_addr_with_ssid(pp, n+AX25_REPEATER_1)
 
@@ -550,7 +550,7 @@ func igate_send_rec_packet(channel int, recv_pp *packet_t) {
 	/*
 	 * Do not relay packets with TCPIP, TCPXX, RFONLY, or NOGATE in the via path.
 	 */
-	for n := 0; n < ax25_get_num_repeaters(pp); n++ {
+	for n := range ax25_get_num_repeaters(pp) {
 		/* includes ssid. Do we want to ignore it? */
 		var via = ax25_get_addr_with_ssid(pp, n+AX25_REPEATER_1)
 
@@ -1296,7 +1296,7 @@ func maybe_xmit_packet_from_igate(message []byte, to_chan int) {
 	 *	NOGATE or RFONLY - means IGate should not pass them.
 	 *	TCPXX or qAX - means it came from somewhere that did not identify itself correctly.
 	 */
-	for n := 0; n < ax25_get_num_repeaters(pp3); n++ {
+	for n := range ax25_get_num_repeaters(pp3) {
 		/* includes ssid. Do we want to ignore it? */
 		var via = ax25_get_addr_with_ssid(pp3, n+AX25_REPEATER_1)
 

--- a/src/il2p_crc_test.go
+++ b/src/il2p_crc_test.go
@@ -88,7 +88,7 @@ func TestIL2PCRCEncodeDecodeFrame(t *testing.T) {
 	var pp = ax25_u_frame(addrs, 2, cr_cmd, frame_type_U_UI, 0, 0xF0, pinfo)
 	require.NotNil(t, pp)
 
-	for max_fec := 0; max_fec <= 1; max_fec++ {
+	for max_fec := range 2 {
 		var encoded, enc_len = il2p_encode_frame(pp, max_fec, true)
 		assert.Positive(t, enc_len)
 

--- a/src/il2p_direwolf_test.go
+++ b/src/il2p_direwolf_test.go
@@ -239,7 +239,7 @@ func test_payload(t *testing.T) {
 		original_payload[n] = byte(n & 0xff)
 	}
 
-	for max_fec := 0; max_fec <= 1; max_fec++ {
+	for max_fec := range 2 {
 		for payload_length := 1; payload_length <= IL2P_MAX_PAYLOAD_SIZE; payload_length++ {
 			// dw_printf ("\n--------- max_fec = %d, payload_length = %d\n", max_fec, payload_length);
 			var encoded, k = il2p_encode_payload(original_payload[:payload_length], max_fec)
@@ -531,7 +531,7 @@ func test_example_headers(t *testing.T) {
 func enc_dec_compare(t *testing.T, pp1 *packet_t) {
 	t.Helper()
 
-	for max_fec := 0; max_fec <= 1; max_fec++ {
+	for max_fec := range 2 {
 		var encoded, enc_len = il2p_encode_frame(pp1, max_fec)
 		assert.GreaterOrEqual(t, enc_len, 0)
 
@@ -582,7 +582,7 @@ func all_frame_types(t *testing.T) {
 	dw_printf("\nU frames...\n")
 
 	for ftype := frame_type_U_SABME; ftype <= frame_type_U_TEST; ftype++ {
-		for pf := 0; pf <= 1; pf++ {
+		for pf := range 2 {
 			var cmin, cmax cmdres_t
 
 			switch ftype {
@@ -637,7 +637,7 @@ func all_frame_types(t *testing.T) {
 	dw_printf("\nS frames...\n")
 
 	for ftype := frame_type_S_RR; ftype <= frame_type_S_SREJ; ftype++ {
-		for pf := 0; pf <= 1; pf++ {
+		for pf := range 2 {
 			var modulo = modulo_8
 			var nr = int(modulo/2 + 1)
 
@@ -682,7 +682,7 @@ func all_frame_types(t *testing.T) {
 
 	var ftype = frame_type_S_SREJ
 
-	for pf := 0; pf <= 1; pf++ {
+	for pf := range 2 {
 		var modulo = modulo_128
 		var nr = 127
 		var cr = cr_res
@@ -702,7 +702,7 @@ func all_frame_types(t *testing.T) {
 
 	pinfo = []byte("The rain in Spain stays mainly on the plain.")
 
-	for pf := 0; pf <= 1; pf++ {
+	for pf := range 2 {
 		var modulo = modulo_8
 		var nr = 0x55 & int(modulo-1)
 		var ns = 0xaa & int(modulo-1)
@@ -765,7 +765,8 @@ func test_serdes(t *testing.T) {
 
 		var channel = 0
 
-		for max_fec := 0; max_fec <= 1; max_fec++ {
+		for max_fec := range 2 {
+			//nolint:intrange // il2pSerdesPolarity is a package-level global read by callbacks; a range loop would shadow it with a local.
 			for il2pSerdesPolarity = 0; il2pSerdesPolarity <= 2; il2pSerdesPolarity++ { // 2 means throw in some errors.
 				var num_bits_sent = il2p_send_frame(channel, pp, max_fec, il2pSerdesPolarity)
 				dw_printf("%d bits sent.\n", num_bits_sent)

--- a/src/il2p_header.go
+++ b/src/il2p_header.go
@@ -468,7 +468,7 @@ func il2p_decode_header_type_1(hdr []byte, num_sym_changed int) *packet_t {
 	// Someone overly ambitious might check the addresses found in the first payload block.
 
 	var byteBuf []byte
-	for i := 0; i <= 5; i++ {
+	for i := range 6 {
 		byteBuf = append(byteBuf, byte(sixbit_to_ascii(hdr[i]&0x3f)))
 	}
 
@@ -491,7 +491,7 @@ func il2p_decode_header_type_1(hdr []byte, num_sym_changed int) *packet_t {
 	addrs[AX25_DESTINATION] += fmt.Sprintf("-%d", destSSID)
 
 	byteBuf = []byte{}
-	for i := 0; i <= 5; i++ {
+	for i := range 6 {
 		byteBuf = append(byteBuf, byte(sixbit_to_ascii(hdr[i+6]&0x3f)))
 	}
 

--- a/src/il2p_init.go
+++ b/src/il2p_init.go
@@ -159,7 +159,7 @@ func il2p_decode_rs(rec_block []byte, num_parity int) ([]byte, int) {
 		} else if derrors > 0 {
 			dw_printf("%d errors fixed in positions:\n", derrors)
 
-			for j := 0; j < derrors; j++ {
+			for j := range derrors {
 				dw_printf("        %3d  (0x%02x)\n", derrlocs[j], derrlocs[j])
 			}
 

--- a/src/il2p_payload.go
+++ b/src/il2p_payload.go
@@ -134,7 +134,7 @@ func il2p_encode_payload(payload []byte, max_fec int) ([]byte, int) {
 
 	// First the large blocks.
 
-	for b := 0; b < ipp.large_block_count; b++ {
+	for range ipp.large_block_count {
 		var scram = il2p_scramble_block(pin[:ipp.large_block_size])
 		pout = append(pout, scram...)
 
@@ -150,7 +150,7 @@ func il2p_encode_payload(payload []byte, max_fec int) ([]byte, int) {
 
 	// Then the small blocks.
 
-	for b := 0; b < ipp.small_block_count; b++ {
+	for range ipp.small_block_count {
 		var scram = il2p_scramble_block(pin[:ipp.small_block_size])
 		pout = append(pout, scram...)
 
@@ -208,7 +208,7 @@ func il2p_decode_payload(received []byte, payload_size int, max_fec int, symbols
 
 	// First the large blocks.
 
-	for b := 0; b < ipp.large_block_count; b++ {
+	for range ipp.large_block_count {
 		var corrected_block, e = il2p_decode_rs(pin[:ipp.large_block_size+ipp.parity_symbols_per_block], ipp.parity_symbols_per_block)
 
 		// dw_printf ("%s:%d: large block decode_rs returned status = %d\n", __FILE__, __LINE__, e);
@@ -234,7 +234,7 @@ func il2p_decode_payload(received []byte, payload_size int, max_fec int, symbols
 
 	// Then the small blocks.
 
-	for b := 0; b < ipp.small_block_count; b++ {
+	for range ipp.small_block_count {
 		var corrected_block, e = il2p_decode_rs(pin[:ipp.small_block_size+ipp.parity_symbols_per_block], ipp.parity_symbols_per_block)
 
 		// dw_printf ("%s:%d: small block decode_rs returned status = %d\n", __FILE__, __LINE__, e);

--- a/src/latlong_test.go
+++ b/src/latlong_test.go
@@ -724,26 +724,26 @@ func BenchmarkLatitudeConversions(b *testing.B) {
 	lat := 42.3601
 
 	b.Run("to_str", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = latitude_to_str(lat, 0)
 		}
 	})
 
 	b.Run("to_comp_str", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = latitude_to_comp_str(lat)
 		}
 	})
 
 	b.Run("to_nmea", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, _ = latitude_to_nmea(lat)
 		}
 	})
 
 	b.Run("from_nmea", func(b *testing.B) {
 		str := "4221.6060"
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = latitude_from_nmea(str, 'N')
 		}
 	})
@@ -755,13 +755,13 @@ func BenchmarkDistanceBearing(b *testing.B) {
 	lat2, lon2 := -33.8688, 151.2093
 
 	b.Run("distance", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = ll_distance_km(lat1, lon1, lat2, lon2)
 		}
 	})
 
 	b.Run("bearing", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = ll_bearing_deg(lat1, lon1, lat2, lon2)
 		}
 	})
@@ -770,7 +770,7 @@ func BenchmarkDistanceBearing(b *testing.B) {
 		dist := 1000.0
 
 		bearing := 45.0
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = ll_dest_lat(lat1, lon1, dist, bearing)
 			_ = ll_dest_lon(lat1, lon1, dist, bearing)
 		}

--- a/src/mheard.go
+++ b/src/mheard.go
@@ -190,7 +190,7 @@ func (mdb *MHeardDB) SaveRF(channel int, A *decode_aprs_t, pp *packet_t, alevel 
 	// HACK - Reduce hop count by number of used WIDEn-0 addresses.
 
 	if hops > 1 {
-		for k := 0; k < ax25_get_num_repeaters(pp); k++ {
+		for k := range ax25_get_num_repeaters(pp) {
 			var digi = ax25_get_addr_no_ssid(pp, AX25_REPEATER_1+k)
 			var ssid = ax25_get_ssid(pp, AX25_REPEATER_1+k)
 			var used = ax25_get_h(pp, AX25_REPEATER_1+k)

--- a/src/morse.go
+++ b/src/morse.go
@@ -122,7 +122,7 @@ func morse_init(audio_config_p *audio_s, amp int) {
 	 */
 	save_audio_config_p = audio_config_p
 
-	for j := range len(SineTable) {
+	for j := range SineTable {
 		var a = (float64(j) / 256.0) * (2 * math.Pi)
 		var s = int(math.Sin(a) * 32767.0 * float64(amp) / 100.0)
 

--- a/src/multi_modem.go
+++ b/src/multi_modem.go
@@ -208,12 +208,12 @@ func multi_modem_process_sample(channel int, audio_sample int) {
 	/* 1.2: We can feed one demodulator but end up with multiple outputs. */
 
 	/* Send same thing to all. */
-	for d := 0; d < save_audio_config_p.achan[channel].num_subchan; d++ {
+	for d := range save_audio_config_p.achan[channel].num_subchan {
 		demod_process_sample(channel, d, audio_sample)
 	}
 
-	for subchan := 0; subchan < save_audio_config_p.achan[channel].num_subchan; subchan++ {
-		for slice := 0; slice < save_audio_config_p.achan[channel].num_slicers; slice++ {
+	for subchan := range save_audio_config_p.achan[channel].num_subchan {
+		for slice := range save_audio_config_p.achan[channel].num_slicers {
 			if candidate[channel][subchan][slice].packet_p != nil {
 				candidate[channel][subchan][slice].age++
 				if candidate[channel][subchan][slice].age > process_age[channel] {


### PR DESCRIPTION
## Summary
🤖 Enables the `intrange` linter (previously disabled in `.golangci.yml`) and converts flagged C-style counting loops to Go 1.22+ `for ... range N` form.

- Most conversions were mechanical via `golangci-lint run --fix`.
- Two loops with parenthesized/compound bound expressions (`atest.go`, `dtmf.go`) were mangled by the autofixer, dropping the range expression — fixed by hand.
- One test loop in `il2p_direwolf_test.go` reuses a package-level global (`il2pSerdesPolarity`) read by callbacks; converting it would shadow the global with a local and change behaviour, so it's left as a classic loop with a `//nolint:intrange` explaining why.

## Test plan
- [x] `make check` passes
- [x] `make test` passes
- [x] `go build ./...` passes