### PR TITLE
test: Add make race target

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,6 +66,7 @@ jobs:
       run: "go clean -cache"
 
     - run: "make test"
+    - run: "make race"
     - run: "make coveragereport"
     - run: "pipx install 'reuse[charset-normalizer]'"  # For validating the licence config
     - run: "make check"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ test: gotest test-scripts
 gotest:
 	go test $(GOTEST_FLAGS) -cover -coverpkg=./cmd/...,./src/... -coverprofile $(COVERAGE_FILE) $(SRC_DIRS)  # TODO Construct coverpkg from $SRC_DIRS
 
+.PHONY: race
+race:
+	go test $(GOTEST_FLAGS) -race $(SRC_DIRS)
+
 # TODO Better output name, non-PHONY target, docs, etc.
 .PHONY: gotest-bin
 gotest-bin:


### PR DESCRIPTION
## Summary
🤖 Adds a `make race` target that runs `go test -race` over the standard source dirs, so the Go race detector can be run easily without remembering flags.

## Test plan
- [x] `make race` passes locally
- [x] `make fix` / `go mod tidy` produce no further changes