### PR TITLE
test: Reenable godoclint linter and satisfy it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - "forbidigo"  # fmt.Print* are fine for now
     - "funlen"  # We have inherited lots of long lines
     - "gocyclo"  # One day
-    - "godoclint"  # There's lots to be done with documentation formatting, but not right now
     - "godot"  # Implicit full stops are ok
     - "godox"  # There will be TODOs
     - "maintidx"  # One day...

--- a/cmd/samoyed-appserver/main.go
+++ b/cmd/samoyed-appserver/main.go
@@ -633,7 +633,7 @@ func agw_cb_Y_outstanding_frames_for_station(channel byte, call_from Callsign, c
 	s.txQueueLen = frame_count
 } /* end agw_cb_Y_outstanding_frames_for_station */
 
-// strings.Cut for []bytes
+// BytesCut is strings.Cut for []bytes.
 func BytesCut(s []byte, b byte) ([]byte, []byte, bool) { //nolint:unparam
 	var i = bytes.Index(s, []byte{b})
 

--- a/src/agwpe.go
+++ b/src/agwpe.go
@@ -25,7 +25,7 @@ type AGWPEMessage struct {
 	Data   []byte
 }
 
-// binary.Write won't send variable-length slices, and I keep forgetting that, so...
+// Write sends msg to w. binary.Write won't send variable-length slices, and I keep forgetting that, so...
 func (msg *AGWPEMessage) Write(w io.Writer, order binary.ByteOrder) (int, error) {
 	var headerErr = binary.Write(w, order, msg.Header)
 	if headerErr != nil {

--- a/src/aprs_tt.go
+++ b/src/aprs_tt.go
@@ -1131,7 +1131,7 @@ func (g *TTGateway) parseAprstt3Call(state *ttParseState, e string) int {
  *
  *----------------------------------------------------------------*/
 
-/* R_M is the average radius of earth in meters. */
+// R_M is the average radius of earth in meters.
 const R_M = 6371000.0
 
 func (g *TTGateway) parseLocation(state *ttParseState, e string) int {

--- a/src/atest.go
+++ b/src/atest.go
@@ -1,4 +1,5 @@
-/* Test fixture for the Dire Wolf demodulators */
+// Test fixture for the Dire Wolf demodulators.
+
 //nolint:gochecknoglobals
 package direwolf
 

--- a/src/audio.go
+++ b/src/audio.go
@@ -476,9 +476,9 @@ const UDP_AUDIO_OUT_BUF_MAXLEN = 1472
 
 const DEFAULT_NUM_CHANNELS = 1
 const DEFAULT_SAMPLES_PER_SEC = 44100 /* Very early observations.  Might no longer be valid. */
-/* 22050 works a lot better than 11025. */
-/* 44100 works a little better than 22050. */
-/* If you have a reasonable machine, use the highest rate. */
+// MIN_SAMPLES_PER_SEC : 22050 works a lot better than 11025.
+// 44100 works a little better than 22050.
+// If you have a reasonable machine, use the highest rate.
 const MIN_SAMPLES_PER_SEC = 8000
 
 //const MAX_SAMPLES_PER_SEC	48000	/* Originally 44100.  Later increased because */

--- a/src/ax25_link.go
+++ b/src/ax25_link.go
@@ -1023,10 +1023,8 @@ func dl_disconnect_request(E *dlq_item_t) {
 	}
 } /* end dl_disconnect_request */
 
-// Number of segments is ceiling( (datalen + 1 ) / (N1 - 1))
-
-// we add one to datalen for the original PID.
-// We subtract one from N1 for the segment identifier header.
+// DIVROUNDUP computes ceiling(a/b). Number of segments is ceiling( (datalen + 1 ) / (N1 - 1)):
+// we add one to datalen for the original PID, and subtract one from N1 for the segment identifier header.
 func DIVROUNDUP(a, b int) int {
 	return (a + b - 1) / b
 }
@@ -2303,8 +2301,8 @@ func i_frame(S *ax25_dlsm_t, cr cmdres_t, p int, nr int, ns int, pid int, info [
 	}
 } /* end i_frame */
 
-// The original spec always sent SABM and went to state 1.
-// I was thinking, why not use v2.2 instead of we were already connected with v2.2?
+// SABME_or_SABM picks the state to enter after connecting. The original spec always sent SABM
+// and went to state 1. I was thinking, why not use v2.2 instead of we were already connected with v2.2?
 // My version of establish_data_link combined the two original functions and
 // already uses SABME or SABM based on S.modulo.
 func SABME_or_SABM(S *ax25_dlsm_t) dlsm_state_e {

--- a/src/cm108_linux.go
+++ b/src/cm108_linux.go
@@ -186,7 +186,7 @@ type CM108Thing struct {
 	// This is what we use to match up audio and HID.
 }
 
-// Test for supported devices.
+// GOOD_DEVICE tests for supported devices.
 func GOOD_DEVICE(v, p int) bool {
 	return (v == CMEDIA_VID && ((p >= CMEDIA_PID1_MIN && p <= CMEDIA_PID1_MAX) || p == CMEDIA_PID_CM108AH ||
 		p == CMEDIA_PID_CM108AH_alt || p == CMEDIA_PID_CM108B || p == CMEDIA_PID_CM119A || p == CMEDIA_PID_CM119B)) ||

--- a/src/pll_dcd.go
+++ b/src/pll_dcd.go
@@ -47,7 +47,7 @@ type DCDConfig struct {
 	DCD_GOOD_WIDTH int
 }
 
-// These values are good for 1200 bps AFSK.
+// GenericDCDConfig returns values that are good for 1200 bps AFSK.
 // Might want to override for other modems.
 func GenericDCDConfig() *DCDConfig {
 	var c = new(DCDConfig)

--- a/src/testutils.go
+++ b/src/testutils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// AssertOutputContains runs command and asserts its stdout contains expectedOutputContains.
 // Note that any of the Dire Wolf colour formatting totally screws this for reasons I don't yet understand.
 // See also what happens if you pipe output to a pager...
 func AssertOutputContains(t *testing.T, command func(), expectedOutputContains string) {

--- a/src/text2tt.go
+++ b/src/text2tt.go
@@ -24,7 +24,7 @@ func checksum(tt string) int {
 	return (cs % 10)
 }
 
-// Utility program for testing the encoding.
+// Text2TTMain is a utility program for testing the encoding.
 func Text2TTMain() {
 	if len(os.Args) < 2 {
 		fmt.Printf("Supply text string on command line.\n")

--- a/src/tt2text.go
+++ b/src/tt2text.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// Utility program for testing the decoding.
+// TT2TextMain is a utility program for testing the decoding.
 func TT2TextMain() {
 	if len(os.Args) < 2 {
 		fmt.Printf("Supply button sequence on command line.\n")

--- a/src/util.go
+++ b/src/util.go
@@ -16,7 +16,7 @@ func SLEEP_SEC(s int) {
 	SLEEP_MS(s * 1000)
 }
 
-// Because sometimes it's really convenient to have C's ternary ?:
+// IfThenElse exists because sometimes it's really convenient to have C's ternary ?:.
 func IfThenElse[T any](x bool, a T, b T) T { //nolint:ireturn
 	if x {
 		return a
@@ -28,7 +28,7 @@ func IfThenElse[T any](x bool, a T, b T) T { //nolint:ireturn
 // MAX_NET_CLIENTS is used for both KISS and AGWPE
 const MAX_NET_CLIENTS = 3
 
-// There are several places where we deal with fixed-width byte arrays containing a string.
+// ByteArrayToString handles the several places where we deal with fixed-width byte arrays containing a string.
 // For C this was fine, because strings are null-terminated; for Go we want to explicitly drop trailing nulls.
 // This takes a slice because I didn't know how to make it take an arbitrary sized array, and didn't see the value.
 func ByteArrayToString(b []byte) string {
@@ -41,7 +41,7 @@ func dw_printf(format string, a ...any) (int, error) {
 	return fmt.Printf(format, a...)
 }
 
-// #define ACHAN2ADEV(n) ((n)>>1)
+// ACHAN2ADEV is `#define ACHAN2ADEV(n) ((n)>>1)`.
 func ACHAN2ADEV(n int) int {
 	return n >> 1
 }
@@ -50,7 +50,7 @@ func ADEVFIRSTCHAN(n int) int {
 	return n * 2
 }
 
-// #define DW_KNOTS_TO_MPH(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 1.15077945)
+// DW_KNOTS_TO_MPH is `#define DW_KNOTS_TO_MPH(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 1.15077945)`.
 func DW_KNOTS_TO_MPH(x float64) float64 {
 	if x == G_UNKNOWN {
 		return G_UNKNOWN
@@ -59,7 +59,7 @@ func DW_KNOTS_TO_MPH(x float64) float64 {
 	return x * 1.15077945
 }
 
-// #define DW_MPH_TO_KNOTS(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 0.868976)
+// DW_MPH_TO_KNOTS is `#define DW_MPH_TO_KNOTS(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 0.868976)`.
 func DW_MPH_TO_KNOTS(x float64) float64 {
 	if x == G_UNKNOWN {
 		return G_UNKNOWN
@@ -68,7 +68,7 @@ func DW_MPH_TO_KNOTS(x float64) float64 {
 	return x * 0.868976
 }
 
-// #define DW_METERS_TO_FEET(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 3.2808399)
+// DW_METERS_TO_FEET is `#define DW_METERS_TO_FEET(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 3.2808399)`.
 func DW_METERS_TO_FEET(x float64) float64 {
 	if x == G_UNKNOWN {
 		return G_UNKNOWN
@@ -77,7 +77,7 @@ func DW_METERS_TO_FEET(x float64) float64 {
 	return x * 3.2808399
 }
 
-// #define DW_FEET_TO_METERS(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 0.3048)
+// DW_FEET_TO_METERS is `#define DW_FEET_TO_METERS(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 0.3048)`.
 func DW_FEET_TO_METERS(x float64) float64 {
 	if x == G_UNKNOWN {
 		return G_UNKNOWN
@@ -86,7 +86,7 @@ func DW_FEET_TO_METERS(x float64) float64 {
 	return x * 0.3048
 }
 
-// #define DW_MILES_TO_KM(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 1.609344)
+// DW_MILES_TO_KM is `#define DW_MILES_TO_KM(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 1.609344)`.
 func DW_MILES_TO_KM(x float64) float64 {
 	if x == G_UNKNOWN {
 		return G_UNKNOWN
@@ -95,7 +95,7 @@ func DW_MILES_TO_KM(x float64) float64 {
 	return x * 1.609344
 }
 
-// #define DW_MBAR_TO_INHG(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 0.0295333727)
+// DW_MBAR_TO_INHG is `#define DW_MBAR_TO_INHG(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 0.0295333727)`.
 func DW_MBAR_TO_INHG(x float64) float64 {
 	if x == G_UNKNOWN {
 		return G_UNKNOWN
@@ -104,7 +104,7 @@ func DW_MBAR_TO_INHG(x float64) float64 {
 	return x * 0.0295333727
 }
 
-// #define DW_KM_TO_MILES(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 0.621371192)
+// DW_KM_TO_MILES is `#define DW_KM_TO_MILES(x) ((x) == G_UNKNOWN ? G_UNKNOWN : (x) * 0.621371192)`.
 func DW_KM_TO_MILES(x float64) float64 {
 	if x == G_UNKNOWN {
 		return G_UNKNOWN
@@ -121,7 +121,7 @@ func R2D(r float64) float64 {
 	return r * 180 / math.Pi
 }
 
-// Can't be "assert" because of conflicts with stretchr/testify/assert, but otherwise, it's compatible enough
+// Assert can't be named "assert" because of conflicts with stretchr/testify/assert, but otherwise, it's compatible enough.
 func Assert(t bool) {
 	if !t {
 		_, file, line, _ := runtime.Caller(1)

--- a/src/version.go
+++ b/src/version.go
@@ -8,13 +8,14 @@ import (
 
 var SAMOYED_VERSION string //nolint:gochecknoglobals // Set at build time via `-ldflags "-X 'github.com/doismellburning/samoyed/src.SAMOYED_VERSION=X'"`
 
-// A bunch of things, both Dire Wolf and APRS, seem to expect two-part single-digit versions.
+// MAJOR_VERSION and MINOR_VERSION exist because a bunch of things, both Dire Wolf and APRS,
+// seem to expect two-part single-digit versions.
 // This obviously doesn't interact well with my choice of CalVer...
 // TODO Figure out what to do with MAJOR_VERSION etc.
 const MAJOR_VERSION = 0
 const MINOR_VERSION = 0
 
-// Put in APRS destination field to identify the equipment used.
+// APP_TOCALL is put in APRS destination field to identify the equipment used.
 // Dire Wolf used APDW - "Assigned by WB4APR in tocalls.txt".
 // KG 2026-01-19: Nobody has assigned SMYD, but I figured it was better to differentiate sooner rather than later.
 const APP_TOCALL = "SMYD"
@@ -22,7 +23,7 @@ const APP_TOCALL = "SMYD"
 // For user-defined data format.
 // APRS protocol spec Chapter 18 and http://www.aprs.org/aprs11/expfmts.txt
 
-// KG 2026-01-19: Dire Wolf has D reserved per
+// USER_DEF_USER_ID : KG 2026-01-19: Dire Wolf has D reserved per
 // https://www.aprs.org/aprs11/expfmts.txt and there seems a lot less space for
 // me to comfortably just DIY like with APP_TOCALL (and S is already assigned).
 // So I'll stick with D for now as it seems the least-worst option.


### PR DESCRIPTION
## Summary
🤖 Re-enables the `godoclint` linter that was disabled in `.golangci.yml` and fixes the 27 flagged issues, mostly comments ported from the original C source that didn't lead with the Go symbol name they document (e.g. `DW_KNOTS_TO_MPH`, `MIN_SAMPLES_PER_SEC`). Also detaches `atest.go`'s file comment from the package declaration so there's a single canonical package-level godoc (in `direwolf.go`).

## Test plan
- [x] `make check` passes (vet, golangci-lint, shellcheck, reuse, go mod tidy)
- [x] `make test` passes