### PR TITLE
fix: Address concurrency and correctness issues in NET/ROM transport (review of #512)

### DIFF
--- a/src/ax25_link.go
+++ b/src/ax25_link.go
@@ -151,6 +151,8 @@ package direwolf
 import (
 	"runtime"
 	"slices"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -484,6 +486,12 @@ type reg_callsign_t struct {
 
 var reg_callsign_list *reg_callsign_t
 
+// reg_callsign_mu guards reg_callsign_list. Registration/lookup normally
+// happens on the data link state machine's own goroutine (via the dlq
+// queue), but NET/ROM's find_registered_client reads it directly from the
+// packet-receive path, so all access must go through this lock.
+var reg_callsign_mu sync.Mutex
+
 // Use these, rather than setting variables directly, to make debug out easier.
 
 func SET_VS(S *ax25_dlsm_t, n int) {
@@ -723,12 +731,14 @@ func get_link_handle(addrs [AX25_MAX_ADDRS]string, num_addr int, channel int, cl
 	if client == -1 { // from the radio.
 		var found *reg_callsign_t
 
+		reg_callsign_mu.Lock()
 		for r := reg_callsign_list; r != nil && found == nil; r = r.next {
 			if addrs[AX25_DESTINATION] == r.callsign && channel == r.channel {
 				found = r
 				incoming_for_client = r.client
 			}
 		}
+		reg_callsign_mu.Unlock()
 
 		if found == nil {
 			if s_debug_link_handle {
@@ -1383,10 +1393,12 @@ func dl_register_callsign(E *dlq_item_t) {
 	r.callsign = E.addrs[0]
 	r.channel = E._chan
 	r.client = E.client
-	r.next = reg_callsign_list
 	r.magic = RC_MAGIC
 
+	reg_callsign_mu.Lock()
+	r.next = reg_callsign_list
 	reg_callsign_list = r
+	reg_callsign_mu.Unlock()
 } /* end dl_register_callsign */
 
 func dl_unregister_callsign(E *dlq_item_t) {
@@ -1394,6 +1406,9 @@ func dl_unregister_callsign(E *dlq_item_t) {
 		text_color_set(DW_COLOR_DEBUG)
 		dw_printf("dl_unregister_callsign (%s, chan=%d, client=%d)\n", E.addrs[0], E._chan, E.client)
 	}
+
+	reg_callsign_mu.Lock()
+	defer reg_callsign_mu.Unlock()
 
 	var prev *reg_callsign_t
 
@@ -1656,6 +1671,9 @@ func dl_client_cleanup(E *dlq_item_t) {
 	 * Remove registered callsigns for this client.
 	 */
 
+	reg_callsign_mu.Lock()
+	defer reg_callsign_mu.Unlock()
+
 	var rcprev *reg_callsign_t
 
 	var r = reg_callsign_list
@@ -1676,6 +1694,24 @@ func dl_client_cleanup(E *dlq_item_t) {
 		}
 	}
 } /* end dl_client_cleanup */
+
+// find_registered_client returns the client that registered callsign on
+// channel to accept incoming connections (via the AGW 'X' command), or -1 if
+// no client has registered it. Unlike get_link_handle's equivalent lookup,
+// this may be called from goroutines other than the data link state
+// machine's own (e.g. NET/ROM's packet-receive path), hence the match is
+// case-insensitive/trimmed rather than requiring byte-for-byte equality.
+func find_registered_client(channel int, callsign string) int {
+	reg_callsign_mu.Lock()
+	defer reg_callsign_mu.Unlock()
+
+	for r := reg_callsign_list; r != nil; r = r.next {
+		if r.channel == channel && strings.EqualFold(strings.TrimSpace(r.callsign), strings.TrimSpace(callsign)) {
+			return r.client
+		}
+	}
+	return -1
+}
 
 /*------------------------------------------------------------------------------
  *

--- a/src/netrom_link.go
+++ b/src/netrom_link.go
@@ -61,17 +61,19 @@ type netromLinkManager struct {
 }
 
 func newNetromLinkManager(nodeCall, nodeAlias string) *netromLinkManager {
-	return &netromLinkManager{
-		mu:        sync.Mutex{},
-		circuits:  nil,
-		nodeCall:  nodeCall,
-		nodeAlias: nodeAlias,
-		nextIdx:   1,
-		nextID:    1,
-	}
+	var m = new(netromLinkManager)
+	m.nodeCall = nodeCall
+	m.nodeAlias = nodeAlias
+	m.nextIdx = 1
+	m.nextID = 1
+	return m
 }
 
-// allocCircuit creates and registers a new circuit, returning it locked.
+// allocCircuit reserves a fresh local idx/id and returns a new circuit that is
+// not yet visible to lookups. Call publishCircuit once its identity fields
+// (channel, localCall, remoteCall, remoteNode, remoteIdx, remoteID) are set,
+// so that findByLocal/findByCallsigns/findByRemote never observe a partially
+// initialised circuit.
 func (m *netromLinkManager) allocCircuit() *netromCircuit {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -92,8 +94,26 @@ func (m *netromLinkManager) allocCircuit() *netromCircuit {
 		m.nextID = 1
 	}
 
-	m.circuits = append(m.circuits, c)
 	return c
+}
+
+// publishCircuit makes c visible to findByLocal/findByCallsigns/findByRemote.
+func (m *netromLinkManager) publishCircuit(c *netromCircuit) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.circuits = append(m.circuits, c)
+}
+
+// setRemote updates a circuit's remote idx/id, which findByRemote uses as
+// lookup keys, under the manager lock rather than c.mu so that finder reads
+// and this write are synchronized by the same mutex.
+func (m *netromLinkManager) setRemote(c *netromCircuit, idx, id byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c.remoteIdx = idx
+	c.remoteID = id
 }
 
 func (m *netromLinkManager) findByLocal(idx, id byte) *netromCircuit {
@@ -166,6 +186,8 @@ func (m *netromLinkManager) connectRequest(channel, client int, dstNode string, 
 	c.window = NETROM_WINDOW_DEFAULT
 	c.mu.Unlock()
 
+	m.publishCircuit(c)
+
 	var payload = netromBuildConnect(
 		dstNode, m.nodeCall, netromConfigTTL(),
 		0, 0, // remote ckt fields – 0 because remote doesn't have a circuit yet.
@@ -177,7 +199,11 @@ func (m *netromLinkManager) connectRequest(channel, client int, dstNode string, 
 	netromTx(channel, route.neighbor, payload)
 
 	c.mu.Lock()
-	c.startT1()
+	// The CONNECT ACK may already have arrived and transitioned the circuit
+	// while netromTx was in flight; only arm T1 if we're still waiting.
+	if c.state == nrStateAwaitingConnection {
+		c.startT1()
+	}
 	c.mu.Unlock()
 }
 
@@ -241,15 +267,33 @@ func (m *netromLinkManager) rxFrame(fromChan int, f *netromTransportFrame) {
 }
 
 func (m *netromLinkManager) rxConnect(fromChan int, f *netromTransportFrame) {
+	// A retransmitted CONNECT REQUEST (e.g. our CONNECT ACK was lost) should
+	// not allocate a second circuit for the same remote circuit; just resend
+	// the ACK for the circuit we already have.
+	if existing := m.findByRemote(f.net.src, f.origIdx, f.origID); existing != nil {
+		existing.mu.Lock()
+		var ackPayload = netromBuildConnAck(
+			f.net.src, m.nodeCall, netromConfigTTL(),
+			f.origIdx, f.origID,
+			existing.localIdx, existing.localID,
+			existing.window,
+			false,
+		)
+		existing.mu.Unlock()
+		netromTx(fromChan, f.net.src, ackPayload)
+		return
+	}
+
 	// Allocate a circuit for the incoming connection.
 	var c = m.allocCircuit()
+	var client = find_registered_client(fromChan, f.dstCallsign)
 	c.mu.Lock()
 	c.localNode = m.nodeCall
 	c.remoteNode = f.net.src
 	c.localCall = f.dstCallsign
 	c.remoteCall = f.origCallsign
 	c.channel = fromChan
-	c.client = -1 // will be set when an application registers for this callsign.
+	c.client = client
 	c.remoteIdx = f.origIdx
 	c.remoteID = f.origID
 	if f.windowSize > 0 {
@@ -257,6 +301,8 @@ func (m *netromLinkManager) rxConnect(fromChan int, f *netromTransportFrame) {
 	}
 	c.state = nrStateConnected
 	c.mu.Unlock()
+
+	m.publishCircuit(c)
 
 	// Send CONNECT ACK.
 	var payload = netromBuildConnAck(
@@ -288,8 +334,7 @@ func (m *netromLinkManager) rxConnAck(f *netromTransportFrame) {
 	}
 
 	c.stopT1()
-	c.remoteIdx = f.acceptIdx
-	c.remoteID = f.acceptID
+	m.setRemote(c, f.acceptIdx, f.acceptID)
 	if f.windowSize > 0 {
 		c.window = f.windowSize
 	}

--- a/src/netrom_link_test.go
+++ b/src/netrom_link_test.go
@@ -4,6 +4,7 @@
 package direwolf
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -25,6 +26,7 @@ func TestNetromLinkManagerFindByLocal(t *testing.T) {
 	var mgr = newNetromLinkManager("Q1TEST", "QNODE1")
 
 	var c = mgr.allocCircuit()
+	mgr.publishCircuit(c)
 	var idx = c.localIdx
 	var id = c.localID
 
@@ -46,6 +48,7 @@ func TestNetromLinkManagerFindByRemote(t *testing.T) {
 	c.remoteNode = "Q2TEST"
 	c.remoteIdx = 0x10
 	c.remoteID = 0x20
+	mgr.publishCircuit(c)
 
 	var found = mgr.findByRemote("Q2TEST", 0x10, 0x20)
 	if found != c {
@@ -62,6 +65,7 @@ func TestNetromLinkManagerRemoveCircuit(t *testing.T) {
 	var mgr = newNetromLinkManager("Q1TEST", "QNODE1")
 
 	var c = mgr.allocCircuit()
+	mgr.publishCircuit(c)
 	var idx = c.localIdx
 	var id = c.localID
 
@@ -119,5 +123,107 @@ func TestNetromCircuitInitialState(t *testing.T) {
 	}
 	if c.window != NETROM_WINDOW_DEFAULT {
 		t.Errorf("window: got %d, want %d", c.window, NETROM_WINDOW_DEFAULT)
+	}
+}
+
+// TestNetromLinkManagerConcurrentFindAndSetRemoteNoRace exercises findByRemote
+// (reader) and setRemote (writer) concurrently on the same published circuit.
+// Both must be synchronized under the manager lock so that `go test -race`
+// stays clean; run with -race to actually catch a regression.
+func TestNetromLinkManagerConcurrentFindAndSetRemoteNoRace(t *testing.T) {
+	var mgr = newNetromLinkManager("Q1TEST", "QNODE1")
+
+	var c = mgr.allocCircuit()
+	c.remoteNode = "Q2TEST"
+	mgr.publishCircuit(c)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			mgr.setRemote(c, 0x10, 0x20)
+		}()
+		go func() {
+			defer wg.Done()
+			mgr.findByRemote("Q2TEST", 0x10, 0x20)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestNetromRxConnectDedupesRetransmit verifies that a retransmitted CONNECT
+// REQUEST for a circuit we already accepted resends the CONNECT ACK rather
+// than allocating a second, duplicate circuit.
+func TestNetromRxConnectDedupesRetransmit(t *testing.T) {
+	var mgr = newNetromLinkManager("Q1TEST", "QNODE1")
+
+	var payload = netromBuildConnect("Q1TEST", "Q2TEST", NETROM_TTL_DEFAULT, 0, 0, 0x11, 0x22, "Q2TEST", "QNODE2", "Q1TEST", "QNODE1", NETROM_WINDOW_DEFAULT)
+	var f, err = netromParseTransportFrame(payload)
+	if err != nil {
+		t.Fatalf("failed to parse test CONNECT REQUEST: %v", err)
+	}
+
+	mgr.rxConnect(0, f)
+	mgr.rxConnect(0, f) // retransmit of the same CONNECT REQUEST.
+
+	if len(mgr.circuits) != 1 {
+		t.Errorf("expected exactly one circuit after a retransmitted CONNECT REQUEST, got %d", len(mgr.circuits))
+	}
+}
+
+// TestNetromRxConnectUsesRegisteredClient verifies that an inbound circuit is
+// wired up to whichever AGW client has registered the destination callsign,
+// instead of being permanently orphaned with client == -1.
+func TestNetromRxConnectUsesRegisteredClient(t *testing.T) {
+	reg_callsign_list = nil
+	t.Cleanup(func() { reg_callsign_list = nil })
+
+	var regE = new(dlq_item_t)
+	regE._type = DLQ_REGISTER_CALLSIGN
+	regE._chan = 0
+	regE.addrs[0] = "Q1TEST"
+	regE.client = 1
+	dl_register_callsign(regE)
+
+	var mgr = newNetromLinkManager("Q1TEST", "QNODE1")
+	var payload = netromBuildConnect("Q1TEST", "Q2TEST", NETROM_TTL_DEFAULT, 0, 0, 0x11, 0x22, "Q2TEST", "QNODE2", "Q1TEST", "QNODE1", NETROM_WINDOW_DEFAULT)
+	var f, err = netromParseTransportFrame(payload)
+	if err != nil {
+		t.Fatalf("failed to parse test CONNECT REQUEST: %v", err)
+	}
+
+	mgr.rxConnect(0, f)
+
+	if len(mgr.circuits) != 1 {
+		t.Fatalf("expected one circuit, got %d", len(mgr.circuits))
+	}
+	if mgr.circuits[0].client != 1 {
+		t.Errorf("expected inbound circuit to be assigned to registered client 1, got %d", mgr.circuits[0].client)
+	}
+}
+
+// TestNetromRxConnectUnregisteredCallsignStaysUnowned verifies that an
+// inbound circuit for a callsign nobody has registered is left with
+// client == -1 (no application to deliver data to), rather than panicking or
+// guessing a client.
+func TestNetromRxConnectUnregisteredCallsignStaysUnowned(t *testing.T) {
+	reg_callsign_list = nil
+	t.Cleanup(func() { reg_callsign_list = nil })
+
+	var mgr = newNetromLinkManager("Q1TEST", "QNODE1")
+	var payload = netromBuildConnect("Q1TEST", "Q2TEST", NETROM_TTL_DEFAULT, 0, 0, 0x11, 0x22, "Q2TEST", "QNODE2", "Q1TEST", "QNODE1", NETROM_WINDOW_DEFAULT)
+	var f, err = netromParseTransportFrame(payload)
+	if err != nil {
+		t.Fatalf("failed to parse test CONNECT REQUEST: %v", err)
+	}
+
+	mgr.rxConnect(0, f)
+
+	if len(mgr.circuits) != 1 {
+		t.Fatalf("expected one circuit, got %d", len(mgr.circuits))
+	}
+	if mgr.circuits[0].client != -1 {
+		t.Errorf("expected unregistered inbound circuit to have client == -1, got %d", mgr.circuits[0].client)
 	}
 }

--- a/src/netrom_router.go
+++ b/src/netrom_router.go
@@ -29,10 +29,9 @@ type netromRouter struct {
 }
 
 func newNetromRouter() *netromRouter {
-	return &netromRouter{
-		mu:     sync.RWMutex{},
-		routes: make(map[string]*netromRouteEntry),
-	}
+	var r = new(netromRouter)
+	r.routes = make(map[string]*netromRouteEntry)
+	return r
 }
 
 // update processes one NODES broadcast received from fromNeighbor.


### PR DESCRIPTION
## Summary

🤖 Fixes for the high-priority issues found in a review of #512 ("feat: Add NET/ROM full transport layer"), targeted at that branch rather than `main`.

- **Circuit identity-field data race**: `findByLocal`/`findByCallsigns`/`findByRemote` read circuit fields (`channel`, `localCall`, `remoteCall`, `remoteNode`, `remoteIdx`, `remoteID`) under only the manager lock, while writers set them under the per-circuit lock after the circuit was already published. `allocCircuit` no longer auto-publishes; callers now finish initializing a circuit and call the new `publishCircuit`, so finders never see a partially-initialised circuit. The one field that legitimately changes post-publish (`remoteIdx`/`remoteID` in `rxConnAck`) now goes through a `setRemote` helper under the manager lock, matching the finders.
- **T1 re-arm race**: `connectRequest` unconditionally re-armed T1 after sending CONNECT REQUEST, even if a fast CONNECT ACK had already raced it and moved the circuit to connected — eventually tearing down a healthy connection. Now guarded by a state check.
- **Duplicate circuits from retransmitted CONNECT REQUEST**: `rxConnect` allocated a new circuit for every inbound CONNECT REQUEST, including retransmits, growing `m.circuits` without bound. It now looks up an existing circuit by remote node/idx/id first and just resends the ACK.
- **Orphaned inbound circuits**: inbound circuits set `client = -1` expecting a registration step that didn't exist anywhere, so every inbound NET/ROM connection was silently auto-accepted and then black-holed. `rxConnect` now looks up the AGW client that registered the destination callsign (the same `reg_callsign_list` mechanism native AX.25 connected mode uses via the `X` command), guarded by a new mutex since NET/ROM reads it from a different goroutine than the data-link state machine that owns it.
- Minor style: `new(Foo)` instead of `&Foo{}` for the `netromLinkManager`/`netromRouter` constructors.
- Added regression tests: retransmit dedup, inbound-client wiring (registered and unregistered cases), and a concurrent finder/setter stress test for the identity-field race (run with `-race`).

`make fix`, `make check`, and `make test` all pass; `go test -race ./...` is clean.

## Test plan
- [x] `make fix`
- [x] `make check`
- [x] `make test`
- [x] `go test -race ./...`