### PR TITLE
test: Reenable noctx linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - "maintidx"  # One day...
     - "mnd"  # I do not like magic numbers, but there are plenty inherited from upstream, so let's roll with them for now
     - "nakedret"  # Naked returns in long functions are kinda an ok tradeoff right now
-    - "noctx"  # One day I will learn what a Context is, but that is not today
     - "nonamedreturns"  # Named returns seem a useful tradeoff for now - several functions that return ("output") many things, and names help
     - "paralleltest"  # One day, but let's have *working* tests first
     - "prealloc"  # One day, but not now

--- a/cmd/samoyed-aclients/main.go
+++ b/cmd/samoyed-aclients/main.go
@@ -26,6 +26,7 @@ package main
  *---------------------------------------------------------------*/
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -184,7 +185,7 @@ func main() {
  *--------------------------------------------------------------------*/
 
 func client_thread_net(my_index int, hostname string, port string, description string, packetChan chan<- string) {
-	var conn, connErr = net.Dial("tcp4", net.JoinHostPort(hostname, port)) //nolint:gosec // G704: hostport should be provided by user-supplied config
+	var conn, connErr = new(net.Dialer).DialContext(context.Background(), "tcp4", net.JoinHostPort(hostname, port))
 	if connErr != nil {
 		fmt.Printf("Client %d unable to connect to %s on %s, port %s\n",
 			my_index, description, hostname, port)

--- a/cmd/samoyed-appserver/agwlib.go
+++ b/cmd/samoyed-appserver/agwlib.go
@@ -58,6 +58,7 @@ package main
  *---------------------------------------------------------------*/
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -136,7 +137,7 @@ func agwlib_init(host string, port string, init_func func() error) error {
 
 	var connErr error
 
-	s_tnc_sock, connErr = net.Dial("tcp4", net.JoinHostPort(host, port))
+	s_tnc_sock, connErr = new(net.Dialer).DialContext(context.Background(), "tcp4", net.JoinHostPort(host, port))
 	if connErr != nil {
 		return connErr
 	}
@@ -183,7 +184,7 @@ func tnc_listen_thread() {
 
 			var connErr error
 
-			s_tnc_sock, connErr = net.Dial("tcp4", net.JoinHostPort(s_tnc_host, s_tnc_port))
+			s_tnc_sock, connErr = new(net.Dialer).DialContext(context.Background(), "tcp4", net.JoinHostPort(s_tnc_host, s_tnc_port))
 			if connErr == nil {
 				fmt.Printf("Successfully reattached to network TNC.\n")
 

--- a/cmd/samoyed-kissutil/main.go
+++ b/cmd/samoyed-kissutil/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -417,7 +418,7 @@ func tnc_listen_net() {
 
 	// For the IGate we would loop around and try to reconnect if the TNC
 	// goes away.  We should probably do the same here.
-	var conn, connErr = net.Dial("tcp", net.JoinHostPort(hostname, port))
+	var conn, connErr = new(net.Dialer).DialContext(context.Background(), "tcp", net.JoinHostPort(hostname, port))
 	if connErr != nil {
 		fmt.Printf("Unable to connect to %s on port %s: %s\n", hostname, port, connErr)
 		os.Exit(1)

--- a/cmd/samoyed-tnctest/main.go
+++ b/cmd/samoyed-tnctest/main.go
@@ -39,6 +39,7 @@ $ ./tnctest localhost:5001=dw1 localhost:5002=dw2
 */
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -421,7 +422,7 @@ func tnc_thread_net(my_index int, hostname string, port string, description stri
 	/*
 	 * Connect to TNC server.
 	 */
-	var conn, connErr = net.Dial("tcp4", net.JoinHostPort(hostname, port)) //nolint:gosec // G704: hostport should be provided by user-supplied config
+	var conn, connErr = new(net.Dialer).DialContext(context.Background(), "tcp4", net.JoinHostPort(hostname, port))
 	if connErr != nil {
 		fmt.Printf("TNC %d unable to connect to %s on %s, port %s: %s\n",
 			my_index, description, hostname, port, connErr)

--- a/cmd/samoyed-ttcalc/main.go
+++ b/cmd/samoyed-ttcalc/main.go
@@ -24,6 +24,7 @@ package main
  *---------------------------------------------------------------*/
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -253,7 +254,7 @@ func calculator(str string) int {
  *---------------------------------------------------------------*/
 
 func connect_to_server(hostname string, port string) (net.Conn, error) {
-	var conn, connErr = net.Dial("tcp4", net.JoinHostPort(hostname, port))
+	var conn, connErr = new(net.Dialer).DialContext(context.Background(), "tcp4", net.JoinHostPort(hostname, port))
 	if connErr != nil {
 		return conn, connErr
 	}

--- a/src/aprs_tt.go
+++ b/src/aprs_tt.go
@@ -26,6 +26,7 @@ package direwolf
 // What do we call the parts separated by * key?  Field.
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os/exec"
@@ -1681,7 +1682,7 @@ func dw_run_cmd(cmd string, oneline int) ([]byte, error) {
 		cmd = strings.TrimSpace(cmd)
 	}
 
-	return exec.Command(cmd).Output()
+	return exec.CommandContext(context.Background(), cmd).Output()
 }
 
 /* end aprs_tt.c */

--- a/src/atest_test.go
+++ b/src/atest_test.go
@@ -2,6 +2,7 @@ package direwolf
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"os"
@@ -21,7 +22,7 @@ func Test_atest_basic_1(t *testing.T) {
 
 	var f = filepath.Join(tmpdir, "test1.wav")
 
-	var cmd = exec.Command("gen_packets", "-o", f) //nolint:gosec
+	var cmd = exec.CommandContext(context.Background(), "gen_packets", "-o", f) //nolint:gosec
 
 	var err = cmd.Run()
 	if err != nil {

--- a/src/audio.go
+++ b/src/audio.go
@@ -23,6 +23,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -1292,7 +1293,7 @@ func audio_open(pa *audio_s) int {
 				 * UDP output - dial to the specified host:port and send audio packets.
 				 */
 				var outAddr = audio_out_name[4:] // skip "udp:"
-				var udpOutConn, dialErr = net.Dial("udp", outAddr)
+				var udpOutConn, dialErr = new(net.Dialer).DialContext(context.Background(), "udp", outAddr)
 				if dialErr != nil {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Could not connect to UDP output address %s: %v\n", outAddr, dialErr)

--- a/src/audio_test.go
+++ b/src/audio_test.go
@@ -4,6 +4,7 @@
 package direwolf
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
@@ -206,14 +207,14 @@ func setupAdev0(t *testing.T) *adev_s {
 
 func Test_audioFlushReal_UDP_sendsBytes(t *testing.T) {
 	// Start a UDP listener to receive the audio output.
-	var listener, err = net.ListenPacket("udp", "127.0.0.1:0")
+	var listener, err = new(net.ListenConfig).ListenPacket(context.Background(), "udp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	defer listener.Close()
 
 	// Dial from the "transmitter" side.
 	var conn net.Conn
-	conn, err = net.Dial("udp", listener.LocalAddr().String())
+	conn, err = new(net.Dialer).DialContext(context.Background(), "udp", listener.LocalAddr().String())
 	require.NoError(t, err)
 
 	defer conn.Close()
@@ -315,13 +316,13 @@ func Test_audioFlushReal_UDP_emptyBuffer_isNoop(t *testing.T) {
 
 func Test_audioUDPSilenceKeepalive_chunkSizeAndCleanShutdown(t *testing.T) {
 	// Start a UDP listener to receive the keepalive silence.
-	var listener, err = net.ListenPacket("udp", "127.0.0.1:0")
+	var listener, err = new(net.ListenConfig).ListenPacket(context.Background(), "udp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	defer listener.Close()
 
 	var conn net.Conn
-	conn, err = net.Dial("udp", listener.LocalAddr().String())
+	conn, err = new(net.Dialer).DialContext(context.Background(), "udp", listener.LocalAddr().String())
 	require.NoError(t, err)
 
 	defer conn.Close()

--- a/src/axudp.go
+++ b/src/axudp.go
@@ -4,6 +4,7 @@
 package direwolf
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -178,7 +179,7 @@ func (b *AXUDPBridge) RunUDPListener() {
 
 // RunKISSServer accepts TCP connections from KISS clients.
 func (b *AXUDPBridge) RunKISSServer(kissPort int) {
-	var ln, listenErr = net.Listen("tcp", fmt.Sprintf(":%d", kissPort))
+	var ln, listenErr = new(net.ListenConfig).Listen(context.Background(), "tcp", fmt.Sprintf(":%d", kissPort))
 	if listenErr != nil {
 		fmt.Fprintf(os.Stderr, "samoyed-axudp: TCP listen on port %d: %v\n", kissPort, listenErr)
 		os.Exit(1)

--- a/src/axudp_test.go
+++ b/src/axudp_test.go
@@ -4,6 +4,7 @@
 package direwolf
 
 import (
+	"context"
 	"io"
 	"net"
 	"os"
@@ -477,13 +478,13 @@ func (c *singleReadConn) Read(b []byte) (int, error) {
 // processed before the loop exits, not silently dropped.
 func TestHandleKISSClientProcessesFinalReadBytes(t *testing.T) {
 	// Create a UDP socket pair: src is used by the bridge, dst receives frames.
-	var srcPkt, srcErr = net.ListenPacket("udp", "127.0.0.1:0")
+	var srcPkt, srcErr = new(net.ListenConfig).ListenPacket(context.Background(), "udp", "127.0.0.1:0")
 	if srcErr != nil {
 		t.Fatal(srcErr)
 	}
 	defer srcPkt.Close()
 
-	var dstPkt, dstErr = net.ListenPacket("udp", "127.0.0.1:0")
+	var dstPkt, dstErr = new(net.ListenConfig).ListenPacket(context.Background(), "udp", "127.0.0.1:0")
 	if dstErr != nil {
 		t.Fatal(dstErr)
 	}

--- a/src/igate.go
+++ b/src/igate.go
@@ -26,6 +26,7 @@ package direwolf
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -352,7 +353,7 @@ func connect_thread() {
 		 * Connect to IGate server if not currently connected.
 		 */
 		if igate_sock == nil {
-			var conn, connErr = net.Dial("tcp", net.JoinHostPort(server_name, strconv.Itoa(save_igate_config_p.t2_server_port)))
+			var conn, connErr = new(net.Dialer).DialContext(context.Background(), "tcp", net.JoinHostPort(server_name, strconv.Itoa(save_igate_config_p.t2_server_port)))
 			stats_connects++
 			stats_connect_at = time.Now()
 

--- a/src/kissnet.go
+++ b/src/kissnet.go
@@ -145,6 +145,7 @@ same direwolf instance.
 */
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"syscall"
@@ -551,7 +552,7 @@ func (kns *KissNetService) connectListenThread(kps *kissport_status_s) {
 		dw_printf("Binding to port %d ... \n", kps.tcp_port);
 	#endif
 	*/
-	var listener, listenErr = net.Listen("tcp", fmt.Sprintf(":%d", kps.tcp_port))
+	var listener, listenErr = new(net.ListenConfig).Listen(context.Background(), "tcp", fmt.Sprintf(":%d", kps.tcp_port))
 	if listenErr != nil {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("connectListenThread: Listen failed: %s", listenErr)

--- a/src/morse_decode_linux_test.go
+++ b/src/morse_decode_linux_test.go
@@ -1,6 +1,7 @@
 package direwolf
 
 import (
+	"context"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -56,7 +57,7 @@ func Test_Morse_Generate_Decode(t *testing.T) {
 
 	// Now decode
 
-	var cmd = exec.Command("morse2ascii", f) //nolint:gosec
+	var cmd = exec.CommandContext(context.Background(), "morse2ascii", f) //nolint:gosec
 
 	var output, outputErr = cmd.Output()
 

--- a/src/nettnc.go
+++ b/src/nettnc.go
@@ -9,6 +9,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"context"
 	"net"
 	"os"
 	"strconv"
@@ -123,7 +124,7 @@ func nettnc_attach(channel int, host string, port int) int {
 	nt.port = port
 	s_net_tncs[channel] = nt
 
-	var conn, connErr = net.Dial("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	var conn, connErr = new(net.Dialer).DialContext(context.Background(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if connErr == nil {
 		nt.setSock(conn)
 	} else {
@@ -178,7 +179,7 @@ func (nt *NetTNC) listenThread(channel int) {
 			// avoid confusion with the AX.25 connect.
 			dw_printf("Attempting to reattach to network TNC...\n")
 
-			var newConn, connErr = net.Dial("tcp", net.JoinHostPort(nt.host, strconv.Itoa(nt.port)))
+			var newConn, connErr = new(net.Dialer).DialContext(context.Background(), "tcp", net.JoinHostPort(nt.host, strconv.Itoa(nt.port)))
 			if connErr == nil {
 				nt.setSock(newConn)
 

--- a/src/server.go
+++ b/src/server.go
@@ -113,6 +113,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"net"
@@ -365,7 +366,7 @@ func server_connect_listen_thread(server_port int) {
 	    	dw_printf("Binding to port %d ... \n", server_port);
 	#endif
 	*/
-	var listener, listenErr = net.Listen("tcp", fmt.Sprintf(":%d", server_port))
+	var listener, listenErr = new(net.ListenConfig).Listen(context.Background(), "tcp", fmt.Sprintf(":%d", server_port))
 	if listenErr != nil {
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("connect_listen_thread: Listen failed: %s", listenErr)

--- a/src/waypoint.go
+++ b/src/waypoint.go
@@ -7,6 +7,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -68,7 +69,7 @@ func NewWaypointSender(mc *misc_config_s) (*WaypointSender, error) {
 	if udpRequested {
 		var addr = net.JoinHostPort(mc.waypoint_udp_hostname, strconv.Itoa(mc.waypoint_udp_portnum))
 
-		var conn, err = net.Dial("udp", addr)
+		var conn, err = new(net.Dialer).DialContext(context.Background(), "udp", addr)
 		if err != nil {
 			text_color_set(DW_COLOR_ERROR)
 			dw_printf("Couldn't create socket for waypoint send to %s: %s\n", addr, err)

--- a/src/waypoint_impl_test.go
+++ b/src/waypoint_impl_test.go
@@ -5,6 +5,7 @@ package direwolf
 // A failing test may thus be a problem with the test itself rather than any future changes...
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -154,7 +155,7 @@ func receiveUDP(t *testing.T, conn net.PacketConn) string {
 func setupUDPWaypoint(t *testing.T, formats int) (*WaypointSender, net.PacketConn) {
 	t.Helper()
 
-	var listener, err = net.ListenPacket("udp", "127.0.0.1:0")
+	var listener, err = new(net.ListenConfig).ListenPacket(context.Background(), "udp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	var mc = misc_config_s{ //nolint: exhaustruct
@@ -306,7 +307,7 @@ func TestWaypointSendAisWrongFormat(t *testing.T) {
 
 // TestWaypointDefaultFormats verifies that NewWaypointSender sets defaults when formats==0.
 func TestWaypointDefaultFormats(t *testing.T) {
-	var listener, err = net.ListenPacket("udp", "127.0.0.1:0")
+	var listener, err = new(net.ListenConfig).ListenPacket(context.Background(), "udp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	var mc = misc_config_s{ //nolint: exhaustruct
@@ -328,7 +329,7 @@ func TestWaypointDefaultFormats(t *testing.T) {
 
 // TestWaypointGarminImpliesNMEAGeneric verifies Garmin format forces NMEA generic.
 func TestWaypointGarminImpliesNMEAGeneric(t *testing.T) {
-	var listener, err = net.ListenPacket("udp", "127.0.0.1:0")
+	var listener, err = new(net.ListenConfig).ListenPacket(context.Background(), "udp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	var mc = misc_config_s{ //nolint: exhaustruct
@@ -350,7 +351,7 @@ func TestWaypointGarminImpliesNMEAGeneric(t *testing.T) {
 
 // TestWaypointTermClearsState verifies that Close resets the struct fields.
 func TestWaypointTermClearsState(t *testing.T) {
-	var listener, err = net.ListenPacket("udp", "127.0.0.1:0")
+	var listener, err = new(net.ListenConfig).ListenPacket(context.Background(), "udp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		listener.Close() //nolint:errcheck

--- a/src/xmit.go
+++ b/src/xmit.go
@@ -31,6 +31,7 @@ package direwolf
  *---------------------------------------------------------------*/
 
 import (
+	"context"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -936,7 +937,7 @@ func (xs *XmitService) xmit_speech(c int, pp *packet_t) {
 /* Broken out into separate function so configuration can validate it. */
 
 func xmit_speak_it(script string, c int, msg string) error {
-	var cmd = exec.Command(script, strconv.Itoa(c), msg) //nolint:gosec // Trust the user-supplied config
+	var cmd = exec.CommandContext(context.Background(), script, strconv.Itoa(c), msg) //nolint:gosec // Trust the user-supplied config
 
 	var err = cmd.Run()
 	if err != nil {


### PR DESCRIPTION
## Summary
🤖 Reenables the `noctx` golangci-lint linter (previously disabled in 2d70eaf) by swapping `net.Dial`/`net.Listen`/`net.ListenPacket`/`exec.Command` calls for their `Context`-aware equivalents, passing `context.Background()` at each call site.

**This is a mechanical fix, not a functional one.** `context.Background()` never cancels and never expires, so runtime behaviour is unchanged everywhere in this diff — every dial, listen, and subprocess call still blocks exactly as it did before (e.g. a dead/unreachable TNC host still hangs on the OS-level TCP connect timeout rather than failing fast). No timeouts or cancellation were added anywhere.

The value here is limited to:
- keeping `make check` green, matching this repo's other "reenable X linter" commits (perfsprint, err113) rather than leaving the linter disabled indefinitely
- marking every blocking call site that currently has no cancellation/timeout plumbed through with a grep-able waypoint (`context.Background()`), for later work that threads a real, shutdown-aware context through instead

If/when there's appetite for the real payoff (bounded dials, interruptible reconnect loops, graceful shutdown), that's a separate, larger follow-up — it needs an actual shutdown signal threaded from `main` down through the attach/listen loops, which doesn't exist anywhere in this codebase today.

## Test plan
- [x] `go build ./...`
- [x] `make fix`
- [x] `make check` (vet, golangci-lint incl. noctx, shellcheck, reuse, go mod tidy)
- [x] `make test` (full suite, including scripted TNC tests)