### PR TITLE
chore: Enable most excluded staticcheck checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,6 @@ linters:
       checks:
         - all
         - '-ST1003' # Default
-        - '-ST1016' # Default
         - '-ST1020' # Default
         - '-ST1021' # Default
         - '-ST1022' # Default

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,6 @@ linters:
       checks:
         - all
         - '-ST1003' # Default
-        - '-ST1020' # Default
         - '-ST1021' # Default
         - '-ST1022' # Default
         - '-S1007' # Raw strings are good but I want to copy the pattern verbatim from upstream

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,6 @@ linters:
       checks:
         - all
         - '-ST1003' # Default
-        - '-ST1022' # Default
         - '-S1007' # Raw strings are good but I want to copy the pattern verbatim from upstream
     wsl_v5:
       disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters:
     staticcheck:
       checks:
         - all
-        - '-ST1000' # Default
         - '-ST1003' # Default
         - '-ST1016' # Default
         - '-ST1020' # Default

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,6 @@ linters:
       checks:
         - all
         - '-ST1003' # Default
-        - '-S1007' # Raw strings are good but I want to copy the pattern verbatim from upstream
     wsl_v5:
       disable:
         - "decl"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters:
     staticcheck:
       checks:
         - all
-        - '-QF1001' # De Morgan's law *would* simplify some logic, but I'm copying upstream's style
         - '-ST1000' # Default
         - '-ST1003' # Default
         - '-ST1016' # Default

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,6 @@ linters:
       checks:
         - all
         - '-ST1003' # Default
-        - '-ST1021' # Default
         - '-ST1022' # Default
         - '-S1007' # Raw strings are good but I want to copy the pattern verbatim from upstream
     wsl_v5:

--- a/src/ax25_link.go
+++ b/src/ax25_link.go
@@ -2601,7 +2601,7 @@ func i_frame_continued(S *ax25_dlsm_t, p int, ns int, pid int, info []byte) {
 					ask_resend_count++
 
 					x = AX25MODULO(x+1, S.modulo)
-					if !(x != AX25MODULO(last+1, S.modulo)) {
+					if x == AX25MODULO(last+1, S.modulo) {
 						break
 					}
 				}

--- a/src/beacon.go
+++ b/src/beacon.go
@@ -607,7 +607,7 @@ func (bs *BeaconService) sbCalculateNextTime(now time.Time, current_speed_mph fl
 func (bs *BeaconService) send(j int, gpsinfo *dwgps_info_t) {
 	var bp = &(bs.miscConfig.beacon[j])
 
-	if !(bp.sendto_chan >= 0) {
+	if bp.sendto_chan < 0 {
 		panic("assert(bp.sendto_chan >= 0)")
 	}
 

--- a/src/config.go
+++ b/src/config.go
@@ -328,7 +328,7 @@ func alldigits(p string) bool {
 
 func alllettersorpm(p string) bool {
 	return !strings.ContainsFunc(p, func(r rune) bool {
-		return !(unicode.IsLetter(r) || r == '+' || r == '-')
+		return !unicode.IsLetter(r) && r != '+' && r != '-'
 	})
 }
 
@@ -1915,7 +1915,7 @@ func handleMODEM(ps *parseState) bool {
 				/* Here we only catch something other than letters and + mixed in. */
 				/* Later, we check for valid letters and no more than one letter if + specified. */
 				if strings.ContainsFunc(t, func(r rune) bool {
-					return !(unicode.IsLetter(r) || r == '+' || r == '-')
+					return !unicode.IsLetter(r) && r != '+' && r != '-'
 				}) {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Line %d: Demodulator type can only contain letters and + character.\n", ps.line)
@@ -5352,7 +5352,7 @@ func handleKISSPORT(ps *parseState) bool {
 		for i := 0; i < MAX_KISS_TCP_PORTS && slot == -1; i++ {
 			if ps.misc.kiss_port[i] == tcp_port { //nolint:staticcheck
 				slot = i
-				if !(slot == 0 && tcp_port == DEFAULT_KISS_PORT) {
+				if slot != 0 || tcp_port != DEFAULT_KISS_PORT {
 					text_color_set(DW_COLOR_ERROR)
 					dw_printf("Line %d: Warning: Duplicate TCP port %d will overwrite previous value.\n", ps.line, tcp_port)
 				}

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -3609,13 +3609,13 @@ func get_timestamp(A *decode_aprs_t, p [7]byte) time.Time { //nolint:unparam
 	}
 	var phms hms_s
 
-	if !(unicode.IsDigit(rune(p[0])) &&
-		unicode.IsDigit(rune(p[1])) &&
-		unicode.IsDigit(rune(p[2])) &&
-		unicode.IsDigit(rune(p[3])) &&
-		unicode.IsDigit(rune(p[4])) &&
-		unicode.IsDigit(rune(p[5])) &&
-		(p[6] == 'z' || p[6] == '/' || p[6] == 'h')) { //nolnit:staticcheck
+	if !unicode.IsDigit(rune(p[0])) ||
+		!unicode.IsDigit(rune(p[1])) ||
+		!unicode.IsDigit(rune(p[2])) ||
+		!unicode.IsDigit(rune(p[3])) ||
+		!unicode.IsDigit(rune(p[4])) ||
+		!unicode.IsDigit(rune(p[5])) ||
+		(p[6] != 'z' && p[6] != '/' && p[6] != 'h') { //nolnit:staticcheck
 		text_color_set(DW_COLOR_ERROR)
 		dw_printf("Timestamp must be 6 digits followed by z, h, or /.\n")
 

--- a/src/decode_aprs.go
+++ b/src/decode_aprs.go
@@ -3999,23 +3999,23 @@ func process_comment(A *decode_aprs_t, commentData []byte) {
 	// Third fractional digit can be space instead.
 	// "MHz" should be exactly that capitalization.
 	// Print warning later it not.
-	var std_freq_re = regexp.MustCompile("^[/ ]?([0-9A-O][0-9][0-9]\\.[0-9][0-9][0-9 ])([Mm][Hh][Zz])") /* Frequency in standard format. */
+	var std_freq_re = regexp.MustCompile(`^[/ ]?([0-9A-O][0-9][0-9]\.[0-9][0-9][0-9 ])([Mm][Hh][Zz])`) /* Frequency in standard format. */
 
 	// If no tone, we might gobble up / after any data extension,
 	// We could also have a space but it's not required.
 	// I don't understand the difference between T and C so treat the same for now.
 	// We can also have "off" instead of number to explicitly mean none.
 
-	var std_tone_re = regexp.MustCompile("^[/ ]?([TtCc][012][0-9][0-9])")                                                    /* Tone in standard format. */
-	var std_toff_re = regexp.MustCompile("^[/ ]?[TtCc][Oo][Ff][Ff]")                                                         /* Explicitly no tone. */
-	var std_dcs_re = regexp.MustCompile("^[/ ]?[Dd]([0-7][0-7][0-7])")                                                       /* Digital codes squelch in standard format. */
-	var std_offset_re = regexp.MustCompile("^[/ ]?([+-][0-9][0-9][0-9])")                                                    /* Xmit freq offset in standard format. */
-	var std_range_re = regexp.MustCompile("^[/ ]?[Rr]([0-9][0-9])([mk])")                                                    /* Range in standard format. */
-	var dao_re = regexp.MustCompile("!([A-Z][0-9 ][0-9 ]|[a-z][!-{ ][!-{ ]|T[0-9 B][0-9 ])!")                                /* DAO */
-	var alt_re = regexp.MustCompile("/A=[0-9-][0-9][0-9][0-9][0-9][0-9]")                                                    /* /A= altitude */
-	var bad_freq_re = regexp.MustCompile("[0-9][0-9][0-9]\\.[0-9][0-9][0-9]?")                                               /* Likely frequency, not standard format */
-	var bad_tone_re = regexp.MustCompile("(^|[^0-9.])([6789][0-9]\\.[0-9]|[12][0-9][0-9]\\.[0-9]|67|77|100|123)($|[^0-9.])") /* Likely tone, not standard format */
-	var base91_tel_re = regexp.MustCompile("\\|(([!-{][!-{]){2,7})\\|")                                                      /* Base 91 compressed telemetry data. */
+	var std_tone_re = regexp.MustCompile("^[/ ]?([TtCc][012][0-9][0-9])")                                                  /* Tone in standard format. */
+	var std_toff_re = regexp.MustCompile("^[/ ]?[TtCc][Oo][Ff][Ff]")                                                       /* Explicitly no tone. */
+	var std_dcs_re = regexp.MustCompile("^[/ ]?[Dd]([0-7][0-7][0-7])")                                                     /* Digital codes squelch in standard format. */
+	var std_offset_re = regexp.MustCompile("^[/ ]?([+-][0-9][0-9][0-9])")                                                  /* Xmit freq offset in standard format. */
+	var std_range_re = regexp.MustCompile("^[/ ]?[Rr]([0-9][0-9])([mk])")                                                  /* Range in standard format. */
+	var dao_re = regexp.MustCompile("!([A-Z][0-9 ][0-9 ]|[a-z][!-{ ][!-{ ]|T[0-9 B][0-9 ])!")                              /* DAO */
+	var alt_re = regexp.MustCompile("/A=[0-9-][0-9][0-9][0-9][0-9][0-9]")                                                  /* /A= altitude */
+	var bad_freq_re = regexp.MustCompile(`[0-9][0-9][0-9]\.[0-9][0-9][0-9]?`)                                              /* Likely frequency, not standard format */
+	var bad_tone_re = regexp.MustCompile(`(^|[^0-9.])([6789][0-9]\.[0-9]|[12][0-9][0-9]\.[0-9]|67|77|100|123)($|[^0-9.])`) /* Likely tone, not standard format */
+	var base91_tel_re = regexp.MustCompile(`\|(([!-{][!-{]){2,7})\|`)                                                      /* Base 91 compressed telemetry data. */
 
 	commentData = bytes.TrimRight(commentData, "\x00") // Drop any trailing nulls
 	var clen = len(commentData)

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -614,15 +614,15 @@ x = Silence FX.25 information.`)
 	gen_tone_init(audio_config, audio_amplitude, false)
 	morse_init(audio_config, audio_amplitude)
 
-	if !(audio_config.adev[0].bits_per_sample == 8 || audio_config.adev[0].bits_per_sample == 16) {
+	if audio_config.adev[0].bits_per_sample != 8 && audio_config.adev[0].bits_per_sample != 16 {
 		panic("audio_config.adev[0].bits_per_sample == 8 || audio_config.adev[0].bits_per_sample == 16")
 	}
 
-	if !(audio_config.adev[0].num_channels == 1 || audio_config.adev[0].num_channels == 2) {
+	if audio_config.adev[0].num_channels != 1 && audio_config.adev[0].num_channels != 2 {
 		panic("assert(audio_config.adev[0].num_channels == 1 || audio_config.adev[0].num_channels == 2)")
 	}
 
-	if !(audio_config.adev[0].samples_per_sec >= MIN_SAMPLES_PER_SEC && audio_config.adev[0].samples_per_sec <= MAX_SAMPLES_PER_SEC) {
+	if audio_config.adev[0].samples_per_sec < MIN_SAMPLES_PER_SEC || audio_config.adev[0].samples_per_sec > MAX_SAMPLES_PER_SEC {
 		panic("assert(audio_config.adev[0].samples_per_sec >= MIN_SAMPLES_PER_SEC && audio_config.adev[0].samples_per_sec <= MAX_SAMPLES_PER_SEC)")
 	}
 

--- a/src/gen_packets.go
+++ b/src/gen_packets.go
@@ -514,15 +514,15 @@ EAS for Emergency Alert System (EAS) Specific Area Message Encoding (SAME).`)
 	FX25Init(1)
 	il2p_init(0) // There are no "-d" options so far but it could be handy here.
 
-	if !(modem.adev[0].bits_per_sample == 8 || modem.adev[0].bits_per_sample == 16) {
+	if modem.adev[0].bits_per_sample != 8 && modem.adev[0].bits_per_sample != 16 {
 		panic("assert(modem.adev[0].bits_per_sample == 8 || modem.adev[0].bits_per_sample == 16)")
 	}
 
-	if !(modem.adev[0].num_channels == 1 || modem.adev[0].num_channels == 2) {
+	if modem.adev[0].num_channels != 1 && modem.adev[0].num_channels != 2 {
 		panic("assert(modem.adev[0].num_channels == 1 || modem.adev[0].num_channels == 2)")
 	}
 
-	if !(modem.adev[0].samples_per_sec >= MIN_SAMPLES_PER_SEC && modem.adev[0].samples_per_sec <= MAX_SAMPLES_PER_SEC) {
+	if modem.adev[0].samples_per_sec < MIN_SAMPLES_PER_SEC || modem.adev[0].samples_per_sec > MAX_SAMPLES_PER_SEC {
 		panic("assert(modem.adev[0].samples_per_sec >= MIN_SAMPLES_PER_SEC && modem.adev[0].samples_per_sec <= MAX_SAMPLES_PER_SEC)")
 	}
 
@@ -731,7 +731,7 @@ func audio_file_open(fname string, pa *audio_s) int {
 	gen_header.data[3] = 'a'
 	gen_header.datasize = 0
 
-	if !(gen_header.nchannels == 1 || gen_header.nchannels == 2) {
+	if gen_header.nchannels != 1 && gen_header.nchannels != 2 {
 		panic("assert(gen_header.nchannels == 1 || gen_header.nchannels == 2)")
 	}
 

--- a/src/hdlc_rec.go
+++ b/src/hdlc_rec.go
@@ -221,7 +221,7 @@ func (s *hdlcState) recEasBit(raw int, future_use int) { //nolint:unparam
 			// examples contain a slash.
 			// It's not clear if a space can occur in other places.
 
-			if !((ch >= ' ' && ch <= 0x7f) || ch == '\r' || ch == '\n') {
+			if (ch < ' ' || ch > 0x7f) && ch != '\r' && ch != '\n' {
 				//#define DEBUG_E 1
 				/*
 				   #ifdef DEBUG_E

--- a/src/hdlc_rec2.go
+++ b/src/hdlc_rec2.go
@@ -977,7 +977,7 @@ func sanity_check(buf []byte, bits_flipped BitFixLevel, sanity_test sanity_t) bo
 	for j := alen + 2; j < len(buf); j++ {
 		var ch = buf[j]
 
-		if !((ch >= 0x1c && ch <= 0x7f) || ch == 0x0a || ch == 0x0d || ch == 0x80 || ch == 0x9f || ch == 0xc2 || ch == 0xb0 || ch == 0xf8) {
+		if (ch < 0x1c || ch > 0x7f) && ch != 0x0a && ch != 0x0d && ch != 0x80 && ch != 0x9f && ch != 0xc2 && ch != 0xb0 && ch != 0xf8 {
 			/* TODO KG
 			#if DEBUGx
 				    text_color_set(DW_COLOR_ERROR);

--- a/src/kissnet.go
+++ b/src/kissnet.go
@@ -367,7 +367,7 @@ func (kns *KissNetService) Copy(_msg []byte, channel int, cmd int, from_kps *kis
 		for kps := kns.allPorts; kps != nil; kps = kps.pnext {
 			for client := range MAX_NET_CLIENTS {
 				// To all but origin.
-				if !(kps == from_kps && client == from_client) {
+				if kps != from_kps || client != from_client {
 					var conn = kps.clientConn(client)
 					if conn != nil {
 						if kps.channel == -1 || kps.channel == channel {

--- a/src/pfilter.go
+++ b/src/pfilter.go
@@ -1005,7 +1005,7 @@ func filt_s(pf *pfstate_t) (int, error) {
 				// Zero length is acceptable and is not the same as missing.
 
 				if strings.ContainsFunc(over, func(r rune) bool {
-					return !(unicode.IsUpper(r) || unicode.IsDigit(r) || r == '\\')
+					return !unicode.IsUpper(r) && !unicode.IsDigit(r) && r != '\\'
 				}) {
 					return -1, newFilterError(pf, "Symbol filter, overlay must be upper case letter, digit, or \\.")
 				}


### PR DESCRIPTION
## Summary

🤖 Per request, this removes staticcheck ignores from `.golangci.yml` one at a time, each as its own commit that fixes any resulting issues before removing the exclusion:

- `QF1001` (De Morgan's law) — 17 real violations across 10 files, simplified
- `ST1000`, `ST1016`, `ST1020`, `ST1021`, `ST1022` — no violations found, clean enable
- `S1007` (raw strings for regexps) — 4 violations in `decode_aprs.go`, fixed

`ST1003` (Go naming conventions) is intentionally **not** touched here — it has 2756 violations across nearly the whole codebase, since this project deliberately keeps C-derived `snake_case`/`ALL_CAPS` names close to upstream Dire Wolf naming (per AGENTS.md: "we don't need to change existing things if not necessary"). Mass-renaming would be a large, high-risk, out-of-scope change; happy to tackle it separately/incrementally if wanted.

## Test plan

- [x] `make check` passes
- [x] `make test` passes