### PR TITLE
fix: Reenable nlreturn linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - "nakedret"  # Naked returns in long functions are kinda an ok tradeoff right now
     - "noctx"  # One day I will learn what a Context is, but that is not today
     - "nonamedreturns"  # Named returns seem a useful tradeoff for now - several functions that return ("output") many things, and names help
-    - "nlreturn"  # Lots of false positives on C code that isn't a return
     - "paralleltest"  # One day, but let's have *working* tests first
     - "perfsprint"  # Performance optimisations, worth looking at, but not right now
     - "prealloc"  # One day, but not now

--- a/cmd/samoyed-aclients/main.go
+++ b/cmd/samoyed-aclients/main.go
@@ -258,6 +258,7 @@ func client_thread_net(my_index int, hostname string, port string, description s
 			var pp = direwolf.AX25FromFrame(data[1:mon_cmd.DataLen], alevel)
 			if pp == nil {
 				fmt.Printf("Client %d got invalid AX.25 frame from %s.\n", my_index, description)
+
 				continue
 			}
 

--- a/cmd/samoyed-appserver/main.go
+++ b/cmd/samoyed-appserver/main.go
@@ -454,6 +454,7 @@ func agw_cb_D_connected_data(channel byte, call_from Callsign, call_to Callsign,
 	if s == nil {
 		// Uh oh. Data from some station when not connected.
 		fmt.Printf("Internal error.  Incoming data, no corresponding session: %d,%s: %s\n", channel, call_from, dataStr)
+
 		return
 	}
 
@@ -621,6 +622,7 @@ func agw_cb_Y_outstanding_frames_for_station(channel byte, call_from Callsign, c
 
 	if s == nil {
 		fmt.Printf("Oops!  Did not expect to be here.\n")
+
 		return
 	}
 

--- a/cmd/samoyed-cm108/main_linux.go
+++ b/cmd/samoyed-cm108/main_linux.go
@@ -79,6 +79,7 @@ func main() {
 
 	if len(things) == 0 {
 		fmt.Printf("No relevant USB devices found!\n")
+
 		return
 	}
 

--- a/cmd/samoyed-fxrec/main.go
+++ b/cmd/samoyed-fxrec/main.go
@@ -29,6 +29,7 @@ func main() {
 			var _, readErr = fp.Read(buf)
 			if readErr != nil && !errors.Is(readErr, io.EOF) {
 				fmt.Printf("Error reading %s: %s.\n", fname, readErr)
+
 				break
 			}
 			var ch = buf[0]
@@ -48,6 +49,7 @@ func main() {
 
 	if direwolf.FX25TestCount == 11 {
 		fmt.Printf("***** FX25 unit test Success - all tests passed. *****\n")
+
 		return
 	}
 

--- a/cmd/samoyed-kissutil/main.go
+++ b/cmd/samoyed-kissutil/main.go
@@ -220,17 +220,20 @@ func parse_number(str string, de_fault int) int {
 
 	if len(str) == 0 {
 		fmt.Printf("Missing number for KISS command.  Using default %d.\n", de_fault)
+
 		return de_fault
 	}
 
 	var n, err = strconv.Atoi(str)
 	if err != nil {
 		fmt.Printf("Invalid number %q for KISS command.  Using default %d.\n", str, de_fault)
+
 		return de_fault
 	}
 
 	if n < 0 || n > 255 { // must fit in a byte.
 		fmt.Printf("Number for KISS command is out of range 0-255.  Using default %d.\n", de_fault)
+
 		return de_fault
 	}
 

--- a/cmd/samoyed-ll2utm/main.go
+++ b/cmd/samoyed-ll2utm/main.go
@@ -20,6 +20,7 @@ func D2R(degrees float64) float64 {
 func main() {
 	if len(os.Args) != 3 {
 		usage()
+
 		return
 	}
 

--- a/cmd/samoyed-ttcalc/main.go
+++ b/cmd/samoyed-ttcalc/main.go
@@ -231,6 +231,7 @@ func calculator(str string) int {
 			lastop = ADD
 		} else if p == '#' {
 			result = do_lastop(lastop, result, num)
+
 			return result
 		}
 	}

--- a/src/aprs_tt.go
+++ b/src/aprs_tt.go
@@ -613,6 +613,7 @@ func (g *TTGateway) expandMacro(state *ttParseState, e string) int {
 			/* Found match to a different type.  Really shouldn't be here. */
 			/* Print internal error message... */
 			dw_printf("expand_macro: type != TTLOC_MACRO\n")
+
 			return (TT_ERROR_INTERNAL)
 		}
 
@@ -1564,17 +1565,20 @@ func (g *TTGateway) parseComment(state *ttParseState, e string) int {
 
 	if length == 2 && unicode.IsDigit(rune(e[1])) {
 		state.micE = rune(e[1])
+
 		return (0)
 	}
 
 	if length == 7 && unicode.IsDigit(rune(e[1])) && unicode.IsDigit(rune(e[2])) && unicode.IsDigit(rune(e[3])) && unicode.IsDigit(rune(e[4])) && unicode.IsDigit(rune(e[5])) &&
 		unicode.IsDigit(rune(e[6])) {
 		state.freq = e[1:4] + "." + e[4:7] + "MHz"
+
 		return (0)
 	}
 
 	if length == 4 && unicode.IsDigit(rune(e[1])) && unicode.IsDigit(rune(e[2])) && unicode.IsDigit(rune(e[3])) {
 		state.ctcss = e[1:]
+
 		return (0)
 	}
 

--- a/src/atest.go
+++ b/src/atest.go
@@ -602,6 +602,7 @@ o = DCD output control
 
 				if audio_sample >= 256*256 {
 					e_o_f = true
+
 					continue
 				}
 
@@ -675,6 +676,7 @@ o = DCD output control
 func audio_get_fake(_ int) int {
 	if wav_data.Datasize <= 0 {
 		e_o_f = true
+
 		return (-1)
 	}
 

--- a/src/audio.go
+++ b/src/audio.go
@@ -827,6 +827,7 @@ func parseALSACardsProc(content string) map[string]int {
 		}
 		result[cardID] = num
 	}
+
 	return result
 }
 
@@ -844,6 +845,7 @@ func resolveALSACardNumber(cardID string) (int, bool) {
 	}
 	var cards = parseALSACardsProc(string(content))
 	var num, ok = cards[cardID]
+
 	return num, ok
 }
 
@@ -1609,6 +1611,7 @@ func audio_flush_real(a int) int {
 
 	if adev[a].outputStream == nil {
 		adev[a].outbufLen = 0
+
 		return -1
 	}
 

--- a/src/ax25_link.go
+++ b/src/ax25_link.go
@@ -1305,6 +1305,7 @@ func data_request_good_size(S *ax25_dlsm_t, txdata *cdata_t) {
 		 */
 		if S.layer_3_initiated {
 			cdata_delete(txdata)
+
 			break
 		}
 
@@ -1701,6 +1702,7 @@ func dl_data_indication(S *ax25_dlsm_t, pid int, dataBytes []byte) {
 		// Ready state.
 		if pid != AX25_PID_SEGMENTATION_FRAGMENT {
 			server_rec_conn_data(S.channel, S.client, S.addrs[PEERCALL], S.addrs[OWNCALL], pid, dataBytes)
+
 			return
 		} else if dataBytes[0]&0x80 > 0 {
 			// Ready state, First segment.

--- a/src/ax25_pad.go
+++ b/src/ax25_pad.go
@@ -511,6 +511,7 @@ func AX25FromText(monitor string, strict bool) *packet_t {
 
 	if !colonFound {
 		AX25Delete(this_p)
+
 		return (nil)
 	}
 

--- a/src/axudp.go
+++ b/src/axudp.go
@@ -75,6 +75,7 @@ func ParseAXUDPConfig(path string) ([]AXUDPMapEntry, error) {
 			UDPAddr:  udpAddr,
 		})
 	}
+
 	return entries, nil
 }
 
@@ -117,6 +118,7 @@ func NewAXUDPBridge(maps []AXUDPMapEntry, udpConn *net.UDPConn, verbose bool) *A
 	b.maps = maps
 	b.udpConn = udpConn
 	b.verbose = verbose
+
 	return b
 }
 
@@ -193,6 +195,7 @@ func (b *AXUDPBridge) RunKISSServer(kissPort int) {
 				os.Exit(1)
 			}
 			fmt.Fprintf(os.Stderr, "samoyed-axudp: accept: %v\n", acceptErr)
+
 			continue
 		}
 		fmt.Printf("samoyed-axudp: new KISS client %v\n", conn.RemoteAddr())
@@ -231,6 +234,7 @@ func (b *AXUDPBridge) broadcastKISS(ax25frame []byte) {
 	// already exceeds the limit, skip the expensive encoding step entirely.
 	if len(ax25frame) > MAX_KISS_LEN-3 {
 		fmt.Fprintf(os.Stderr, "samoyed-axudp: dropping oversized AX.25 frame (%d bytes), too large to KISS-encode within %d bytes\n", len(ax25frame), MAX_KISS_LEN)
+
 		return
 	}
 
@@ -244,6 +248,7 @@ func (b *AXUDPBridge) broadcastKISS(ax25frame []byte) {
 	// panic.  Drop the frame before writing to clients to prevent this.
 	if len(kissframe) > MAX_KISS_LEN {
 		fmt.Fprintf(os.Stderr, "samoyed-axudp: dropping oversized KISS frame (%d bytes > %d), AX.25 frame too large after encoding\n", len(kissframe), MAX_KISS_LEN)
+
 		return
 	}
 
@@ -258,6 +263,7 @@ func (b *AXUDPBridge) broadcastKISS(ax25frame []byte) {
 			// Cannot set a deadline — treat as a broken connection and close it
 			// to unblock the read goroutine in handleKISSClient.
 			c.Close()
+
 			continue
 		}
 		var _, writeErr = c.Write(kissframe)
@@ -275,6 +281,7 @@ func ax25AddrBase(cs string) string {
 	if idx := strings.LastIndexByte(cs, '-'); idx >= 0 {
 		return cs[:idx]
 	}
+
 	return cs
 }
 
@@ -296,6 +303,7 @@ func (b *AXUDPBridge) lookupMap(dest string) (AXUDPMapEntry, bool) {
 			return e, true
 		}
 	}
+
 	return AXUDPMapEntry{}, false //nolint: exhaustruct
 }
 
@@ -304,6 +312,7 @@ func (b *AXUDPBridge) lookupMap(dest string) (AXUDPMapEntry, bool) {
 // 0xFFFF) over the frame bytes, appended little-endian.
 func axudpAddCRC(frame []byte) []byte {
 	var crc = fcs_calc(frame)
+
 	return append(append([]byte(nil), frame...), byte(crc), byte(crc>>8))
 }
 
@@ -320,6 +329,7 @@ func axudpStripCRC(pkt []byte) ([]byte, bool) {
 	if got != want {
 		return nil, false
 	}
+
 	return frame, true
 }
 
@@ -362,6 +372,7 @@ func (b *AXUDPBridge) handleKISSClient(conn net.Conn) {
 
 		if readErr != nil {
 			fmt.Printf("samoyed-axudp: KISS client %v disconnected: %v\n", conn.RemoteAddr(), readErr)
+
 			return
 		}
 	}
@@ -424,6 +435,7 @@ func my_kiss_rec_byte_axudp(kf *KISSFrame, overflow *bool, b byte, b2 *AXUDPBrid
 				if len(unwrapped) > 0 {
 					return unwrapped[0]
 				}
+
 				return 0
 			}())
 		}

--- a/src/axudp_test.go
+++ b/src/axudp_test.go
@@ -280,6 +280,7 @@ func TestAXUDPLookupMap(t *testing.T) {
 		var entry, ok = b.lookupMap(tc.dest)
 		if ok != tc.wantFound {
 			t.Errorf("lookupMap(%q): found=%v want %v", tc.dest, ok, tc.wantFound)
+
 			continue
 		}
 		if ok && entry.Addr != tc.wantAddr {
@@ -436,6 +437,7 @@ func (f *fakeConn) Write(b []byte) (int, error) {
 	f.mu.Lock()
 	f.writes = append(f.writes, append([]byte(nil), b...))
 	f.mu.Unlock()
+
 	return len(b), nil
 }
 
@@ -466,6 +468,7 @@ func (c *singleReadConn) Read(b []byte) (int, error) {
 		return 0, io.EOF
 	}
 	c.done = true
+
 	return copy(b, c.data), io.EOF
 }
 

--- a/src/beacon.go
+++ b/src/beacon.go
@@ -216,22 +216,26 @@ func NewBeaconService(pmodem *audio_s, pconfig *misc_config_s, pigate *igate_con
 					var e = bp.every + n
 					if e > 3600 {
 						bp.every = 3600
+
 						break
 					}
 
 					if IS_GOOD(e) {
 						bp.every = e
+
 						break
 					}
 
 					e = bp.every - n
 					if e < 1 {
 						bp.every = 1 // Impose a larger minimum?
+
 						break
 					}
 
 					if IS_GOOD(e) {
 						bp.every = e
+
 						break
 					}
 				}

--- a/src/beacon_impl_test.go
+++ b/src/beacon_impl_test.go
@@ -17,6 +17,7 @@ func makeBeaconModemConfig() *audio_s {
 	var cfg = new(audio_s)
 	cfg.chan_medium[0] = MEDIUM_RADIO
 	cfg.mycall[0] = "Q1TEST"
+
 	return cfg
 }
 
@@ -25,6 +26,7 @@ func makeBeaconIGateConfig() *igate_config_s {
 	cfg.t2_server_name = "rotate.aprs2.net"
 	cfg.t2_login = "Q1TEST"
 	cfg.t2_passcode = "12345"
+
 	return cfg
 }
 
@@ -38,6 +40,7 @@ func makeSBConfig() *misc_config_s {
 	cfg.sb_turn_time = 15   // seconds
 	cfg.sb_turn_angle = 30  // degrees
 	cfg.sb_turn_slope = 255 // degrees * MPH
+
 	return cfg
 }
 

--- a/src/config.go
+++ b/src/config.go
@@ -1350,6 +1350,7 @@ func handleADEVICE(ps *parseState) bool {
 		var i, iErr = strconv.Atoi(ps.keyword[7:])
 		if iErr != nil {
 			dw_printf("Config file: Could not parse ADEVICE number on line %d: %s.\n", ps.line, iErr)
+
 			return true
 		}
 
@@ -1447,6 +1448,7 @@ func handlePAIDEVICE(ps *parseState) bool {
 	ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)] = MEDIUM_RADIO
 
 	ps.audio.adev[ps.adevice].adevice_in = t
+
 	return false
 }
 
@@ -1480,6 +1482,7 @@ func handlePAODEVICE(ps *parseState) bool {
 	ps.audio.chan_medium[ADEVFIRSTCHAN(ps.adevice)] = MEDIUM_RADIO
 
 	ps.audio.adev[ps.adevice].adevice_out = t
+
 	return false
 }
 
@@ -1504,6 +1507,7 @@ func handleARATE(ps *parseState) bool {
 		dw_printf("Line %d: Use a more reasonable audio sample rate in range of %d - %d.\n",
 			ps.line, MIN_SAMPLES_PER_SEC, MAX_SAMPLES_PER_SEC)
 	}
+
 	return false
 }
 
@@ -1534,6 +1538,7 @@ func handleACHANNELS(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Number of audio channels must be 1 or 2.\n", ps.line)
 	}
+
 	return false
 }
 
@@ -1582,6 +1587,7 @@ func handleCHANNEL(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Channel number must in range of 0 to %d.\n", ps.line, MAX_RADIO_CHANS-1)
 	}
+
 	return false
 }
 
@@ -1619,6 +1625,7 @@ func handleICHANNEL(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: ICHANNEL number must in range of %d to %d.\n", ps.line, MAX_RADIO_CHANS, MAX_TOTAL_CHANS-1)
 	}
+
 	return false
 }
 
@@ -1691,6 +1698,7 @@ func handleNCHANNEL(ps *parseState) bool {
 		return true
 	}
 	ps.audio.nettnc_port[nchan] = n
+
 	return false
 }
 
@@ -1730,6 +1738,7 @@ func handleMYCALL(ps *parseState) bool {
 			}
 		}
 	}
+
 	return false
 }
 
@@ -2066,6 +2075,7 @@ func handleMODEM(ps *parseState) bool {
 
 		//dw_printf ("debug: div = %d\n", p_audio_config.achan[channel].decimate);
 	}
+
 	return false
 }
 
@@ -2086,6 +2096,7 @@ func handleDTMF(ps *parseState) bool {
 	}
 
 	ps.audio.achan[ps.channel].dtmf_decode = DTMF_DECODE_ON
+
 	return false
 }
 
@@ -2157,6 +2168,7 @@ func handleFIX_BITS(ps *parseState) bool {
 
 		t = split("", false)
 	}
+
 	return false
 }
 
@@ -2616,6 +2628,7 @@ func handleTXINH(ps *parseState) bool {
 		ps.audio.achan[ps.channel].ictrl[ICTYPE_TXINH].method = PTT_METHOD_GPIO
 		// #endif
 	}
+
 	return false
 }
 
@@ -2652,6 +2665,7 @@ func handleDWAIT(ps *parseState) bool {
 		dw_printf("Line %d: Invalid delay time for DWAIT. Using %d.\n",
 			ps.line, ps.audio.achan[ps.channel].dwait)
 	}
+
 	return false
 }
 
@@ -2691,6 +2705,7 @@ func handleSLOTTIME(ps *parseState) bool {
 		dw_printf("section, to understand what this means.\n")
 		dw_printf("Why don't you just use the default?\n")
 	}
+
 	return false
 }
 
@@ -2727,6 +2742,7 @@ func handlePERSIST(ps *parseState) bool {
 		dw_printf("section, to understand what this means.\n")
 		dw_printf("Why don't you just use the default?\n")
 	}
+
 	return false
 }
 
@@ -2778,6 +2794,7 @@ func handleTXDELAY(ps *parseState) bool {
 		dw_printf("Line %d: Invalid time for transmit delay. Using %d.\n",
 			ps.line, ps.audio.achan[ps.channel].txdelay)
 	}
+
 	return false
 }
 
@@ -2827,6 +2844,7 @@ func handleTXTAIL(ps *parseState) bool {
 		dw_printf("Line %d: Invalid time for transmit timing. Using %d.\n",
 			ps.line, ps.audio.achan[ps.channel].txtail)
 	}
+
 	return false
 }
 
@@ -2860,6 +2878,7 @@ func handleFULLDUP(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Expected ON or OFF for FULLDUP.\n", ps.line)
 	}
+
 	return false
 }
 
@@ -2940,6 +2959,7 @@ func handleFX25TX(ps *parseState) bool {
 		dw_printf("Line %d: Unreasonable value for FX.25 transmission mode. Using %d.\n",
 			ps.line, ps.audio.achan[ps.channel].fx25_strength)
 	}
+
 	return false
 }
 
@@ -2978,6 +2998,7 @@ func handleFX25AUTO(ps *parseState) bool {
 		dw_printf("Line %d: Unreasonable count for connected mode automatic FX.25. Using %d.\n",
 			ps.line, ps.audio.fx25_auto_enable)
 	}
+
 	return false
 }
 
@@ -3032,6 +3053,7 @@ func handleIL2PTX(ps *parseState) bool {
 			}
 		}
 	}
+
 	return false
 }
 
@@ -3190,6 +3212,7 @@ func handleDIGIPEAT(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file, line %d: Found \"%s\" where end of line was expected.\n", ps.line, t)
 	}
+
 	return false
 }
 
@@ -3216,6 +3239,7 @@ func handleDEDUPE(ps *parseState) bool {
 		dw_printf("Line %d: Unreasonable value for dedupe time. Using %d.\n",
 			ps.line, ps.digi.dedupe_time)
 	}
+
 	return false
 }
 
@@ -3293,6 +3317,7 @@ func handleREGEN(ps *parseState) bool {
 	}
 
 	ps.digi.regen[from_chan][to_chan] = true
+
 	return false
 }
 
@@ -3400,6 +3425,7 @@ func handleCDIGIPEAT(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file, line %d: Found \"%s\" where end of line was expected.\n", ps.line, t)
 	}
+
 	return false
 }
 
@@ -3662,6 +3688,7 @@ func handleTTCORRAL(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing latitude for TTCORRAL command.\n", ps.line)
+
 		return true
 	}
 	ps.tt.corral_lat = parse_ll(t, LAT, ps.line)
@@ -3670,6 +3697,7 @@ func handleTTCORRAL(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing longitude for TTCORRAL command.\n", ps.line)
+
 		return true
 	}
 	ps.tt.corral_lon = parse_ll(t, LON, ps.line)
@@ -3678,6 +3706,7 @@ func handleTTCORRAL(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing offset-or-ambiguity for TTCORRAL command.\n", ps.line)
+
 		return true
 	}
 	ps.tt.corral_offset = parse_ll(t, LAT, ps.line)
@@ -3711,6 +3740,7 @@ func handleTTPOINT(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTPOINT command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -3733,6 +3763,7 @@ func handleTTPOINT(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing latitude for TTPOINT command.\n", ps.line)
+
 		return true
 	}
 	tl.point.lat = parse_ll(t, LAT, ps.line)
@@ -3743,11 +3774,13 @@ func handleTTPOINT(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing longitude for TTPOINT command.\n", ps.line)
+
 		return true
 	}
 	tl.point.lon = parse_ll(t, LON, ps.line)
 
 	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+
 	return false
 }
 
@@ -3772,6 +3805,7 @@ func handleTTVECTOR(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTVECTOR command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -3797,6 +3831,7 @@ func handleTTVECTOR(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing latitude for TTVECTOR command.\n", ps.line)
+
 		return true
 	}
 	tl.vector.lat = parse_ll(t, LAT, ps.line)
@@ -3807,6 +3842,7 @@ func handleTTVECTOR(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing longitude for TTVECTOR command.\n", ps.line)
+
 		return true
 	}
 	tl.vector.lon = parse_ll(t, LON, ps.line)
@@ -3817,12 +3853,14 @@ func handleTTVECTOR(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing scale for TTVECTOR command.\n", ps.line)
+
 		return true
 	}
 	var scale, scaleErr = strconv.ParseFloat(t, 64)
 	if scaleErr != nil {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Invalid scale \"%s\" for TTVECTOR command.\n", ps.line, t)
+
 		return true
 	}
 
@@ -3832,6 +3870,7 @@ func handleTTVECTOR(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing unit for TTVECTOR command.\n", ps.line)
+
 		return true
 	}
 
@@ -3849,6 +3888,7 @@ func handleTTVECTOR(ps *parseState) bool {
 	tl.vector.scale = scale * meters
 
 	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+
 	return false
 }
 
@@ -3869,6 +3909,7 @@ func handleTTGRID(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTGRID command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -3890,6 +3931,7 @@ func handleTTGRID(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing minimum latitude for TTGRID command.\n", ps.line)
+
 		return true
 	}
 	tl.grid.lat0 = parse_ll(t, LAT, ps.line)
@@ -3900,6 +3942,7 @@ func handleTTGRID(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing minimum longitude for TTGRID command.\n", ps.line)
+
 		return true
 	}
 	tl.grid.lon0 = parse_ll(t, LON, ps.line)
@@ -3910,6 +3953,7 @@ func handleTTGRID(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing maximum latitude for TTGRID command.\n", ps.line)
+
 		return true
 	}
 	tl.grid.lat9 = parse_ll(t, LAT, ps.line)
@@ -3920,11 +3964,13 @@ func handleTTGRID(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing maximum longitude for TTGRID command.\n", ps.line)
+
 		return true
 	}
 	tl.grid.lon9 = parse_ll(t, LON, ps.line)
 
 	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+
 	return false
 }
 
@@ -3946,6 +3992,7 @@ func handleTTUTM(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTUTM command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -3953,6 +4000,7 @@ func handleTTUTM(ps *parseState) bool {
 	if t[0] != 'B' {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTUTM pattern must begin with upper case 'B'.\n", ps.line)
+
 		return true
 	}
 	for j := 1; j < len(t); j++ {
@@ -3969,6 +4017,7 @@ func handleTTUTM(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing zone for TTUTM command.\n", ps.line)
+
 		return true
 	}
 
@@ -3982,6 +4031,7 @@ func handleTTUTM(ps *parseState) bool {
 		if scaleErr != nil {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Line %d: Invalid scale \"%s\" for TTUTM command.\n", ps.line, t)
+
 			return true
 		}
 
@@ -3995,6 +4045,7 @@ func handleTTUTM(ps *parseState) bool {
 			if xErr != nil {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Line %d: Invalid x offset \"%s\" for TTUTM command.\n", ps.line, t)
+
 				return true
 			}
 
@@ -4008,6 +4059,7 @@ func handleTTUTM(ps *parseState) bool {
 				if yErr != nil {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Line %d: Invalid y offset \"%s\" for TTUTM command.\n", ps.line, t)
+
 					return true
 				}
 
@@ -4029,10 +4081,12 @@ func handleTTUTM(ps *parseState) bool {
 	if geoErr != nil {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Invalid UTM location: \n%s\n", ps.line, geoErr)
+
 		return true
 	}
 
 	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+
 	return false
 }
 
@@ -4060,6 +4114,7 @@ func handleTTUSNGMGRS(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTUSNG/TTMGRS command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -4067,6 +4122,7 @@ func handleTTUSNGMGRS(ps *parseState) bool {
 	if t[0] != 'B' {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTUSNG/TTMGRS pattern must begin with upper case 'B'.\n", ps.line)
+
 		return true
 	}
 	var num_x = 0
@@ -4087,6 +4143,7 @@ func handleTTUSNGMGRS(ps *parseState) bool {
 	if num_x < 1 || num_x > 5 || num_x != num_y {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTUSNG/TTMGRS must have 1 to 5 x and same number y.\n", ps.line)
+
 		return true
 	}
 
@@ -4096,6 +4153,7 @@ func handleTTUSNGMGRS(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing zone & square for TTUSNG/TTMGRS command.\n", ps.line)
+
 		return true
 	}
 	tl.mgrs.zone = t
@@ -4106,6 +4164,7 @@ func handleTTUSNGMGRS(ps *parseState) bool {
 	if convertErr != nil {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Invalid USNG/MGRS zone & square:  %s\n%s\n", ps.line, tl.mgrs.zone, convertErr)
+
 		return true
 	}
 
@@ -4118,6 +4177,7 @@ func handleTTUSNGMGRS(ps *parseState) bool {
 	}
 
 	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+
 	return false
 }
 
@@ -4145,6 +4205,7 @@ func handleTTMHEAD(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTMHEAD command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -4152,6 +4213,7 @@ func handleTTMHEAD(ps *parseState) bool {
 	if t[0] != 'B' {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTMHEAD pattern must begin with upper case 'B'.\n", ps.line)
+
 		return true
 	}
 
@@ -4177,6 +4239,7 @@ func handleTTMHEAD(ps *parseState) bool {
 	if count_other != 0 {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTMHEAD must have only lower case x to match received data.\n", ps.line)
+
 		return true
 	}
 
@@ -4189,6 +4252,7 @@ func handleTTMHEAD(ps *parseState) bool {
 		if !alldigits(t) || (len(t) != 4 && len(t) != 6 && len(t) != 10) {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Line %d: TTMHEAD prefix must be 4, 6, or 10 digits.\n", ps.line)
+
 			return true
 		}
 
@@ -4196,6 +4260,7 @@ func handleTTMHEAD(ps *parseState) bool {
 		if mhErrors != 0 {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Line %d: TTMHEAD prefix not a valid DTMF sequence.\n", ps.line)
+
 			return true
 		}
 	}
@@ -4205,10 +4270,12 @@ func handleTTMHEAD(ps *parseState) bool {
 	if k != 4 && k != 6 && k != 10 && k != 12 {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTMHEAD prefix and user data must have a total of 4, 6, 10, or 12 digits.\n", ps.line)
+
 		return true
 	}
 
 	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+
 	return false
 }
 
@@ -4235,6 +4302,7 @@ func handleTTSATSQ(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTSATSQ command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -4242,6 +4310,7 @@ func handleTTSATSQ(ps *parseState) bool {
 	if t[0] != 'B' {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTSATSQ pattern must begin with upper case 'B'.\n", ps.line)
+
 		return true
 	}
 
@@ -4257,10 +4326,12 @@ func handleTTSATSQ(ps *parseState) bool {
 	if t[j:] != "xxxx" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTSATSQ pattern must end with exactly xxxx in lower case.\n", ps.line)
+
 		return true
 	}
 
 	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+
 	return false
 }
 
@@ -4287,6 +4358,7 @@ func handleTTAMBIG(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTAMBIG command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -4294,6 +4366,7 @@ func handleTTAMBIG(ps *parseState) bool {
 	if t[0] != 'B' {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTAMBIG pattern must begin with upper case 'B'.\n", ps.line)
+
 		return true
 	}
 
@@ -4309,10 +4382,12 @@ func handleTTAMBIG(ps *parseState) bool {
 	if t[j:] != "x" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: TTAMBIG pattern must end with exactly one x in lower case.\n", ps.line)
+
 		return true
 	}
 
 	ps.tt.ttlocs = append(ps.tt.ttlocs, tl)
+
 	return false
 }
 
@@ -4353,6 +4428,7 @@ func handleTTMACRO(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing pattern for TTMACRO command.\n", ps.line)
+
 		return true
 	}
 	tl.pattern = t
@@ -4365,6 +4441,7 @@ func handleTTMACRO(ps *parseState) bool {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Line %d: TTMACRO pattern can contain only digits, A, B, C, D, and lower case x, y, or z.\n", ps.line)
 			tt_error++
+
 			break
 		}
 		// Count how many x, y, z in the pattern.
@@ -4384,6 +4461,7 @@ func handleTTMACRO(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing definition for TTMACRO command.\n", ps.line)
 		tl.macro.definition = "" // Don't die on null pointer later.
+
 		return true
 	}
 
@@ -4560,6 +4638,7 @@ func handleTTMACRO(ps *parseState) bool {
 	} else {
 		dw_printf("Line %d: Errors found in TTMACRO, skipping.\n", ps.line)
 	}
+
 	return false
 }
 
@@ -4577,6 +4656,7 @@ func handleTTOBJ(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing DTMF receive channel for TTOBJ command.\n", ps.line)
+
 		return true
 	}
 
@@ -4585,6 +4665,7 @@ func handleTTOBJ(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file: DTMF receive channel must be in range of 0 to %d on line %d.\n",
 			MAX_RADIO_CHANS-1, ps.line)
+
 		return true
 	}
 
@@ -4595,6 +4676,7 @@ func handleTTOBJ(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file, line %d: TTOBJ DTMF receive channel %d is not valid.\n",
 			ps.line, r)
+
 		return true
 	}
 
@@ -4602,6 +4684,7 @@ func handleTTOBJ(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing transmit channel for TTOBJ command.\n", ps.line)
+
 		return true
 	}
 
@@ -4641,6 +4724,7 @@ func handleTTOBJ(ps *parseState) bool {
 				for _, c := range part {
 					if !unicode.IsDigit(c) && !strings.ContainsRune("aApPiIgG", c) {
 						isLegacy = false
+
 						break
 					}
 				}
@@ -4703,6 +4787,7 @@ func handleTTOBJ(ps *parseState) bool {
 			dw_printf("Config file, line %d: invalid via path.\n", ps.line)
 		}
 	}
+
 	return false
 }
 
@@ -4718,6 +4803,7 @@ func handleTTERR(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing message identifier for TTERR command.\n", ps.line)
+
 		return true
 	}
 
@@ -4725,6 +4811,7 @@ func handleTTERR(ps *parseState) bool {
 	for n := range TT_ERROR_MAXP1 {
 		if strings.EqualFold(t, ttErrorString(n)) {
 			msg_num = n
+
 			break
 		}
 	}
@@ -4739,6 +4826,7 @@ func handleTTERR(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing method (SPEECH, MORSE) for TTERR command.\n", ps.line)
+
 		return true
 	}
 
@@ -4752,6 +4840,7 @@ func handleTTERR(ps *parseState) bool {
 	if method != "MORSE" && method != "SPEECH" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Response method of %s must be SPEECH or MORSE for TTERR command.\n", ps.line, method)
+
 		return true
 	}
 
@@ -4759,6 +4848,7 @@ func handleTTERR(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing response text for TTERR command.\n", ps.line)
+
 		return true
 	}
 
@@ -4772,6 +4862,7 @@ func handleTTERR(ps *parseState) bool {
 	// TODO1.3: Need SSID too!
 
 	ps.tt.response[msg_num].mtext = t
+
 	return false
 }
 
@@ -4787,6 +4878,7 @@ func handleTTSTATUS(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing status number for TTSTATUS command.\n", ps.line)
+
 		return true
 	}
 
@@ -4795,6 +4887,7 @@ func handleTTSTATUS(ps *parseState) bool {
 	if status_num < 1 || status_num > 9 {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Status number for TTSTATUS command must be in range of 1 to 9.\n", ps.line)
+
 		return true
 	}
 
@@ -4802,6 +4895,7 @@ func handleTTSTATUS(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing status text for TTSTATUS command.\n", ps.line)
+
 		return true
 	}
 
@@ -4811,6 +4905,7 @@ func handleTTSTATUS(ps *parseState) bool {
 	t = strings.TrimSpace(t)
 
 	ps.tt.status[status_num] = t
+
 	return false
 }
 
@@ -4826,10 +4921,12 @@ func handleTTCMD(ps *parseState) bool {
 	if t == "" {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing command for TTCMD command.\n", ps.line)
+
 		return true
 	}
 
 	ps.tt.ttcmd = t
+
 	return false
 }
 
@@ -4930,6 +5027,7 @@ func handleIGLOGIN(ps *parseState) bool {
 	}
 
 	ps.igate.t2_passcode = t
+
 	return false
 }
 
@@ -4984,6 +5082,7 @@ func handleIGTXVIA(ps *parseState) bool {
 		   #endif
 		*/
 	}
+
 	return false
 }
 
@@ -5016,6 +5115,7 @@ func handleIGFILTER(ps *parseState) bool {
 		dw_printf("The default behavior is appropriate for most situations.\n")
 		dw_printf("Please read \"Successful-APRS-IGate-Operation.pdf\".\n")
 	}
+
 	return false
 }
 
@@ -5069,6 +5169,7 @@ func handleIGTXLIMIT(ps *parseState) bool {
 			ps.line, ps.igate.tx_limit_5)
 		dw_printf("You won't make friends by setting a limit this high.\n")
 	}
+
 	return false
 }
 
@@ -5096,6 +5197,7 @@ func handleIGMSP(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Missing number of times for message sender position.  Using default 1.\n", ps.line)
 	}
+
 	return false
 }
 
@@ -5123,6 +5225,7 @@ func handleSATGATE(ps *parseState) bool {
 	} else {
 		ps.igate.satgate_delay = DEFAULT_SATGATE_DELAY
 	}
+
 	return false
 }
 
@@ -5170,6 +5273,7 @@ func handleAGWPORT(ps *parseState) bool {
 		dw_printf("Line %d: Invalid port number for AGW TCPIP Socket Interface. Using %d.\n",
 			ps.line, ps.misc.agwpe_port)
 	}
+
 	return false
 }
 
@@ -5264,6 +5368,7 @@ func handleKISSPORT(ps *parseState) bool {
 			dw_printf("Line %d: Too many KISSPORT commands.\n", ps.line)
 		}
 	}
+
 	return false
 }
 
@@ -5307,6 +5412,7 @@ func handleNULLMODEM(ps *parseState) bool {
 
 		ps.misc.kiss_serial_speed = n
 	}
+
 	return false
 }
 
@@ -5332,6 +5438,7 @@ func handleSERIALKISSPOLL(ps *parseState) bool {
 		ps.misc.kiss_serial_speed = 0
 		ps.misc.kiss_serial_poll = 1 // set polling.
 	}
+
 	return false
 }
 
@@ -5342,6 +5449,7 @@ func handleKISSCOPY(ps *parseState) bool {
 	 *			  This does not apply to pseudo terminal KISS.
 	 */
 	ps.misc.kiss_copy = true
+
 	return false
 }
 
@@ -5368,6 +5476,7 @@ func handleDNSSD(ps *parseState) bool {
 	} else {
 		ps.misc.dns_sd_enabled = n != 0
 	}
+
 	return false
 }
 
@@ -5382,6 +5491,7 @@ func handleDNSSDNAME(ps *parseState) bool {
 	} else {
 		ps.misc.dns_sd_name = t
 	}
+
 	return false
 }
 
@@ -5414,6 +5524,7 @@ func handleGPSNMEA(ps *parseState) bool {
 	} else {
 		ps.misc.gpsnmea_speed = 4800 // The standard at one time.
 	}
+
 	return false
 }
 
@@ -5534,6 +5645,7 @@ func handleWAYPOINT(ps *parseState) bool {
 			dw_printf("Config file: Invalid output format '%c' for WAYPOINT on line %d.\n", c, ps.line)
 		}
 	}
+
 	return false
 }
 
@@ -5563,6 +5675,7 @@ func handleLOGDIR(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file: LOGDIR on line %d should have directory path and nothing more.\n", ps.line)
 	}
+
 	return false
 }
 
@@ -5592,6 +5705,7 @@ func handleLOGFILE(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Config file: LOGFILE on line %d should have file name and nothing more.\n", ps.line)
 	}
+
 	return false
 }
 
@@ -5605,6 +5719,7 @@ func handleBEACON(ps *parseState) bool {
 	text_color_set(DW_COLOR_ERROR)
 	dw_printf("Config file, line %d: Old style 'BEACON' has been replaced with new commands.\n", ps.line)
 	dw_printf("Use PBEACON, OBEACON, TBEACON, or CBEACON instead.\n")
+
 	return false
 }
 
@@ -5652,6 +5767,7 @@ func handleXBEACON(ps *parseState) bool {
 
 		return true
 	}
+
 	return false
 }
 
@@ -5749,6 +5865,7 @@ func handleFRACK(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Invalid FRACK time. Using default %d.\n", ps.line, ps.misc.frack)
 	}
+
 	return false
 }
 
@@ -5772,6 +5889,7 @@ func handleRETRY(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Invalid RETRY number. Using default %d.\n", ps.line, ps.misc.retry)
 	}
+
 	return false
 }
 
@@ -5795,6 +5913,7 @@ func handlePACLEN(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Invalid PACLEN value. Using default %d.\n", ps.line, ps.misc.paclen)
 	}
+
 	return false
 }
 
@@ -5823,6 +5942,7 @@ func handleMAXFRAME(ps *parseState) bool {
 		dw_printf("Line %d: Invalid MAXFRAME value outside range of %d to %d. Using default %d.\n",
 			ps.line, AX25_K_MAXFRAME_BASIC_MIN, AX25_K_MAXFRAME_BASIC_MAX, ps.misc.maxframe_basic)
 	}
+
 	return false
 }
 
@@ -5849,6 +5969,7 @@ func handleEMAXFRAME(ps *parseState) bool {
 		dw_printf("Line %d: Invalid EMAXFRAME value outside of range %d to %d. Using default %d.\n",
 			ps.line, AX25_K_MAXFRAME_EXTENDED_MIN, AX25_K_MAXFRAME_EXTENDED_MAX, ps.misc.maxframe_extended)
 	}
+
 	return false
 }
 
@@ -5872,6 +5993,7 @@ func handleMAXV22(ps *parseState) bool {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Line %d: Invalid MAXV22 number. Will use half of RETRY.\n", ps.line)
 	}
+
 	return false
 }
 
@@ -5906,6 +6028,7 @@ func handleV20(ps *parseState) bool {
 
 		t = split("", false)
 	}
+
 	return false
 }
 
@@ -5941,6 +6064,7 @@ func handleNOXID(ps *parseState) bool {
 
 		t = split("", false)
 	}
+
 	return false
 }
 

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -249,6 +249,7 @@ func decode_aprs(pp *packet_t, quiet bool, third_party_src string) *decode_aprs_
 
 	if len(pinfo) == 0 {
 		A.g_data_type_desc = "AX.25 UI frame with empty information field"
+
 		return A
 	}
 
@@ -1249,11 +1250,13 @@ func mic_e_digit(A *decode_aprs_t, c byte, mask int, std_msg *int, cust_msg *int
 
 	if c >= 'A' && c <= 'J' {
 		*cust_msg |= mask
+
 		return int(c - 'A')
 	}
 
 	if c >= 'P' && c <= 'Y' {
 		*std_msg |= mask
+
 		return int(c - 'P')
 	}
 
@@ -1263,6 +1266,7 @@ func mic_e_digit(A *decode_aprs_t, c byte, mask int, std_msg *int, cust_msg *int
 
 	if c == 'K' {
 		*cust_msg |= mask
+
 		return (0)
 	}
 
@@ -1272,6 +1276,7 @@ func mic_e_digit(A *decode_aprs_t, c byte, mask int, std_msg *int, cust_msg *int
 
 	if c == 'Z' {
 		*std_msg |= mask
+
 		return (0)
 	}
 
@@ -1514,6 +1519,7 @@ func aprs_mic_e(A *decode_aprs_t, pp *packet_t, info []byte) {
 	if len(info) <= sizeof_struct_aprs_mic_e_s {
 		// Too short for a comment.  We are finished.
 		A.g_mfr = "UNKNOWN vendor/model"
+
 		return
 	}
 
@@ -1526,6 +1532,7 @@ func aprs_mic_e(A *decode_aprs_t, pp *packet_t, info []byte) {
 		if len(mcomment) == 0 {
 			// Nothing left after removing trailing CR.
 			A.g_mfr = "UNKNOWN vendor/model"
+
 			return
 		}
 	}
@@ -2547,6 +2554,7 @@ func aprs_user_defined(A *decode_aprs_t, info []byte) {
 
 			if aisData == nil {
 				A.g_data_type_desc = "AIS"
+
 				return
 			}
 		}
@@ -3738,12 +3746,14 @@ func directivityString(d int) (string, error) {
 	if d < 0 || d >= len(dirs) {
 		return "", fmt.Errorf("directivity index %d out of range [0,%d]", d, len(dirs)-1)
 	}
+
 	return dirs[d], nil
 }
 
 func data_extension_comment(A *decode_aprs_t, pdext []byte) bool { //nolint:unparam
 	if len(pdext) < 7 {
 		A.g_comment = string(pdext)
+
 		return false
 	}
 
@@ -3754,6 +3764,7 @@ func data_extension_comment(A *decode_aprs_t, pdext []byte) bool { //nolint:unpa
 		pdext[4] == 'C' {
 		/* not decoded at this time */
 		process_comment(A, pdext[7:])
+
 		return true
 	}
 
@@ -4024,6 +4035,7 @@ func process_comment(A *decode_aprs_t, commentData []byte) {
 
 	var atof = func(b []byte) float64 {
 		var f, _ = strconv.ParseFloat(string(b), 64)
+
 		return float64(f)
 	}
 
@@ -4116,6 +4128,7 @@ func process_comment(A *decode_aprs_t, commentData []byte) {
 			for i := range NUM_CTCSS {
 				if f == i_ctcss[i] {
 					A.g_tone = f_ctcss[i]
+
 					break
 				}
 			}

--- a/src/decode_aprs_main.go
+++ b/src/decode_aprs_main.go
@@ -78,6 +78,7 @@ func DecodeAPRSMain() {
 		if len(line) == 0 || strings.HasPrefix(line, "#") {
 			/* comment or blank line */
 			fmt.Printf("%s\n", line)
+
 			continue
 		}
 
@@ -113,6 +114,7 @@ func DecodeAPRSLine(line string) {
 		if bytes[0] == FEND {
 			if len(bytes) < 2 || bytes[1] != 0 {
 				fmt.Printf("Was expecting to find 00 after the initial C0.\n")
+
 				return
 			}
 

--- a/src/dedupe.go
+++ b/src/dedupe.go
@@ -120,6 +120,7 @@ type DedupeService struct {
 func NewDedupeService(ttl time.Duration) *DedupeService {
 	var ds = new(DedupeService)
 	ds.historyTime = ttl
+
 	return ds
 }
 

--- a/src/deviceid.go
+++ b/src/deviceid.go
@@ -97,6 +97,7 @@ func NewDeviceIDData() *DeviceIDData {
 		fp, err = os.Open(location) //nolint:gosec // G304: location comes from hardcoded search_locations (allowlisted search paths), not user input
 		if err == nil {
 			defer fp.Close()
+
 			break
 		}
 	}
@@ -117,6 +118,7 @@ func NewDeviceIDData() *DeviceIDData {
 	var data, readErr = io.ReadAll(fp)
 	if readErr != nil {
 		dw_printf("Error reading deviceid file %s: %s\n", fp.Name(), readErr)
+
 		return d
 	}
 
@@ -128,6 +130,7 @@ func NewDeviceIDData() *DeviceIDData {
 	var unmarshallErr = yaml.Unmarshal(data, &deviceidConfig)
 	if unmarshallErr != nil {
 		dw_printf("Error parsing deviceid file %s: %s\n", fp.Name(), unmarshallErr)
+
 		return d
 	}
 

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -1027,6 +1027,7 @@ func app_process_rec_packet(channel int, subchan int, slice int, pp *packet_t, a
 		for _, r := range pinfo {
 			if !unicode.IsPrint(rune(r)) {
 				hasNonPrintable = true
+
 				break
 			}
 		}

--- a/src/dwgpsnmea.go
+++ b/src/dwgpsnmea.go
@@ -384,6 +384,7 @@ func dwgpsnmea_gprmc(sentence string, quiet bool) *GPRMCResult {
 	sentence, err := remove_checksum(sentence, quiet)
 	if err != nil {
 		result.Fix = DWFIX_ERROR
+
 		return result
 	}
 
@@ -412,6 +413,7 @@ func dwgpsnmea_gprmc(sentence string, quiet bool) *GPRMCResult {
 	if pstatus != "" && len(pstatus) == 1 {
 		if pstatus != "A" {
 			result.Fix = DWFIX_NO_FIX
+
 			return result /* Not "Active." Don't parse. */
 		}
 	} else {
@@ -533,6 +535,7 @@ func dwgpsnmea_gpgga(sentence string, quiet bool) *GPGGAResult {
 	sentence, err := remove_checksum(sentence, quiet)
 	if err != nil {
 		result.Fix = DWFIX_ERROR
+
 		return result
 	}
 
@@ -569,6 +572,7 @@ func dwgpsnmea_gpgga(sentence string, quiet bool) *GPGGAResult {
 	if len(pfix) == 1 {
 		if pfix == "0" {
 			result.Fix = DWFIX_NO_FIX /* No Fix. Don't parse the rest. */
+
 			return result
 		}
 	} else {

--- a/src/fx25_extract.go
+++ b/src/fx25_extract.go
@@ -104,6 +104,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 		// if syndrome is zero, data[] is a codeword and there are no
 		// errors to correct. So return data[] unmodified
 		count = 0
+
 		goto finish
 	}
 
@@ -270,6 +271,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 		// deg(lambda) unequal to number of roots => uncorrectable
 		// error detected
 		count = -1
+
 		goto finish
 	}
 	// Compute err+eras evaluator poly omega(x) = s(x)*lambda(x) (modulo
@@ -324,6 +326,7 @@ func decode_rs_char(rs *rs_t, data []byte, eras_pos []int, no_eras int) int {
 			// fprintf(stderr,"\n ERROR: denominator = 0\n");
 			// #endif
 			count = -1
+
 			goto finish
 		}
 		// Apply error to data

--- a/src/fx25_init.go
+++ b/src/fx25_init.go
@@ -227,21 +227,25 @@ func fx25_get_rs(ctag_num int) *rs_t {
 
 func fx25_get_ctag_value(ctag_num int) uint64 {
 	Assert(ctag_num >= CTAG_MIN && ctag_num <= CTAG_MAX)
+
 	return tags[ctag_num].value
 }
 
 func fx25_get_k_data_radio(ctag_num int) int {
 	Assert(ctag_num >= CTAG_MIN && ctag_num <= CTAG_MAX)
+
 	return tags[ctag_num].k_data_radio
 }
 
 func fx25_get_k_data_rs(ctag_num int) int {
 	Assert(ctag_num >= CTAG_MIN && ctag_num <= CTAG_MAX)
+
 	return tags[ctag_num].k_data_rs
 }
 
 func fx25_get_nroots(ctag_num int) int {
 	Assert(ctag_num >= CTAG_MIN && ctag_num <= CTAG_MAX)
+
 	return int(fx25Tab[tags[ctag_num].itab].nroots)
 }
 

--- a/src/gen_packets.go
+++ b/src/gen_packets.go
@@ -102,6 +102,7 @@ var genPacketsRandSeed int32 = 1
 // Yep, if seed is 1, tests pass; if seed is 2, test96f64 decodes 68 not 71+; if seed is 3 then test96f16 decodes 62 not 63+ /KG
 func genPacketsRand() int32 {
 	genPacketsRandSeed = int32((uint32(genPacketsRandSeed)*1103515245 + 12345) & MY_RAND_MAX)
+
 	return genPacketsRandSeed
 }
 

--- a/src/hdlc_rec.go
+++ b/src/hdlc_rec.go
@@ -229,6 +229,7 @@ func (s *hdlcState) recEasBit(raw int, future_use int) { //nolint:unparam
 				   #endif
 				*/
 				s.easGathering = false
+
 				return
 			}
 
@@ -239,6 +240,7 @@ func (s *hdlcState) recEasBit(raw int, future_use int) { //nolint:unparam
 					#endif
 				*/
 				s.easGathering = false
+
 				return
 			}
 
@@ -414,6 +416,7 @@ func (r *HDLCReceiver) RecBitNew(channel int, subchannel int, slice int, _raw in
 
 	if r.audio.achan[channel].modem_type == MODEM_EAS {
 		s.recEasBit(IfThenElse(raw, 1, 0), not_used_remove)
+
 		return
 	}
 
@@ -771,6 +774,7 @@ func (r *HDLCReceiver) DataDetectAny(channel int) int {
 
 func (r *HDLCReceiver) rand() int32 {
 	r.randSeed = int32((uint32(r.randSeed)*1103515245)+12345) & hdlcRecRandMax
+
 	return r.randSeed
 }
 

--- a/src/hdlc_rec2.go
+++ b/src/hdlc_rec2.go
@@ -242,6 +242,7 @@ func hdlc_rec2_block(block *rrbb_t) {
 		#endif
 		*/
 		rrbb_delete(block)
+
 		return
 	}
 
@@ -251,6 +252,7 @@ func hdlc_rec2_block(block *rrbb_t) {
 	 */
 	if try_to_fix_quick_now(block, channel, subchan, slice, alevel) {
 		rrbb_delete(block)
+
 		return
 	}
 
@@ -759,7 +761,8 @@ func try_decode(block *rrbb_t, channel int, subchan int, slice int, alevel ALeve
 				//text_color_set(DW_COLOR_ERROR);
 				//dw_printf ("ATTEMPTING PASSALL PROCESSING\n");
 				multi_modem_process_rec_frame(channel, subchan, slice, H2.frame_buf[:H2.frame_len-2], alevel, RETRY_MAX, 0) /* len-2 to remove FCS. */
-				return true                                                                                                 /* success */
+
+				return true /* success */
 			} else {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("try_decode: internal error passall = %t, retry_conf_retry = %d, retry_conf_type = %d\n",

--- a/src/igate.go
+++ b/src/igate.go
@@ -540,6 +540,7 @@ func igate_send_rec_packet(channel int, recv_pp *packet_t) {
 		var inner_pp = ax25_unwrap_third_party(pp)
 		if inner_pp == nil {
 			AX25Delete(pp)
+
 			return
 		}
 
@@ -1378,6 +1379,7 @@ func maybe_xmit_packet_from_igate(message []byte, to_chan int) {
 				// Previously there was a debug message here about the packet being dropped by filtering.
 				// This is now handled better by the "-df" command line option for filtering details.
 				AX25Delete(pp3)
+
 				return
 			}
 		}

--- a/src/il2p_codec.go
+++ b/src/il2p_codec.go
@@ -62,6 +62,7 @@ func il2p_encode_frame(pp *packet_t, max_fec int, crc ...bool) ([]byte, int) {
 				var crcBytes = il2p_crc_encode(il2p_crc_calc(ax25_get_frame_data(pp)))
 				outbuf.Write(crcBytes[:])
 			}
+
 			return outbuf.Bytes(), outbuf.Len()
 		}
 
@@ -182,6 +183,7 @@ func il2p_decode_frame(irec []byte) *packet_t {
 				dw_printf("IL2P trailing CRC mismatch.\n")
 			}
 			AX25Delete(pp)
+
 			return nil
 		}
 	}
@@ -225,6 +227,7 @@ func il2p_decode_header_payload(uhdr []byte, epayload []byte, symbols_corrected 
 
 			if e <= 0 {
 				AX25Delete(pp)
+
 				return nil
 			}
 

--- a/src/il2p_crc.go
+++ b/src/il2p_crc.go
@@ -77,6 +77,7 @@ func il2p_crc_encode(crc uint16) [IL2P_CRC_ENCODED_SIZE]byte {
 	encoded[1] = il2p_hamming_encode[(crc>>8)&0x0f]
 	encoded[2] = il2p_hamming_encode[(crc>>4)&0x0f]
 	encoded[3] = il2p_hamming_encode[crc&0x0f]
+
 	return encoded
 }
 
@@ -97,6 +98,7 @@ func il2p_crc_decode(encoded []byte) uint16 {
 	var n1 = uint16(il2p_hamming_decode[encoded[1]&0x7f])
 	var n2 = uint16(il2p_hamming_decode[encoded[2]&0x7f])
 	var n3 = uint16(il2p_hamming_decode[encoded[3]&0x7f])
+
 	return (n0 << 12) | (n1 << 8) | (n2 << 4) | n3
 }
 
@@ -116,6 +118,7 @@ func il2p_crc_decode(encoded []byte) uint16 {
 func il2p_crc_check(frame_data []byte, encoded_crc []byte) bool {
 	var expected = il2p_crc_calc(frame_data)
 	var received = il2p_crc_decode(encoded_crc)
+
 	return expected == received
 }
 
@@ -135,5 +138,6 @@ func il2p_crc_enabled(channel int) bool {
 	if save_audio_config_p == nil {
 		return true // Default to enabled if no config available.
 	}
+
 	return save_audio_config_p.achan[channel].il2p_crc
 }

--- a/src/il2p_test_util.go
+++ b/src/il2p_test_util.go
@@ -83,6 +83,7 @@ func multi_modem_process_rec_packet(channel int, subchannel int, slice int, pp *
 
 func demod_get_audio_level_fake(channel int, subchannel int) ALevel {
 	var alevel ALevel
+
 	return (alevel)
 }
 

--- a/src/kiss.go
+++ b/src/kiss.go
@@ -405,6 +405,7 @@ func kisspt_get() (byte, error) {
 			pt_master = nil
 
 			os.Remove(TMP_KISSTNC_SYMLINK)
+
 			return 0, err
 		}
 	}

--- a/src/kissnet.go
+++ b/src/kissnet.go
@@ -597,6 +597,7 @@ func (kns *KissNetService) connectListenThread(kps *kissport_status_s) {
 			var conn, acceptErr = listener.Accept()
 			if acceptErr != nil {
 				dw_printf("Accept failed: %v\n", acceptErr)
+
 				continue
 			}
 

--- a/src/ptt.go
+++ b/src/ptt.go
@@ -1228,6 +1228,7 @@ func get_input_real(it int, channel int) int {
 		var v, parseErr = strconv.Atoi(string(vtemp))
 		if parseErr != nil {
 			dw_printf("Error parsing return value (%s) from GPIO %d: %s\n", vtemp, save_audio_config_p.achan[channel].ictrl[it].in_gpio_num, parseErr)
+
 			return -1
 		}
 

--- a/src/ptt_test.go
+++ b/src/ptt_test.go
@@ -16,11 +16,13 @@ type mockGPIODLine struct {
 
 func (m *mockGPIODLine) SetValue(v int) error {
 	m.value = v
+
 	return nil
 }
 
 func (m *mockGPIODLine) Close() error {
 	m.closed = true
+
 	return nil
 }
 

--- a/src/server.go
+++ b/src/server.go
@@ -295,6 +295,7 @@ func agwConnectedModeAllowed(portx byte) bool {
 		return int(portx) < MAX_RADIO_CHANS
 	}
 	var m = save_audio_config_p.chan_medium[portx]
+
 	return m == MEDIUM_RADIO || m == MEDIUM_NETTNC
 }
 
@@ -408,6 +409,7 @@ func server_connect_listen_thread(server_port int) {
 			var conn, acceptErr = listener.Accept()
 			if acceptErr != nil {
 				dw_printf("Accept failed: %v\n", acceptErr)
+
 				continue
 			}
 
@@ -1183,6 +1185,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 			if len(cmd.Data) < 1 {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("AGW 'V' message too short to contain digipeater count.\n")
+
 				break
 			}
 
@@ -1191,6 +1194,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 			if len(cmd.Data) < 1+10*ndigi {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("AGW 'V' message too short for %d digipeaters.\n", ndigi)
+
 				break
 			}
 
@@ -1266,6 +1270,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 			if cmd.Header.DataLen < 1 || int(cmd.Header.DataLen) > len(cmd.Data) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("AGW 'K' message has invalid data length %d.\n", cmd.Header.DataLen)
+
 				break
 			}
 
@@ -1349,6 +1354,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 			if !agwConnectedModeAllowed(cmd.Header.Portx) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("AGW connect command on unsupported channel %d ignored.\n", cmd.Header.Portx)
+
 				break
 			}
 			/*
@@ -1373,6 +1379,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("\n")
 					dw_printf("AGW client, connect via, has invalid payload: too short\n")
+
 					break
 				}
 
@@ -1390,6 +1397,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 						text_color_set(DW_COLOR_ERROR)
 						dw_printf("\n")
 						dw_printf("AGW client, connect via, payload too short for %d digipeaters.\n", numDigi)
+
 						break
 					}
 
@@ -1401,6 +1409,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("\n")
 					dw_printf("AGW client, connect via, has invalid number of digipeaters = %d\n", numDigi)
+
 					break
 				}
 			}
@@ -1413,12 +1422,14 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 			if !agwConnectedModeAllowed(cmd.Header.Portx) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("AGW 'D' command on unsupported channel %d ignored.\n", cmd.Header.Portx)
+
 				break
 			}
 
 			if int(cmd.Header.DataLen) > len(cmd.Data) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("AGW 'D' message has invalid data length %d.\n", cmd.Header.DataLen)
+
 				break
 			}
 
@@ -1436,6 +1447,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 			if !agwConnectedModeAllowed(cmd.Header.Portx) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("AGW 'd' command on unsupported channel %d ignored.\n", cmd.Header.Portx)
+
 				break
 			}
 
@@ -1495,6 +1507,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 			if pp == nil {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("Failed to create frame from AGW 'M' message.\n")
+
 				break
 			}
 
@@ -1572,6 +1585,7 @@ func handleClientCommand(client int, cmd *AGWPEMessage) {
 			if !agwConnectedModeAllowed(cmd.Header.Portx) {
 				text_color_set(DW_COLOR_ERROR)
 				dw_printf("AGW 'Y' command on unsupported channel %d ignored.\n", cmd.Header.Portx)
+
 				break
 			}
 

--- a/src/server_impl_test.go
+++ b/src/server_impl_test.go
@@ -27,6 +27,7 @@ func readReplyFrom(conn net.Conn) (*AGWPEMessage, error) {
 			return nil, err
 		}
 	}
+
 	return msg, nil
 }
 
@@ -41,6 +42,7 @@ func setupClientPipe(t *testing.T) net.Conn {
 		client.Close()
 		client_sock[0] = nil
 	})
+
 	return client
 }
 
@@ -53,6 +55,7 @@ func asyncReply(conn net.Conn) <-chan *AGWPEMessage {
 		msg, _ := readReplyFrom(conn)
 		ch <- msg
 	}()
+
 	return ch
 }
 
@@ -240,6 +243,7 @@ func dlqAppended(f func()) *dlq_item_t {
 	var newItem = dlq_queue_head
 	dlq_queue_head = savedHead
 	dlq_mutex.Unlock()
+
 	return newItem
 }
 

--- a/src/symbols.go
+++ b/src/symbols.go
@@ -620,6 +620,7 @@ func (sd *APRSSymbolData) symbols_from_dest_or_src(dti byte, src string, dest st
 			var ssid, _ = strconv.Atoi(ssidStr)
 			if ssid >= 1 && ssid <= 15 {
 				var sts = ssidToSym()
+
 				return '/', sts[ssid], true // All in Primary table
 			}
 		}
@@ -656,6 +657,7 @@ func (sd *APRSSymbolData) symbols_into_dest(symtab byte, symbol byte) (string, b
 	} else if symbol >= '!' && symbol <= '~' && (unicode.IsUpper(rune(symtab)) || unicode.IsDigit(rune(symtab))) {
 		/* Alternate Symbol table with overlay. */
 		var at = alternateSymtab()
+
 		return fmt.Sprintf("GPS%s%c", at[symbol-' '].xy, symtab), true
 	}
 
@@ -708,6 +710,7 @@ func (sd *APRSSymbolData) symbols_get_description(symtab byte, symbol byte) stri
 		symbol = ' '
 
 		var pt = primarySymtab()
+
 		return pt[symbol-' '].description
 	}
 

--- a/src/tq.go
+++ b/src/tq.go
@@ -409,6 +409,7 @@ func lm_data_request(channel int, prio int, pp *packet_t) {
 	if channel >= 0 && channel < MAX_TOTAL_CHANS && save_audio_config_p.chan_medium[channel] == MEDIUM_NETTNC {
 		// For NETTNC channels, just yeet out the packet and let the external TNC handle it - we don't have enough info to do much else
 		tq_append(channel, prio, pp)
+
 		return
 	}
 
@@ -555,6 +556,7 @@ func lm_seize_request(channel int) {
 		// MEDIUM_NETTNC: no internal modem to seize; confirm the channel immediately.
 		// See lm_data_request for the rationale for allowing MEDIUM_NETTNC.
 		dlq_seize_confirm(channel)
+
 		return
 	}
 

--- a/src/tt_user.go
+++ b/src/tt_user.go
@@ -265,6 +265,7 @@ func find_avail() int {
 	for i := range MAX_TT_USERS {
 		if tt_user[i].callsign == "" {
 			clear_user(i)
+
 			return (i)
 		}
 	}
@@ -725,6 +726,7 @@ func xmit_object_report(i int, first_time bool) {
 
 	if TT_TESTS_RUNNING {
 		dw_printf("---> %s\n\n", stemp)
+
 		return
 	}
 

--- a/src/xmit.go
+++ b/src/xmit.go
@@ -955,6 +955,7 @@ func xmit_speak_it(script string, c int, msg string) error {
 func (xs *XmitService) timestampPrefix() string {
 	if xs.p_modem.timestamp_format != "" {
 		var formattedTime, _ = strftime.Format(xs.p_modem.timestamp_format, time.Now())
+
 		return " " + formattedTime // space after channel.
 	}
 


### PR DESCRIPTION
🤖 Reenables the `nlreturn` linter, which was previously disabled due to false positives on ported C code. `golangci-lint --fix` resolved all 249 findings by adding blank lines before `return`/`break`/`continue`/`goto` statements — no logic changes.

## Test plan
- [x] `make fix`
- [x] `make check`
- [x] `make test`