### PR TITLE
test: Reenable err113 linter and satisfy it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ linters:
   disable:
     - "dupl"  # One day
     - "dupword"  # One day
-    - "err113"  # Eventually
     - "errcheck"  # I appreciate the intent, but I'm not checking errors on fmt.Printf etc.
     - "forbidigo"  # fmt.Print* are fine for now
     - "funlen"  # We have inherited lots of long lines

--- a/src/ais.go
+++ b/src/ais.go
@@ -21,9 +21,19 @@ package direwolf
  *******************************************************************************/
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+)
+
+var (
+	errAISInvalidSextetChar  = errors.New("invalid character in AIS NMEA sentence payload")
+	errAISInvalidSextetValue = errors.New("invalid 6-bit value from AIS HDLC payload")
+	errAISMissingChecksum    = errors.New("missing AIS sentence checksum")
+	errAISChecksumMismatch   = errors.New("AIS sentence checksum error")
+	errAISMissingPayload     = errors.New("payload is missing from AIS sentence")
+	errAISUnexpectedFillBits = errors.New("unexpected number of filler bits in AIS sentence")
 )
 
 // Lengths, in bits, for the AIS message types.
@@ -243,7 +253,7 @@ func char_to_sextet(ch byte) (int, error) {
 	} else if ch >= '`' && ch <= 'w' {
 		return int(ch - '`' + 40), nil
 	} else {
-		return 0, fmt.Errorf("invalid character %q in AIS NMEA sentence payload", ch)
+		return 0, fmt.Errorf("%w: %q", errAISInvalidSextetChar, ch)
 	}
 }
 
@@ -257,7 +267,7 @@ func sextet_to_char(val int) (byte, error) {
 	} else if val >= 40 && val <= 63 {
 		return byte('`' + val - 40), nil
 	} else {
-		return '0', fmt.Errorf("invalid 6-bit value %d from AIS HDLC payload", val)
+		return '0', fmt.Errorf("%w: %d", errAISInvalidSextetValue, val)
 	}
 }
 
@@ -368,14 +378,14 @@ func AISParse(sentence string) (*AISData, error) {
 	var data, checksumStr, found = strings.Cut(stemp, "*")
 
 	if !found {
-		return nil, fmt.Errorf("missing AIS sentence checksum")
+		return nil, errAISMissingChecksum
 	}
 
 	var _checksum, _ = strconv.ParseInt(checksumStr, 16, 0)
 	var checksum = byte(_checksum)
 
 	if calculatedChecksum != checksum {
-		return nil, fmt.Errorf("AIS sentence checksum error: expected %02x but found %s", calculatedChecksum, checksumStr)
+		return nil, fmt.Errorf("%w: expected %02x but found %s", errAISChecksumMismatch, calculatedChecksum, checksumStr)
 	}
 
 	// Extract the comma separated fields.
@@ -398,7 +408,7 @@ func AISParse(sentence string) (*AISData, error) {
 	_ = radio_chan
 
 	if len(payload) == 0 {
-		return nil, fmt.Errorf("payload is missing from AIS sentence")
+		return nil, errAISMissingPayload
 	}
 
 	// Convert character representation to bit vector.
@@ -422,7 +432,7 @@ func AISParse(sentence string) (*AISData, error) {
 
 	var fillerErr error
 	if nfill != plen*6-nbytes*8 {
-		fillerErr = fmt.Errorf("number of filler bits is %d when %d is expected", nfill, plen*6-nbytes*8)
+		fillerErr = fmt.Errorf("%w: is %d when %d is expected", errAISUnexpectedFillBits, nfill, plen*6-nbytes*8)
 	}
 
 	// Extract the fields of interest from a few message types.

--- a/src/axudp.go
+++ b/src/axudp.go
@@ -16,6 +16,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var (
+	errAXUDPMapEntryEmptyAX25Addr  = errors.New("map entry: ax25addr is empty")
+	errAXUDPMapEntryEmptyHost      = errors.New("map entry: host is empty")
+	errAXUDPMapEntryPortOutOfRange = errors.New("map entry: port out of range (1-65535)")
+)
+
 // AXUDPMapEntry holds one MAP line from the config.
 type AXUDPMapEntry struct {
 	AX25Addr string       // AX.25 address, i.e. callsign and optional SSID, e.g. "Q1TEST" or "Q1TEST-1"
@@ -56,13 +62,13 @@ func ParseAXUDPConfig(path string) ([]AXUDPMapEntry, error) {
 		var ax25addr = strings.ToUpper(strings.TrimSpace(m.AX25Addr))
 		ax25addr = strings.TrimSuffix(ax25addr, "-0")
 		if ax25addr == "" {
-			return nil, fmt.Errorf("map entry %d: ax25addr is empty", i)
+			return nil, fmt.Errorf("%w: %d", errAXUDPMapEntryEmptyAX25Addr, i)
 		}
 		if m.Host == "" {
-			return nil, fmt.Errorf("map entry %d: host is empty", i)
+			return nil, fmt.Errorf("%w: %d", errAXUDPMapEntryEmptyHost, i)
 		}
 		if m.Port < 1 || m.Port > 65535 {
-			return nil, fmt.Errorf("map entry %d: port %d out of range (1-65535)", i, m.Port)
+			return nil, fmt.Errorf("%w: %d has port %d", errAXUDPMapEntryPortOutOfRange, i, m.Port)
 		}
 		var addr = net.JoinHostPort(m.Host, strconv.Itoa(m.Port))
 		var udpAddr, resolveErr = net.ResolveUDPAddr("udp", addr)

--- a/src/cm108_linux.go
+++ b/src/cm108_linux.go
@@ -89,6 +89,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var (
+	errCM108EnumerateSoundDevices  = errors.New("INTERNAL ERROR: Can't enumerate udev devices")
+	errCM108EnumerateHidrawDevices = errors.New("INTERNAL ERROR: Can't enumerate udev hidraw devices")
+)
+
 /* Dire Wolf cm108.h */
 
 // The CM108, CM109, and CM119 datasheets all say that idProduct can be in the range
@@ -226,10 +231,9 @@ func CM108Inventory(max_things int) ([]*CM108Thing, error) {
 	var devices, devicesErr = e.Devices()
 	if devicesErr != nil {
 		text_color_set(DW_COLOR_ERROR)
-		var msg = "INTERNAL ERROR: Can't enumerate udev devices"
-		dw_printf("%s: %v.\n", msg, devicesErr)
+		dw_printf("%s: %v.\n", errCM108EnumerateSoundDevices, devicesErr)
 
-		return things, errors.New(msg)
+		return things, errCM108EnumerateSoundDevices
 	}
 
 	var cardDevpath string
@@ -290,10 +294,9 @@ func CM108Inventory(max_things int) ([]*CM108Thing, error) {
 	var hidDevices, hidDevicesErr = e2.Devices()
 	if hidDevicesErr != nil {
 		text_color_set(DW_COLOR_ERROR)
-		var msg = "INTERNAL ERROR: Can't enumerate udev hidraw devices"
-		dw_printf("%s: %v.\n", msg, hidDevicesErr)
+		dw_printf("%s: %v.\n", errCM108EnumerateHidrawDevices, hidDevicesErr)
 
-		return nil, errors.New(msg)
+		return nil, errCM108EnumerateHidrawDevices
 	}
 
 	for _, dev := range hidDevices {

--- a/src/config.go
+++ b/src/config.go
@@ -15,6 +15,7 @@ package direwolf
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -30,6 +31,14 @@ import (
 )
 
 const DEFAULT_GPSD_PORT = 2947 // Taken from gps.h
+
+var (
+	errConfigNoEqualsInLine       = errors.New("config file: no = found in line")
+	errConfigInvalidOptionKeyword = errors.New("config file: invalid option keyword")
+	errConfigSendToChanOutOfRange = errors.New("config file: send-to channel is out of range")
+	errConfigSendToChanNoMedium   = errors.New("config file: send-to channel has no medium configured")
+	errConfigMyCallNotSet         = errors.New("config file: MYCALL must be set for channel before beaconing")
+)
 
 /*
  * All the leftovers.
@@ -5988,7 +5997,7 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file: No = found in, %s, on line %d.\n", t, line)
 
-			return fmt.Errorf("config file line %d: no = found in %q", line, t)
+			return fmt.Errorf("%w %d: %q", errConfigNoEqualsInLine, line, t)
 		}
 
 		// QUICK TEMP EXPERIMENT, maybe permanent new feature.
@@ -6264,7 +6273,7 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file, line %d: Invalid option keyword, %s.\n", line, keyword)
 
-			return fmt.Errorf("config file line %d: invalid option keyword %q", line, keyword)
+			return fmt.Errorf("%w %d: %q", errConfigInvalidOptionKeyword, line, keyword)
 		}
 	}
 
@@ -6348,14 +6357,14 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, b.sendto_chan)
 
-			return fmt.Errorf("config file line %d: send-to channel %d is out of range", line, b.sendto_chan)
+			return fmt.Errorf("%w %d: channel %d", errConfigSendToChanOutOfRange, line, b.sendto_chan)
 		}
 
 		if p_audio_config.chan_medium[b.sendto_chan] == MEDIUM_NONE {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Config file, line %d: Send to channel %d is not valid.\n", line, b.sendto_chan)
 
-			return fmt.Errorf("config file line %d: send-to channel %d has no medium configured", line, b.sendto_chan)
+			return fmt.Errorf("%w %d: channel %d", errConfigSendToChanNoMedium, line, b.sendto_chan)
 		}
 
 		if p_audio_config.chan_medium[b.sendto_chan] == MEDIUM_IGATE { // Prevent subscript out of bounds.
@@ -6364,14 +6373,14 @@ func beacon_options(cmd string, b *beacon_s, line int, p_audio_config *audio_s) 
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Config file: MYCALL must be set for channel %d before beaconing is allowed.\n", 0)
 
-				return fmt.Errorf("config file line %d: MYCALL must be set for channel 0 before beaconing", line)
+				return fmt.Errorf("%w %d: channel 0", errConfigMyCallNotSet, line)
 			}
 		} else {
 			if IsNoCall(p_audio_config.mycall[b.sendto_chan]) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Config file: MYCALL must be set for channel %d before beaconing is allowed.\n", b.sendto_chan)
 
-				return fmt.Errorf("config file line %d: MYCALL must be set for channel %d before beaconing", line, b.sendto_chan)
+				return fmt.Errorf("%w %d: channel %d", errConfigMyCallNotSet, line, b.sendto_chan)
 			}
 		}
 	}

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -19,6 +19,7 @@ package direwolf
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -27,6 +28,8 @@ import (
 	"time"
 	"unicode"
 )
+
+var errDirectivityIndexOutOfRange = errors.New("directivity index out of range")
 
 type packet_type_e int
 
@@ -3736,7 +3739,7 @@ func get_maidenhead(A *decode_aprs_t, p []byte) int { //nolint:unparam
 func directivityString(d int) (string, error) {
 	var dirs = []string{"omni", "NE", "E", "SE", "S", "SW", "W", "NW", "N"}
 	if d < 0 || d >= len(dirs) {
-		return "", fmt.Errorf("directivity index %d out of range [0,%d]", d, len(dirs)-1)
+		return "", fmt.Errorf("%w: %d not in [0,%d]", errDirectivityIndexOutOfRange, d, len(dirs)-1)
 	}
 	return dirs[d], nil
 }

--- a/src/dwgpsnmea.go
+++ b/src/dwgpsnmea.go
@@ -34,6 +34,11 @@ import (
 	"github.com/pkg/term"
 )
 
+var (
+	errGPSMissingChecksum = errors.New("missing GPS checksum")
+	errGPSChecksumError   = errors.New("GPS checksum error")
+)
+
 // TODO KG var s_debug = 0 /* Enable debug output. */
 /* See dwgpsnmea_init description for values. */
 
@@ -303,14 +308,12 @@ func read_gpsnmea_thread(fd *term.Term) {
 func remove_checksum(sent string, quiet bool) (string, error) {
 	var msg, checksumStr, found = strings.Cut(sent, "*")
 	if !found {
-		var errorMsg = "Missing GPS checksum"
-
 		if !quiet {
 			text_color_set(DW_COLOR_INFO)
-			dw_printf("%s.\n", errorMsg)
+			dw_printf("%s.\n", errGPSMissingChecksum)
 		}
 
-		return "", errors.New(errorMsg)
+		return "", errGPSMissingChecksum
 	}
 
 	var calculatedChecksum int64
@@ -321,14 +324,14 @@ func remove_checksum(sent string, quiet bool) (string, error) {
 	var checksum, _ = strconv.ParseInt(checksumStr, 16, 0)
 
 	if calculatedChecksum != checksum {
-		var errorMsg = fmt.Sprintf("GPS checksum error. Expected %02x but found %s", calculatedChecksum, checksumStr)
+		var wrappedErr = fmt.Errorf("%w. Expected %02x but found %s", errGPSChecksumError, calculatedChecksum, checksumStr)
 
 		if !quiet {
 			text_color_set(DW_COLOR_ERROR)
-			dw_printf("%s.\n", errorMsg)
+			dw_printf("%s.\n", wrappedErr)
 		}
 
-		return "", errors.New(errorMsg)
+		return "", wrappedErr
 	}
 
 	return msg, nil

--- a/src/dwgpsnmea_test.go
+++ b/src/dwgpsnmea_test.go
@@ -35,7 +35,7 @@ func Test_remove_checksum(t *testing.T) {
 			name:        "missing asterisk",
 			sent:        "$GPRMC,001431.00",
 			wantErr:     true,
-			errContains: "Missing GPS checksum",
+			errContains: "missing GPS checksum",
 			wantResult:  "",
 		},
 		{

--- a/src/latlong.go
+++ b/src/latlong.go
@@ -19,6 +19,11 @@ import (
 	"unicode"
 )
 
+var (
+	errMaidenheadWrongPairCount = errors.New("maidenhead locator must be from 1 to a valid number of pairs of characters")
+	errMaidenheadCharOutOfRange = errors.New("character in maidenhead locator is out of range")
+)
+
 /* Use this value for unknown latitude/longitude or other values. */
 
 const G_UNKNOWN = (-999999)
@@ -699,10 +704,10 @@ func ll_from_grid_square(maidenhead string) (float64, float64, error) {
 	if len(maidenhead)%2 != 0 || np < MH_MIN_PAIR || np > MH_MAX_PAIR {
 		text_color_set(DW_COLOR_ERROR)
 
-		var s = fmt.Sprintf("Maidenhead locator \"%s\" must from 1 to %d pairs of characters.\n", maidenhead, MH_MAX_PAIR)
-		dw_printf("%s", s)
+		var wrappedErr = fmt.Errorf("%w: %q must have from 1 to %d pairs of characters", errMaidenheadWrongPairCount, maidenhead, MH_MAX_PAIR)
+		dw_printf("%s\n", wrappedErr)
 
-		return 0, 0, errors.New(s)
+		return 0, 0, wrappedErr
 	}
 
 	var mh = strings.ToUpper(maidenhead)
@@ -716,11 +721,11 @@ func ll_from_grid_square(maidenhead string) (float64, float64, error) {
 			mh[2*n+1] < pairs[n].min_ch || mh[2*n+1] > pairs[n].max_ch {
 			text_color_set(DW_COLOR_ERROR)
 
-			var s = fmt.Sprintf("The %s pair of characters in Maidenhead locator \"%s\" must be in range of %c thru %c.\n",
-				pairs[n].position, maidenhead, pairs[n].min_ch, pairs[n].max_ch)
-			dw_printf("%s", s)
+			var wrappedErr = fmt.Errorf("%w: the %s pair of characters in %q must be in range of %c thru %c",
+				errMaidenheadCharOutOfRange, pairs[n].position, maidenhead, pairs[n].min_ch, pairs[n].max_ch)
+			dw_printf("%s\n", wrappedErr)
 
-			return 0, 0, errors.New(s)
+			return 0, 0, wrappedErr
 		}
 
 		ilon += int(mh[2*n]-pairs[n].min_ch) * pairs[n].value

--- a/src/pfilter.go
+++ b/src/pfilter.go
@@ -18,10 +18,17 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"unicode"
+)
+
+var (
+	errPfilterNilPacket               = errors.New("INTERNAL ERROR in pfilter: nil packet pointer, please report this")
+	errPfilterSyntax                  = errors.New("filter syntax error")
+	errPfilterValidateSyntheticPacket = errors.New("pfilter_validate: failed to construct synthetic packet")
 )
 
 /*
@@ -158,7 +165,7 @@ func pfilter(from_chan int, to_chan int, filter string, pp *packet_t, is_aprs bo
 	Assert(to_chan >= 0 && to_chan <= MAX_TOTAL_CHANS)
 
 	if pp == nil {
-		return -1, fmt.Errorf("INTERNAL ERROR in pfilter: nil packet pointer, please report this")
+		return -1, errPfilterNilPacket
 	}
 
 	var pfstate pfstate_t
@@ -1360,7 +1367,7 @@ func newFilterError(pf *pfstate_t, msg string) error {
 		}
 	}
 
-	return fmt.Errorf("%s%s\n%*s\n%s", intro, pf.filter_str, len(intro)+pf.tokeni+1, "^", msg)
+	return fmt.Errorf("%w: %s%s\n%*s\n%s", errPfilterSyntax, intro, pf.filter_str, len(intro)+pf.tokeni+1, "^", msg)
 }
 
 // pfilterDummyMonitorLine is a synthetic packet with a known position, symbol
@@ -1398,7 +1405,7 @@ const pfilterDummyMonitorLine = "WB2OSZ-5>APDW12,WIDE1-1,WIDE2-1:!4237.14NS07120
 func pfilter_validate(from_chan int, to_chan int, filter string, is_aprs bool) error {
 	var pp = AX25FromText(pfilterDummyMonitorLine, true)
 	if pp == nil {
-		return fmt.Errorf("pfilter_validate: failed to construct synthetic packet from %q", pfilterDummyMonitorLine)
+		return fmt.Errorf("%w from %q", errPfilterValidateSyntheticPacket, pfilterDummyMonitorLine)
 	}
 	defer AX25Delete(pp)
 

--- a/src/waypoint.go
+++ b/src/waypoint.go
@@ -7,6 +7,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/pkg/term"
 )
+
+var errWaypointNoDestinationOpened = errors.New("waypoint output requested but no destination could be opened")
 
 type WaypointSender struct {
 	serialPortFd *term.Term
@@ -111,7 +114,7 @@ func NewWaypointSender(mc *misc_config_s) (*WaypointSender, error) {
 			requested = append(requested, fmt.Sprintf("serial port %s", mc.waypoint_serial_port))
 		}
 
-		return nil, fmt.Errorf("waypoint output requested but no destination could be opened (%s)", strings.Join(requested, ", "))
+		return nil, fmt.Errorf("%w (%s)", errWaypointNoDestinationOpened, strings.Join(requested, ", "))
 	}
 
 	// Set default formats if user did not specify any.


### PR DESCRIPTION
## Summary
🤖 Reenables the `err113` linter (previously disabled with "Eventually" in `.golangci.yml`) and fixes all 26 violations it found across `src/ais.go`, `src/axudp.go`, `src/cm108_linux.go`, `src/config.go`, `src/decode_aprs.go`, `src/dwgpsnmea.go`, `src/latlong.go`, `src/pfilter.go`, and `src/waypoint.go`.

- Introduced package-level sentinel `errors.New(...)` values for each dynamic error site and wrapped context via `fmt.Errorf("%w: ...", sentinel, ...)`.
- Updated `dwgpsnmea_test.go` for the one test that asserted on error text whose capitalization changed (to satisfy staticcheck's ST1005 lowercase-error convention).

## Test plan
- [x] `make check` (vet, lint, shellcheck, reuse)
- [x] `make test`