### PR TITLE
test: Reenable perfsprint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - "noctx"  # One day I will learn what a Context is, but that is not today
     - "nonamedreturns"  # Named returns seem a useful tradeoff for now - several functions that return ("output") many things, and names help
     - "paralleltest"  # One day, but let's have *working* tests first
-    - "perfsprint"  # Performance optimisations, worth looking at, but not right now
     - "prealloc"  # One day, but not now
     - "testpackage"  # Noble intent, but right now we're doing all sorts of juggling with packages, so let's save this for later
     - "varnamelen"  # Noble intent, but we're inheriting lots of short variable names, and I'd like to stay close to upstream at first

--- a/src/ais.go
+++ b/src/ais.go
@@ -21,6 +21,7 @@ package direwolf
  *******************************************************************************/
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -214,15 +215,15 @@ func get_field_ascii(base []byte, start uint, length uint) int {
 
 func get_field_string(base []byte, start uint, length uint) string {
 	Assert(length%6 == 0)
-	var result string
+	var sb strings.Builder
 	var nc = length / 6 // Number of characters.
 	// Caller better provide space for at least this +1.
 	// No bounds checking here.
 	for i := range nc {
-		result += string(rune(get_field_ascii(base, start+i*6, 6)))
+		sb.WriteRune(rune(get_field_ascii(base, start+i*6, 6)))
 	}
 	// Officially it should be terminated/padded with @ but we also see trailing spaces.
-	result = strings.TrimRight(result, "@ ")
+	var result = strings.TrimRight(sb.String(), "@ ")
 
 	return result
 }
@@ -368,7 +369,7 @@ func AISParse(sentence string) (*AISData, error) {
 	var data, checksumStr, found = strings.Cut(stemp, "*")
 
 	if !found {
-		return nil, fmt.Errorf("missing AIS sentence checksum")
+		return nil, errors.New("missing AIS sentence checksum")
 	}
 
 	var _checksum, _ = strconv.ParseInt(checksumStr, 16, 0)
@@ -398,7 +399,7 @@ func AISParse(sentence string) (*AISData, error) {
 	_ = radio_chan
 
 	if len(payload) == 0 {
-		return nil, fmt.Errorf("payload is missing from AIS sentence")
+		return nil, errors.New("payload is missing from AIS sentence")
 	}
 
 	// Convert character representation to bit vector.

--- a/src/ax25_pad.go
+++ b/src/ax25_pad.go
@@ -1387,10 +1387,11 @@ func ax25_get_addr_with_ssid(this_p *packet_t, n int) string {
 	// Now we return exactly what is in the address field and trim trailing spaces.
 	// This will provide better information for troubleshooting.
 
-	var station string
+	var sb strings.Builder
 	for i := range 6 {
-		station += string((this_p.frame_data[n*7+i] >> 1) & 0x7f)
+		sb.WriteByte((this_p.frame_data[n*7+i] >> 1) & 0x7f)
 	}
+	var station = sb.String()
 
 	if strings.Contains(station, "\000") {
 		text_color_set(DW_COLOR_ERROR)
@@ -1461,12 +1462,11 @@ func ax25_get_addr_no_ssid(this_p *packet_t, n int) string {
 	// Now we return exactly what is in the address field and trim trailing spaces.
 	// This will provide better information for troubleshooting.
 
-	var station string
+	var sb strings.Builder
 	for i := range 6 {
-		station += string((this_p.frame_data[n*7+i] >> 1) & 0x7f)
+		sb.WriteByte((this_p.frame_data[n*7+i] >> 1) & 0x7f)
 	}
-
-	station = strings.TrimRight(station, " ")
+	var station = strings.TrimRight(sb.String(), " ")
 
 	if len(station) == 0 {
 		text_color_set(DW_COLOR_ERROR)

--- a/src/config.go
+++ b/src/config.go
@@ -4503,11 +4503,12 @@ func handleTTMACRO(ps *parseState) bool {
 			// Convert to object name.
 
 			tmp = tmp[3:]
-			var stemp string
+			var sb strings.Builder
 			for len(tmp) > 0 && tmp[0] != '}' && tmp[0] != '*' {
-				stemp += string(tmp[0])
+				sb.WriteByte(tmp[0])
 				tmp = tmp[1:]
 			}
+			var stemp = sb.String()
 			if len(tmp) > 0 && tmp[0] == '}' {
 				if len(stemp) > 9 {
 					text_color_set(DW_COLOR_ERROR)

--- a/src/demod.go
+++ b/src/demod.go
@@ -93,16 +93,16 @@ func demod_init(pa *audio_s) int {
 				 *	- Any plus will be at the end.
 				 */
 				var num_letters = 0
-				var just_letters string
+				var justLettersBuilder strings.Builder
 				var have_plus = 0
 
 				var profileStr = save_audio_config_p.achan[channel].profiles
 				for i, p := range profileStr {
 					if unicode.IsLower(p) {
-						just_letters += string(unicode.ToUpper(p))
+						justLettersBuilder.WriteRune(unicode.ToUpper(p))
 						num_letters++
 					} else if unicode.IsUpper(p) {
-						just_letters += string(p)
+						justLettersBuilder.WriteRune(p)
 						num_letters++
 					} else if p == '+' {
 						have_plus = 1
@@ -126,6 +126,8 @@ func demod_init(pa *audio_s) int {
 							channel, save_audio_config_p.achan[channel].profiles)
 					}
 				}
+
+				var just_letters = justLettersBuilder.String()
 
 				Assert(num_letters == len(just_letters))
 

--- a/src/dtmf.go
+++ b/src/dtmf.go
@@ -17,6 +17,7 @@ package direwolf
 import (
 	"math"
 	"os"
+	"strings"
 )
 
 const DTMF_TIMEOUT_SEC = 5 /* for normal operation. */
@@ -364,7 +365,7 @@ func dtmf_send(channel int, str string, speed int, txdelay int, txtail int) int 
  *----------------------------------------------------------------*/
 
 // test_mode
-var push_button_result string
+var push_button_result strings.Builder
 
 func push_button_raw(channel int, button rune, ms int, test_mode bool) {
 	var fa, fb int
@@ -422,18 +423,18 @@ func push_button_raw(channel int, button rune, ms int, test_mode bool) {
 	case '?': /* check result */
 		Assert(test_mode)
 
-		if push_button_result == "123A456B789C*0#D123$789$" { //nolint:staticcheck
+		if push_button_result.String() == "123A456B789C*0#D123$789$" {
 			text_color_set(DW_COLOR_REC)
 			dw_printf("\nSuccess!\n")
-		} else if push_button_result == "123A456B789C*0#D123789" {
+		} else if push_button_result.String() == "123A456B789C*0#D123789" {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("\n * Time-out failed, otherwise OK *\n")
-			dw_printf("\"%s\"\n", push_button_result)
+			dw_printf("\"%s\"\n", push_button_result.String())
 			os.Exit(1)
 		} else {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("\n *** TEST FAILED ***\n")
-			dw_printf("\"%s\"\n", push_button_result)
+			dw_printf("\"%s\"\n", push_button_result.String())
 			os.Exit(1)
 		}
 	}
@@ -464,7 +465,7 @@ func push_button_raw(channel int, button rune, ms int, test_mode bool) {
 			//x = dtmf_sample (0, dtmf * 0.001);
 
 			if x != ' ' && x != '.' {
-				push_button_result += string([]rune{x})
+				push_button_result.WriteRune(x)
 			}
 		} else {
 			// 'dtmf' can be in range of +-2.0 because it is sum of two sine waves.

--- a/src/pfilter.go
+++ b/src/pfilter.go
@@ -18,6 +18,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -158,7 +159,7 @@ func pfilter(from_chan int, to_chan int, filter string, pp *packet_t, is_aprs bo
 	Assert(to_chan >= 0 && to_chan <= MAX_TOTAL_CHANS)
 
 	if pp == nil {
-		return -1, fmt.Errorf("INTERNAL ERROR in pfilter: nil packet pointer, please report this")
+		return -1, errors.New("INTERNAL ERROR in pfilter: nil packet pointer, please report this")
 	}
 
 	var pfstate pfstate_t

--- a/src/telemetry.go
+++ b/src/telemetry.go
@@ -720,13 +720,15 @@ func ival_to_str(x int) string {
 func t_data_process(pm *t_metadata_s, seq int, araw [T_NUM_ANALOG]float64, ndp [T_NUM_ANALOG]int, draw [T_NUM_DIGITAL]int) string {
 	Assert(pm != nil)
 
-	var output string
+	var output strings.Builder
 
 	if len(pm.project) > 0 {
-		output = pm.project + ": "
+		output.WriteString(pm.project)
+		output.WriteString(": ")
 	}
 
-	output += "Seq=" + ival_to_str(seq)
+	output.WriteString("Seq=")
+	output.WriteString(ival_to_str(seq))
 
 	for n := range T_NUM_ANALOG {
 		// Display all or only defined values?  Only defined for now.
@@ -734,7 +736,9 @@ func t_data_process(pm *t_metadata_s, seq int, araw [T_NUM_ANALOG]float64, ndp [
 			var fval float64
 			var fndp int
 
-			output += ", " + pm.name[n] + "="
+			output.WriteString(", ")
+			output.WriteString(pm.name[n])
+			output.WriteString("=")
 
 			// Scaling and suitable number of decimal places for display.
 
@@ -747,9 +751,10 @@ func t_data_process(pm *t_metadata_s, seq int, araw [T_NUM_ANALOG]float64, ndp [
 
 			var val_str = fval_to_str(fval, fndp)
 
-			output += val_str
+			output.WriteString(val_str)
 			if len(pm.unit[n]) > 0 {
-				output += " " + pm.unit[n]
+				output.WriteString(" ")
+				output.WriteString(pm.unit[n])
 			}
 		}
 	}
@@ -759,7 +764,9 @@ func t_data_process(pm *t_metadata_s, seq int, araw [T_NUM_ANALOG]float64, ndp [
 		if draw[n] != G_UNKNOWN {
 			var dval int
 
-			output += ", " + pm.name[T_NUM_ANALOG+n] + "="
+			output.WriteString(", ")
+			output.WriteString(pm.name[T_NUM_ANALOG+n])
+			output.WriteString("=")
 
 			// Possible inverting for bit sense.
 
@@ -770,14 +777,15 @@ func t_data_process(pm *t_metadata_s, seq int, araw [T_NUM_ANALOG]float64, ndp [
 
 			var val_str = ival_to_str(dval)
 
-			output += val_str
+			output.WriteString(val_str)
 			if len(pm.unit[T_NUM_ANALOG+n]) > 0 {
-				output += " " + pm.unit[T_NUM_ANALOG+n]
+				output.WriteString(" ")
+				output.WriteString(pm.unit[T_NUM_ANALOG+n])
 			}
 		}
 	}
 
-	return output
+	return output.String()
 
 	/* TODO KG
 	#if DEBUG4

--- a/src/tt_text.go
+++ b/src/tt_text.go
@@ -168,7 +168,9 @@ var grid = [10][10]string{
  *----------------------------------------------------------------*/
 
 func tt_text_to_multipress(text string, quiet bool) (string, int) { //nolint:unparam
-	var buttons = ""
+	var buttons strings.Builder
+	var lastButton rune
+	var haveButtons bool
 	var errors = 0
 
 	for _, c := range text {
@@ -184,12 +186,15 @@ func tt_text_to_multipress(text string, quiet bool) (string, int) { //nolint:unp
 				}
 			}
 
-			if len(buttons) > 0 && rune(buttons[len(buttons)-1]) == row+'0' {
-				buttons += "A"
+			if haveButtons && lastButton == row+'0' {
+				buttons.WriteRune('A')
+				lastButton = 'A'
 			}
 
 			for ; n > 0; n-- {
-				buttons += string(row + '0')
+				buttons.WriteRune(row + '0')
+				lastButton = row + '0'
+				haveButtons = true
 			}
 		} else {
 			if unicode.IsUpper(c) {
@@ -216,12 +221,15 @@ func tt_text_to_multipress(text string, quiet bool) (string, int) { //nolint:unp
 				for col := 0; col < 4 && !found; col++ {
 					if c == translate[row][col] {
 						/* Stick in 'A' if previous character used same button. */
-						if len(buttons) > 0 && rune(buttons[len(buttons)-1]) == rune(row+'0') {
-							buttons += "A"
+						if haveButtons && lastButton == rune(row+'0') {
+							buttons.WriteRune('A')
+							lastButton = 'A'
 						}
 
 						for n := col + 1; n > 0; n-- {
-							buttons += string(rune(row + '0'))
+							buttons.WriteRune(rune(row + '0'))
+							lastButton = rune(row + '0')
+							haveButtons = true
 							found = true
 						}
 					}
@@ -237,7 +245,7 @@ func tt_text_to_multipress(text string, quiet bool) (string, int) { //nolint:unp
 		}
 	}
 
-	return buttons, errors
+	return buttons.String(), errors
 } /* end tt_text_to_multipress */
 
 /*------------------------------------------------------------------
@@ -858,7 +866,7 @@ func tt_two_digits_to_letter(buttons string, quiet bool) (string, int) {
  *----------------------------------------------------------------*/
 
 func tt_call10_to_text(buttons string, quiet bool) (string, int) {
-	var text string
+	var text strings.Builder
 	var errors = 0
 
 	/* Validity check. */
@@ -871,7 +879,7 @@ func tt_call10_to_text(buttons string, quiet bool) (string, int) {
 
 		errors++
 
-		return text, errors
+		return text.String(), errors
 	}
 
 	for _, b := range buttons {
@@ -883,7 +891,7 @@ func tt_call10_to_text(buttons string, quiet bool) (string, int) {
 
 			errors++
 
-			return text, errors
+			return text.String(), errors
 		}
 	}
 
@@ -905,7 +913,7 @@ func tt_call10_to_text(buttons string, quiet bool) (string, int) {
 		}
 
 		if call10encoding[row][col] != 0 {
-			text += string(call10encoding[row][col])
+			text.WriteRune(call10encoding[row][col])
 		} else {
 			errors++
 
@@ -918,9 +926,9 @@ func tt_call10_to_text(buttons string, quiet bool) (string, int) {
 
 	/* Trim any trailing spaces. */
 
-	text = strings.TrimSpace(text)
+	var trimmed = strings.TrimSpace(text.String())
 
-	return text, errors
+	return trimmed, errors
 } /* end tt_call10_to_text */
 
 /*------------------------------------------------------------------
@@ -942,7 +950,7 @@ func tt_call10_to_text(buttons string, quiet bool) (string, int) {
  *----------------------------------------------------------------*/
 
 func tt_call5_suffix_to_text(buttons string, quiet bool) (string, int) {
-	var text string
+	var text strings.Builder
 	var errors = 0
 
 	/* Validity check. */
@@ -955,7 +963,7 @@ func tt_call5_suffix_to_text(buttons string, quiet bool) (string, int) {
 
 		errors++
 
-		return text, errors
+		return text.String(), errors
 	}
 
 	for _, b := range buttons {
@@ -967,7 +975,7 @@ func tt_call5_suffix_to_text(buttons string, quiet bool) (string, int) {
 
 			errors++
 
-			return text, errors
+			return text.String(), errors
 		}
 	}
 
@@ -989,7 +997,7 @@ func tt_call5_suffix_to_text(buttons string, quiet bool) (string, int) {
 		}
 
 		if call10encoding[row][col] != 0 {
-			text += string(call10encoding[row][col])
+			text.WriteRune(call10encoding[row][col])
 		} else {
 			errors++
 
@@ -1004,7 +1012,7 @@ func tt_call5_suffix_to_text(buttons string, quiet bool) (string, int) {
 		return "", errors
 	}
 
-	return text, errors
+	return text.String(), errors
 } /* end tt_call5_suffix_to_text */
 
 /*------------------------------------------------------------------
@@ -1045,7 +1053,7 @@ var mhpair = [MAXMHPAIRS]mhpairType{
 }
 
 func tt_mhead_to_text(buttons string, quiet bool) (string, int) {
-	var text string
+	var text strings.Builder
 	var errors = 0
 
 	/* Validity check. */
@@ -1060,7 +1068,7 @@ func tt_mhead_to_text(buttons string, quiet bool) (string, int) {
 
 		errors++
 
-		return text, errors
+		return text.String(), errors
 	}
 
 	for _, b := range buttons {
@@ -1072,7 +1080,7 @@ func tt_mhead_to_text(buttons string, quiet bool) (string, int) {
 
 			errors++
 
-			return text, errors
+			return text.String(), errors
 		}
 	}
 
@@ -1087,16 +1095,16 @@ func tt_mhead_to_text(buttons string, quiet bool) (string, int) {
 			var e2 int
 
 			t2, e2 = tt_two_digits_to_letter(buttons, quiet)
-			text += t2
+			text.WriteString(t2)
 			errors += e2
 			buttons = buttons[2:]
 
 			t2, e2 = tt_two_digits_to_letter(buttons, quiet)
-			text += t2
+			text.WriteString(t2)
 			errors += e2
 			buttons = buttons[2:]
 		} else {
-			text += buttons[0:2]
+			text.WriteString(buttons[0:2])
 			buttons = buttons[2:]
 		}
 	}
@@ -1104,10 +1112,10 @@ func tt_mhead_to_text(buttons string, quiet bool) (string, int) {
 	// No need to handle case where there's anything remaining - we checked earlier
 
 	if errors != 0 {
-		text = ""
+		return "", errors
 	}
 
-	return text, errors
+	return text.String(), errors
 } /* end tt_mhead_to_text */
 
 /*------------------------------------------------------------------
@@ -1269,12 +1277,12 @@ func tt_satsq_to_text(buttons string, quiet bool) (string, int) {
  *----------------------------------------------------------------*/
 
 func tt_ascii2d_to_text(buttons string, quiet bool) (string, int) {
-	var text string
+	var text strings.Builder
 	var errors = 0
 
 	// TODO KG
 	if len(buttons)%2 != 0 {
-		return text, 1
+		return text.String(), 1
 	}
 
 	for i := range len(buttons) / 2 {
@@ -1284,7 +1292,7 @@ func tt_ascii2d_to_text(buttons string, quiet bool) (string, int) {
 		if unicode.IsDigit(c1) && unicode.IsDigit(c2) {
 			var n = (c1-'0')*10 + (c2 - '0')
 
-			text += string(n + 32)
+			text.WriteRune(n + 32)
 		} else {
 			// Unexpected character.
 			errors++
@@ -1296,7 +1304,7 @@ func tt_ascii2d_to_text(buttons string, quiet bool) (string, int) {
 		}
 	}
 
-	return text, errors
+	return text.String(), errors
 } /* end tt_ascii2d_to_text */
 
 /*------------------------------------------------------------------

--- a/src/waypoint.go
+++ b/src/waypoint.go
@@ -105,10 +105,10 @@ func NewWaypointSender(mc *misc_config_s) (*WaypointSender, error) {
 	if (udpRequested || serialRequested) && ws.udpSock == nil && ws.serialPortFd == nil {
 		var requested []string
 		if udpRequested {
-			requested = append(requested, fmt.Sprintf("UDP %s", net.JoinHostPort(mc.waypoint_udp_hostname, strconv.Itoa(mc.waypoint_udp_portnum))))
+			requested = append(requested, "UDP "+net.JoinHostPort(mc.waypoint_udp_hostname, strconv.Itoa(mc.waypoint_udp_portnum)))
 		}
 		if serialRequested {
-			requested = append(requested, fmt.Sprintf("serial port %s", mc.waypoint_serial_port))
+			requested = append(requested, "serial port "+mc.waypoint_serial_port)
 		}
 
 		return nil, fmt.Errorf("waypoint output requested but no destination could be opened (%s)", strings.Join(requested, ", "))


### PR DESCRIPTION
## Summary
🤖 Reenables the `perfsprint` linter (previously disabled in `.golangci.yml`) and fixes the 19 findings it surfaces:
- String concatenation in loops (`ais.go`, `ax25_pad.go`, `config.go`, `demod.go`, `dtmf.go`, `telemetry.go`, `tt_text.go`) replaced with `strings.Builder`
- `fmt.Errorf` with no format verbs replaced with `errors.New` (`ais.go`, `pfilter.go`)
- `fmt.Sprintf` with no format verbs replaced with plain string concatenation (`waypoint.go`)

## Test plan
- [x] `make check` passes
- [x] `make test` passes
- [x] `go test ./src/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)