### PR TITLE
perf: Run independent atest decode passes in parallel in test-scripts

### DIFF
--- a/test-scripts/check-modem1200
+++ b/test-scripts/check-modem1200
@@ -5,7 +5,10 @@ source "$(dirname "$(realpath "$0")")/common"
 goto_tmpdir
 
 $GEN_PACKETS -n 100 -o test12.wav
-$ATEST -F0 -PA -D1 -L66 -G72 test12.wav
-$ATEST -F1 -PA -D1 -L72 -G79 test12.wav
-$ATEST -F0 -PB -D1 -L66 -G74 test12.wav
-$ATEST -F1 -PB -D1 -L70 -G82 test12.wav
+
+pa_f0() { $ATEST -F0 -PA -D1 -L66 -G72 test12.wav; }
+pa_f1() { $ATEST -F1 -PA -D1 -L72 -G79 test12.wav; }
+pb_f0() { $ATEST -F0 -PB -D1 -L66 -G74 test12.wav; }
+pb_f1() { $ATEST -F1 -PB -D1 -L70 -G82 test12.wav; }
+
+run_parallel pa_f0 pa_f1 pb_f0 pb_f1

--- a/test-scripts/check-modem1200-bpsk
+++ b/test-scripts/check-modem1200-bpsk
@@ -5,5 +5,8 @@ source "$(dirname "$(realpath "$0")")/common"
 goto_tmpdir
 
 $GEN_PACKETS -B1200 -k -n 100 -o test12-bpsk.wav
-$ATEST -B1200 -k -F0 -L88 -G94 test12-bpsk.wav
-$ATEST -B1200 -k -F1 -L93 -G99 test12-bpsk.wav
+
+f0() { $ATEST -B1200 -k -F0 -L88 -G94 test12-bpsk.wav; }
+f1() { $ATEST -B1200 -k -F1 -L93 -G99 test12-bpsk.wav; }
+
+run_parallel f0 f1

--- a/test-scripts/check-modem19200
+++ b/test-scripts/check-modem19200
@@ -7,5 +7,8 @@ goto_tmpdir
 $GEN_PACKETS -r 96000 -B19200 -a 170 -o test19.wav
 $ATEST -B19200 -F0 -L4 test19.wav
 $GEN_PACKETS -r 96000 -B19200 -n 100 -o test19.wav
-$ATEST -B19200 -F0 -L60 -G66 test19.wav
-$ATEST -B19200 -F1 -L64 -G69 test19.wav
+
+f0() { $ATEST -B19200 -F0 -L60 -G66 test19.wav; }
+f1() { $ATEST -B19200 -F1 -L64 -G69 test19.wav; }
+
+run_parallel f0 f1

--- a/test-scripts/check-modem2400-a
+++ b/test-scripts/check-modem2400-a
@@ -5,5 +5,8 @@ source "$(dirname "$(realpath "$0")")/common"
 goto_tmpdir
 
 $GEN_PACKETS -B2400 -j -n 100 -o test24-a.wav
-$ATEST -B2400 -j -F0 -L76 -G85 test24-a.wav
-$ATEST -B2400 -j -F1 -L84 -G92 test24-a.wav
+
+f0() { $ATEST -B2400 -j -F0 -L76 -G85 test24-a.wav; }
+f1() { $ATEST -B2400 -j -F1 -L84 -G92 test24-a.wav; }
+
+run_parallel f0 f1

--- a/test-scripts/check-modem2400-b
+++ b/test-scripts/check-modem2400-b
@@ -5,5 +5,8 @@ source "$(dirname "$(realpath "$0")")/common"
 goto_tmpdir
 
 $GEN_PACKETS -B2400 -J -n 100 -o test24-b.wav
-$ATEST -B2400 -J -F0 -L81 -G88 test24-b.wav
-$ATEST -B2400 -J -F1 -L86 -G92 test24-b.wav
+
+f0() { $ATEST -B2400 -J -F0 -L81 -G88 test24-b.wav; }
+f1() { $ATEST -B2400 -J -F1 -L86 -G92 test24-b.wav; }
+
+run_parallel f0 f1

--- a/test-scripts/check-modem300
+++ b/test-scripts/check-modem300
@@ -5,7 +5,10 @@ source "$(dirname "$(realpath "$0")")/common"
 goto_tmpdir
 
 $GEN_PACKETS -B300 -n 100 -o test3.wav
-$ATEST -B300 -PA -F0 -L65 -G71 test3.wav
-$ATEST -B300 -PA -F1 -L69 -G75 test3.wav
-$ATEST -B300 -PB -F0 -L69 -G75 test3.wav
-$ATEST -B300 -PB -F1 -L73 -G79 test3.wav
+
+pa_f0() { $ATEST -B300 -PA -F0 -L65 -G71 test3.wav; }
+pa_f1() { $ATEST -B300 -PA -F1 -L69 -G75 test3.wav; }
+pb_f0() { $ATEST -B300 -PB -F0 -L69 -G75 test3.wav; }
+pb_f1() { $ATEST -B300 -PB -F1 -L73 -G79 test3.wav; }
+
+run_parallel pa_f0 pa_f1 pb_f0 pb_f1

--- a/test-scripts/check-modem300-bpsk
+++ b/test-scripts/check-modem300-bpsk
@@ -5,5 +5,8 @@ source "$(dirname "$(realpath "$0")")/common"
 goto_tmpdir
 
 $GEN_PACKETS -B300 -k -n 100 -o test300-bpsk.wav
-$ATEST -B300 -k -F0 -L78 -G82 test300-bpsk.wav
-$ATEST -B300 -k -F1 -L78 -G82 test300-bpsk.wav
+
+f0() { $ATEST -B300 -k -F0 -L78 -G82 test300-bpsk.wav; }
+f1() { $ATEST -B300 -k -F1 -L78 -G82 test300-bpsk.wav; }
+
+run_parallel f0 f1

--- a/test-scripts/check-modem4800
+++ b/test-scripts/check-modem4800
@@ -5,5 +5,8 @@ source "$(dirname "$(realpath "$0")")/common"
 goto_tmpdir
 
 $GEN_PACKETS -B4800 -n 100 -o test48.wav
-$ATEST -B4800 -F0 -L68 -G74 test48.wav
-$ATEST -B4800 -F1 -L72 -G84 test48.wav
+
+f0() { $ATEST -B4800 -F0 -L68 -G74 test48.wav; }
+f1() { $ATEST -B4800 -F1 -L72 -G84 test48.wav; }
+
+run_parallel f0 f1

--- a/test-scripts/check-modem9600
+++ b/test-scripts/check-modem9600
@@ -8,5 +8,8 @@ $GEN_PACKETS -B9600 -a 170 -o test96.wav
 $ATEST -B9600 -F0 -L4 -G4 test96.wav
 
 $GEN_PACKETS -B9600 -n 100 -o test96.wav
-$ATEST -B9600 -F0 -L61 -G65 test96.wav
-$ATEST -B9600 -F1 -L62 -G66 test96.wav
+
+f0() { $ATEST -B9600 -F0 -L61 -G65 test96.wav; }
+f1() { $ATEST -B9600 -F1 -L62 -G66 test96.wav; }
+
+run_parallel f0 f1

--- a/test-scripts/common
+++ b/test-scripts/common
@@ -22,3 +22,28 @@ function goto_tmpdir() {
 	echo "$TMPDIR"
 	cd "$TMPDIR" || exit
 }
+
+# Runs each named function in parallel, waits for all of them, prints their
+# captured output back out in the order given (for readable logs), and
+# returns non-zero if any of them failed.
+function run_parallel() {
+	local logdir
+	logdir=$(mktemp --directory)
+	local pids=()
+	local names=("$@")
+	local i
+
+	for i in "${!names[@]}"; do
+		"${names[$i]}" > "$logdir/$i.log" 2>&1 &
+		pids+=("$!")
+	done
+
+	local failed=0
+	for i in "${!pids[@]}"; do
+		wait "${pids[$i]}" || failed=1
+		cat "$logdir/$i.log"
+	done
+
+	rm -rf "$logdir"
+	return $failed
+}


### PR DESCRIPTION
## Summary
🤖 `test-scripts/runall` already fans `check-*` scripts out in parallel, so overall wall time is bounded by the slowest single script. `check-modem300-bpsk` dominated at ~140s because it ran its two `atest` decode passes (`-F0`/`-F1`, same WAV, independent) sequentially, ~70s CPU time each. Several other `check-*` scripts have the same pattern.

- Add a `run_parallel` helper to `test-scripts/common` (same pids-array + `wait` pattern already used in `runall` and `check-udp-audio-connect`) that runs named shell functions concurrently, prints their captured output back in order, and propagates failure.
- Use it in `check-modem300-bpsk`, `check-modem300`, `check-modem1200`, `check-modem1200-bpsk`, `check-modem2400-a`, `check-modem2400-b`, `check-modem4800`, `check-modem19200`, `check-modem9600` for their independent `atest` invocations.
- No change to any `-L`/`-G` pass/fail tolerances or test coverage.

Measured locally: `./test-scripts/runall` drops from ~143s to ~70s wall time (all 15 scripts still PASSED).

## Test plan
- [x] `make check` passes (shellcheck, golangci-lint, reuse)
- [x] `make gotest` passes
- [x] Ran each modified script standalone, confirmed PASS/exit 0 and reduced wall time (e.g. `check-modem300-bpsk`: 140s -> 70s)
- [x] Deliberately broke a `-L`/`-G` bound to confirm `run_parallel` still surfaces failure and exits non-zero
- [x] Full `./test-scripts/runall` run: 15/15 PASSED, wall time ~143s -> ~70s