### PR TITLE
Add INP3 pass-through hardening and decode/display support

### DIFF
--- a/docs/source/protocol-support.rst
+++ b/docs/source/protocol-support.rst
@@ -1,0 +1,17 @@
+Protocol Support Notes
+======================
+
+INP3
+----
+
+`INP3 <https://www.cantab.net/users/john.wiseman/Documents/BPQCFGFile.html>`__ is a routing / link-metric
+extension to NET/ROM used by G8BPQ's BPQ32/LinBPQ node software and compatible node switches (TheNet-X,
+XRouter). Samoyed recognises INP3 frames (routing updates, link-timing probes, and keepalives, all carried
+inside the existing NET/ROM PID 0xCF pass-through) and prints a human-readable decode of them, the same way
+it does for APRS traffic.
+
+Samoyed does **not** participate in INP3 routing - it does not maintain a routing table, probe neighbours,
+or broadcast its own presence, and it never forwards connected-mode sessions on behalf of other nodes. That
+would require a full NET/ROM Level 4 (connected-mode circuit-switching) implementation, which Samoyed - like
+Dire Wolf - does not have. INP3 decoding here is purely for visibility: it lets an operator see INP3 traffic
+on the air in a readable form instead of as opaque binary bytes.

--- a/src/decode_inp3.go
+++ b/src/decode_inp3.go
@@ -1,0 +1,425 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package direwolf
+
+/*------------------------------------------------------------------
+ *
+ * Purpose:	Decode the information part of an INP3 frame.
+ *
+ * Description:	INP3 is a routing / link-metric extension to NET/ROM
+ *		(AX.25 PID 0xCF) used by G8BPQ's BPQ32/LinBPQ node
+ *		software and compatible node switches (TheNet-X,
+ *		XRouter). It carries three kinds of message inside
+ *		the ordinary NET/ROM Level 3 envelope
+ *		(L3DEST[7] L3SRCE[7] L3TTL L4FLAGS ...):
+ *
+ *			RIF        - routing information: a list of
+ *			             destination/hop/metric entries,
+ *			             identified by L3SRCE[0] == 0xFF.
+ *			RTT        - a neighbour link-timing probe or
+ *			             reply, identified by L3DEST
+ *			             matching the pseudo-callsign
+ *			             "L3RTT".
+ *			Keepalive  - an otherwise-empty message,
+ *			             identified by L3DEST matching the
+ *			             pseudo-callsign "L3KEEP".
+ *
+ *		Samoyed does not participate in INP3 routing (no
+ *		NET/ROM Level 4 exists to make that useful - see
+ *		docs) - this is a passive decoder for display/logging
+ *		only, analogous to decode_aprs.go for APRS.
+ *
+ *		This was reverse-engineered from the reference
+ *		implementation, G8BPQ's LinBPQ BPQINP3.c (GPL), rather
+ *		than from a formal specification, so some details -
+ *		notably the exact byte length of the NET/ROM Level 3
+ *		header preceding a RIF entry list - are best-effort
+ *		inferences and may not be byte-perfect for every INP3
+ *		implementation in the wild. The RTT message is located
+ *		by searching for its literal "L3RTT: " ID field rather
+ *		than assuming a fixed header length, which avoids that
+ *		particular uncertainty.
+ *
+ *------------------------------------------------------------------*/
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// inp3_kind_e identifies which of the three INP3 message kinds a frame is.
+type inp3_kind_e int
+
+const (
+	inp3_kind_rif inp3_kind_e = iota
+	inp3_kind_rtt
+	inp3_kind_keepalive
+)
+
+// inp3_rif_entry_t is one destination entry within an INP3 RIF (routing)
+// message: a callsign, hop count, RTT/STT metric, and zero or more decoded
+// TLV options.
+type inp3_rif_entry_t struct {
+	Callsign string
+	Hops     int
+	RTT      int // 10ms units. >= 60000 means "unreachable" (route withdrawal).
+
+	Alias string // TLV 0x00, "" if absent.
+
+	HasIPv4    bool // TLV 0x01
+	IPv4       string
+	IPv4Prefix int
+
+	HasPosition bool // TLV 0x10
+	Lat, Lon    float64
+
+	HasCapability bool // TLV 0x11
+	SWType        byte
+	Flags1        byte
+	Flags2        byte
+
+	HasTimestamp bool // TLV 0x12
+	Timestamp    time.Time
+
+	HasTCPPort bool // TLV 0x13
+	TCPPort    int
+
+	HasTZOffset     bool // TLV 0x14
+	TZOffsetMinutes int
+
+	Locator string // TLV 0x15, "" if absent.
+	QTH     string // TLV 0x16, "" if absent.
+	Version string // TLV 0x17, "" if absent.
+}
+
+// inp3_rtt_t holds the parsed fields of an INP3 RTT (link-timing) message.
+type inp3_rtt_t struct {
+	TXTime      string
+	SmoothedRTT string
+	LastRTT     string
+	RTTID       string
+	Alias       string
+	Version     string
+	SWVersion   string
+	Flags       string
+}
+
+// decode_inp3_t is the result of decoding one INP3 frame.
+type decode_inp3_t struct {
+	Kind       inp3_kind_e
+	RIFEntries []inp3_rif_entry_t // populated only for inp3_kind_rif.
+	RTT        *inp3_rtt_t        // populated only for inp3_kind_rtt.
+}
+
+// The pseudo-callsigns INP3 uses as the L3 destination address of RTT and
+// keepalive control messages, instead of an actual node callsign.
+const inp3_pseudo_call_rtt = "L3RTT"
+const inp3_pseudo_call_keep = "L3KEEP"
+
+// inp3_rtt_id_marker is the literal ID field of the fixed-format RTT
+// message struct ("L3RTT: ", 7 bytes), used to locate the struct within the
+// frame regardless of the exact preceding header length.
+const inp3_rtt_id_marker = "L3RTT: "
+
+// inp3_decode_addr decodes a 7-byte AX.25-address-encoded callsign field
+// (as used both for AX.25 address fields and for INP3's embedded NET/ROM L3
+// DEST/SRC/entry-callsign fields) into human-readable text with SSID.
+func inp3_decode_addr(b []byte) string {
+	if len(b) < 7 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for i := range 6 {
+		sb.WriteByte((b[i] >> 1) & 0x7f)
+	}
+
+	var call = strings.TrimRight(sb.String(), " ")
+
+	var ssid = int((b[6] & SSID_SSID_MASK) >> SSID_SSID_SHIFT)
+	if ssid != 0 {
+		call += fmt.Sprintf("-%d", ssid)
+	}
+
+	return call
+}
+
+// decode_inp3 examines a received packet and, if it is an INP3 frame,
+// returns its decoded contents. Returns nil for anything else, including
+// plain NET/ROM traffic (e.g. classic NODES broadcasts or connected-mode
+// circuit frames) that happens to share PID 0xCF.
+func decode_inp3(pp *packet_t) *decode_inp3_t {
+	if ax25_get_pid(pp) != AX25_PID_NETROM {
+		return nil
+	}
+
+	var pinfo = AX25GetInfo(pp)
+
+	if len(pinfo) >= inp3RIFSrceEnd && pinfo[inp3RIFSrceOffset] == 0xff {
+		var D = new(decode_inp3_t)
+		D.Kind = inp3_kind_rif
+		D.RIFEntries = decode_inp3_rif(pinfo[inp3RIFHeaderLen:])
+
+		return D
+	}
+
+	if len(pinfo) >= 7 {
+		var dest = inp3_decode_addr(pinfo[0:7])
+
+		switch dest {
+		case inp3_pseudo_call_rtt:
+			var D = new(decode_inp3_t)
+			D.Kind = inp3_kind_rtt
+			D.RTT = decode_inp3_rtt(pinfo)
+
+			return D
+		case inp3_pseudo_call_keep:
+			var D = new(decode_inp3_t)
+			D.Kind = inp3_kind_keepalive
+
+			return D
+		}
+	}
+
+	return nil
+}
+
+// Offsets within the INP3-embedded NET/ROM L3 envelope: L3DEST[7] L3SRCE[7].
+// See the package doc comment above regarding the uncertainty of the header
+// length (L3TTL + L4FLAGS, 2 bytes) preceding the RIF entry list.
+const inp3RIFSrceOffset = 7
+const inp3RIFSrceEnd = 14
+const inp3RIFHeaderLen = 16
+
+// decode_inp3_rif parses a sequence of RIF entries: each is a 7-byte
+// callsign, 1-byte hop count, 2-byte big-endian RTT/STT, followed by a
+// sequence of TLV options terminated by a single 0x00 length byte.
+func decode_inp3_rif(data []byte) []inp3_rif_entry_t {
+	var entries []inp3_rif_entry_t
+
+	var pos = 0
+	for pos+10 <= len(data) {
+		var e inp3_rif_entry_t
+		e.Callsign = inp3_decode_addr(data[pos : pos+7])
+		e.Hops = int(data[pos+7])
+		e.RTT = int(data[pos+8])<<8 | int(data[pos+9])
+		pos += 10
+
+		pos = decode_inp3_rif_options(data, pos, &e)
+
+		entries = append(entries, e)
+	}
+
+	return entries
+}
+
+// decode_inp3_rif_options parses the TLV options block for one RIF entry,
+// starting at pos, and returns the position just after the terminating
+// 0x00 length byte (or the end of data, if the block is malformed/truncated).
+func decode_inp3_rif_options(data []byte, pos int, e *inp3_rif_entry_t) int {
+	for pos < len(data) {
+		var length = int(data[pos])
+
+		if length == 0 {
+			return pos + 1
+		}
+
+		if pos+length > len(data) {
+			return len(data)
+		}
+
+		var opcode = data[pos+1]
+		var value = data[pos+2 : pos+length]
+
+		decode_inp3_rif_option(opcode, value, e)
+
+		pos += length
+	}
+
+	return pos
+}
+
+func decode_inp3_rif_option(opcode byte, value []byte, e *inp3_rif_entry_t) {
+	switch opcode {
+	case 0x00: // Alias
+		e.Alias = strings.TrimSpace(string(value))
+	case 0x01: // IPv4 address + prefix length
+		if len(value) >= 5 {
+			e.HasIPv4 = true
+			e.IPv4 = fmt.Sprintf("%d.%d.%d.%d", value[0], value[1], value[2], value[3])
+			e.IPv4Prefix = int(value[4])
+		}
+	case 0x10: // Position
+		if len(value) >= 8 {
+			e.HasPosition = true
+			e.Lat = float64(int32(binary.BigEndian.Uint32(value[0:4]))) / 6000.0
+			e.Lon = float64(int32(binary.BigEndian.Uint32(value[4:8]))) / 6000.0
+		}
+	case 0x11: // Capability/flags
+		if len(value) >= 3 {
+			e.HasCapability = true
+			e.SWType = value[0]
+			e.Flags1 = value[1]
+			e.Flags2 = value[2]
+		}
+	case 0x12: // Timestamp
+		if len(value) >= 4 {
+			e.HasTimestamp = true
+			e.Timestamp = time.Unix(int64(binary.BigEndian.Uint32(value[0:4])), 0).UTC()
+		}
+	case 0x13: // TCP service port
+		if len(value) >= 2 {
+			e.HasTCPPort = true
+			e.TCPPort = int(binary.BigEndian.Uint16(value[0:2]))
+		}
+	case 0x14: // Timezone offset, minutes
+		if len(value) >= 2 {
+			e.HasTZOffset = true
+			e.TZOffsetMinutes = int(int16(binary.BigEndian.Uint16(value[0:2])))
+		}
+	case 0x15: // Maidenhead locator
+		e.Locator = string(value)
+	case 0x16: // QTH description
+		e.QTH = string(value)
+	case 0x17: // Software version string
+		e.Version = string(value)
+	}
+}
+
+// Fixed field widths and offsets (relative to the "L3RTT: " marker) of the
+// 236-byte RTT message struct, per BPQINP3.c's _RTTMSG.
+const (
+	inp3RTTTxTimeOff      = 7
+	inp3RTTSmoothedRTTOff = 18
+	inp3RTTLastRTTOff     = 29
+	inp3RTTIDOff          = 40
+	inp3RTTAliasOff       = 51
+	inp3RTTVersionOff     = 58
+	inp3RTTSWVersionOff   = 70
+	inp3RTTFlagsOff       = 79
+	inp3RTTFieldWidth     = 10
+	inp3RTTAliasWidth     = 7
+	inp3RTTVersionWidth   = 12
+	inp3RTTSWVersionWidth = 9
+	inp3RTTFlagsWidth     = 20
+)
+
+// decode_inp3_rtt locates and parses the fixed-format RTT message struct
+// within an INP3 frame's info part, by searching for its literal
+// "L3RTT: " ID field. Returns a struct with whatever fields fit in the
+// available data - a truncated/malformed frame yields empty fields rather
+// than a panic.
+func decode_inp3_rtt(pinfo []byte) *inp3_rtt_t {
+	var idx = strings.Index(string(pinfo), inp3_rtt_id_marker)
+	if idx < 0 {
+		return nil
+	}
+
+	var body = pinfo[idx:]
+	var field = func(off, width int) string {
+		if off+width > len(body) {
+			return ""
+		}
+
+		return strings.TrimSpace(string(body[off : off+width]))
+	}
+
+	return &inp3_rtt_t{
+		TXTime:      field(inp3RTTTxTimeOff, inp3RTTFieldWidth),
+		SmoothedRTT: field(inp3RTTSmoothedRTTOff, inp3RTTFieldWidth),
+		LastRTT:     field(inp3RTTLastRTTOff, inp3RTTFieldWidth),
+		RTTID:       field(inp3RTTIDOff, inp3RTTFieldWidth),
+		Alias:       field(inp3RTTAliasOff, inp3RTTAliasWidth),
+		Version:     field(inp3RTTVersionOff, inp3RTTVersionWidth),
+		SWVersion:   field(inp3RTTSWVersionOff, inp3RTTSWVersionWidth),
+		Flags:       field(inp3RTTFlagsOff, inp3RTTFlagsWidth),
+	}
+}
+
+// decode_inp3_print prints a decoded INP3 frame in human-readable form,
+// following the same dw_printf/text_color_set conventions used by
+// decode_aprs_print.
+func decode_inp3_print(D *decode_inp3_t) {
+	text_color_set(DW_COLOR_DECODED)
+
+	switch D.Kind {
+	case inp3_kind_rif:
+		dw_printf("INP3 routing information, %d entr%s:\n", len(D.RIFEntries), plural_ies(len(D.RIFEntries)))
+
+		for _, e := range D.RIFEntries {
+			decode_inp3_print_rif_entry(e)
+		}
+	case inp3_kind_rtt:
+		if D.RTT == nil {
+			dw_printf("INP3 RTT message (could not locate fixed fields)\n")
+
+			return
+		}
+
+		dw_printf("INP3 RTT: alias=%s sw=%s ver=%s smoothedRTT=%s lastRTT=%s id=%s flags=%s\n",
+			D.RTT.Alias, D.RTT.SWVersion, D.RTT.Version, D.RTT.SmoothedRTT, D.RTT.LastRTT, D.RTT.RTTID, D.RTT.Flags)
+	case inp3_kind_keepalive:
+		dw_printf("INP3 keepalive\n")
+	}
+}
+
+func decode_inp3_print_rif_entry(e inp3_rif_entry_t) {
+	if e.RTT >= 60000 {
+		dw_printf("  %-9s hops=%d  withdrawn/unreachable", e.Callsign, e.Hops)
+	} else {
+		dw_printf("  %-9s hops=%d  rtt=%dms", e.Callsign, e.Hops, e.RTT*10)
+	}
+
+	if e.Alias != "" {
+		dw_printf("  alias=%s", e.Alias)
+	}
+
+	if e.HasIPv4 {
+		dw_printf("  ip=%s/%d", e.IPv4, e.IPv4Prefix)
+	}
+
+	if e.HasPosition {
+		dw_printf("  pos=%.4f,%.4f", e.Lat, e.Lon)
+	}
+
+	if e.HasCapability {
+		dw_printf("  swtype=0x%02x flags=0x%02x,0x%02x", e.SWType, e.Flags1, e.Flags2)
+	}
+
+	if e.HasTimestamp {
+		dw_printf("  time=%s", e.Timestamp.Format(time.RFC3339))
+	}
+
+	if e.HasTCPPort {
+		dw_printf("  tcp=%d", e.TCPPort)
+	}
+
+	if e.HasTZOffset {
+		dw_printf("  tz=%+dmin", e.TZOffsetMinutes)
+	}
+
+	if e.Locator != "" {
+		dw_printf("  loc=%s", e.Locator)
+	}
+
+	if e.QTH != "" {
+		dw_printf("  qth=%s", e.QTH)
+	}
+
+	if e.Version != "" {
+		dw_printf("  version=%s", e.Version)
+	}
+
+	dw_printf("\n")
+}
+
+func plural_ies(n int) string {
+	if n == 1 {
+		return "y"
+	}
+
+	return "ies"
+}

--- a/src/decode_inp3_test.go
+++ b/src/decode_inp3_test.go
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package direwolf
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ax25EncodeAddr7 encodes a callsign (no SSID) into a 7-byte AX.25 address
+// field: 6 bytes of shifted-left ASCII, space-padded, plus a trailing byte
+// with SSID 0 (only the reserved bits are set, matching real AX.25 frames -
+// decode_inp3 only looks at the SSID bits within it).
+func ax25EncodeAddr7(call string) []byte {
+	var padded = call
+	for len(padded) < 6 {
+		padded += " "
+	}
+
+	var b = make([]byte, 7)
+	for i := range 6 {
+		b[i] = padded[i] << 1
+	}
+
+	b[6] = 0x60
+
+	return b
+}
+
+// padRight space-pads (or truncates) s to exactly n bytes.
+func padRight(s string, n int) string {
+	if len(s) >= n {
+		return s[:n]
+	}
+
+	return s + strings.Repeat(" ", n-len(s))
+}
+
+// inp3PacketFrom builds a NET/ROM (PID 0xCF) UI frame carrying pinfo as its
+// information part.
+func inp3PacketFrom(t *testing.T, pinfo []byte) *packet_t {
+	t.Helper()
+
+	var pp = AX25FromText("Q1TEST>Q2TEST:", true)
+	require.NotNil(t, pp)
+	ax25_set_info(pp, pinfo)
+	ax25_set_pid(pp, AX25_PID_NETROM)
+
+	return pp
+}
+
+func Test_decode_inp3_rif(t *testing.T) {
+	// L3 envelope: DEST (arbitrary), SRCE with the 0xFF RIF sentinel, then
+	// 2 header bytes (TTL, flags) before the entry list.
+	var header = ax25EncodeAddr7("NODES")
+	var srce = ax25EncodeAddr7("Q1TEST")
+	srce[0] = 0xff
+	header = append(header, srce...)
+	header = append(header, 0x01, 0x00)
+
+	// Entry 1: a live route with an Alias TLV option.
+	var entry1 = ax25EncodeAddr7("Q1TEST")
+	entry1 = append(entry1, 3)          // hops
+	entry1 = append(entry1, 0x00, 0xfa) // RTT/STT = 250 (10ms units = 2500ms)
+	entry1 = append(entry1, 0x08, 0x00) // TLV: len=8 (2 header + 6 value), opcode 0x00 = Alias
+	entry1 = append(entry1, []byte("TESTND")...)
+	entry1 = append(entry1, 0x00) // options terminator
+
+	// Entry 2: a withdrawn/unreachable route (RTT >= 60000), no options.
+	var entry2 = ax25EncodeAddr7("Q2TEST")
+	entry2 = append(entry2, 99)         // hops
+	entry2 = append(entry2, 0xea, 0x60) // RTT/STT = 60000 (withdrawal sentinel)
+	entry2 = append(entry2, 0x00)       // options terminator
+
+	var pinfo = append(header, entry1...)
+	pinfo = append(pinfo, entry2...)
+
+	var pp = inp3PacketFrom(t, pinfo)
+
+	var D = decode_inp3(pp)
+	require.NotNil(t, D)
+	assert.Equal(t, inp3_kind_rif, D.Kind)
+	require.Len(t, D.RIFEntries, 2)
+
+	assert.Equal(t, "Q1TEST", D.RIFEntries[0].Callsign)
+	assert.Equal(t, 3, D.RIFEntries[0].Hops)
+	assert.Equal(t, 250, D.RIFEntries[0].RTT)
+	assert.Equal(t, "TESTND", D.RIFEntries[0].Alias)
+
+	assert.Equal(t, "Q2TEST", D.RIFEntries[1].Callsign)
+	assert.Equal(t, 99, D.RIFEntries[1].Hops)
+	assert.Equal(t, 60000, D.RIFEntries[1].RTT)
+	assert.Empty(t, D.RIFEntries[1].Alias)
+
+	// Must not panic when printed.
+	decode_inp3_print(D)
+}
+
+func Test_decode_inp3_rif_all_tlv_options(t *testing.T) {
+	var header = ax25EncodeAddr7("NODES")
+	var srce = ax25EncodeAddr7("Q1TEST")
+	srce[0] = 0xff
+	header = append(header, srce...)
+	header = append(header, 0x01, 0x00)
+
+	var entry = ax25EncodeAddr7("Q1TEST")
+	entry = append(entry, 1, 0x00, 0x05) // hops=1, RTT=5
+
+	// 0x01 IPv4 + prefix.
+	entry = append(entry, 0x07, 0x01, 192, 168, 1, 1, 24)
+	// 0x10 Position: lat=51.5 deg, lon=-0.1 deg, in 1/100 arc-min units (*6000).
+	// latraw = 51.5*6000 = 309000 = 0x0004b708, lonraw = -0.1*6000 = -600 = 0xfffffda8.
+	entry = append(entry, 0x0a, 0x10, 0x00, 0x04, 0xb7, 0x08, 0xff, 0xff, 0xfd, 0xa8)
+	// 0x11 Capability flags.
+	entry = append(entry, 0x05, 0x11, 0x01, 0x02, 0x03)
+	// 0x12 Timestamp (Unix time 1700000000 = 0x6553f100).
+	entry = append(entry, 0x06, 0x12, 0x65, 0x53, 0xf1, 0x00)
+	// 0x13 TCP port 8000.
+	entry = append(entry, 0x04, 0x13, 0x1f, 0x40)
+	// 0x14 TZ offset -60 minutes.
+	entry = append(entry, 0x04, 0x14, 0xff, 0xc4)
+	// 0x15 Maidenhead locator.
+	entry = append(entry, byte(2+len("IO91")), 0x15)
+	entry = append(entry, []byte("IO91")...)
+	// 0x16 QTH description.
+	entry = append(entry, byte(2+len("Test City")), 0x16)
+	entry = append(entry, []byte("Test City")...)
+	// 0x17 Software version.
+	entry = append(entry, byte(2+len("Samoyed")), 0x17)
+	entry = append(entry, []byte("Samoyed")...)
+	entry = append(entry, 0x00) // terminator
+
+	var pinfo = append(header, entry...)
+
+	var pp = inp3PacketFrom(t, pinfo)
+
+	var D = decode_inp3(pp)
+	require.NotNil(t, D)
+	require.Len(t, D.RIFEntries, 1)
+
+	var e = D.RIFEntries[0]
+	assert.True(t, e.HasIPv4)
+	assert.Equal(t, "192.168.1.1", e.IPv4)
+	assert.Equal(t, 24, e.IPv4Prefix)
+
+	assert.True(t, e.HasPosition)
+	assert.InDelta(t, 51.5, e.Lat, 0.01)
+	assert.InDelta(t, -0.1, e.Lon, 0.01)
+
+	assert.True(t, e.HasCapability)
+	assert.Equal(t, byte(1), e.SWType)
+	assert.Equal(t, byte(2), e.Flags1)
+	assert.Equal(t, byte(3), e.Flags2)
+
+	assert.True(t, e.HasTimestamp)
+	assert.Equal(t, int64(1700000000), e.Timestamp.Unix())
+
+	assert.True(t, e.HasTCPPort)
+	assert.Equal(t, 8000, e.TCPPort)
+
+	assert.True(t, e.HasTZOffset)
+	assert.Equal(t, -60, e.TZOffsetMinutes)
+
+	assert.Equal(t, "IO91", e.Locator)
+	assert.Equal(t, "Test City", e.QTH)
+	assert.Equal(t, "Samoyed", e.Version)
+
+	decode_inp3_print(D)
+}
+
+func Test_decode_inp3_rtt(t *testing.T) {
+	var header = ax25EncodeAddr7(inp3_pseudo_call_rtt)
+	header = append(header, ax25EncodeAddr7("Q1TEST")...)
+	header = append(header, 0x02, 0x00) // TTL=2, flags
+
+	var body = "L3RTT:" + " " +
+		fmt.Sprintf("%10d", 12345) + " " +
+		fmt.Sprintf("%10d", 42) + " " +
+		fmt.Sprintf("%10d", 41) + " " +
+		fmt.Sprintf("%10d", 7) + " " +
+		padRight("TEST", 7) +
+		padRight("LEVEL3_V2.1", 12) +
+		padRight("BPQ32004", 9) +
+		padRight("$M90 $H4", 20) +
+		padRight("", 137)
+	require.Len(t, body, 236)
+
+	var pinfo = append(header, []byte(body)...)
+
+	var pp = inp3PacketFrom(t, pinfo)
+
+	var D = decode_inp3(pp)
+	require.NotNil(t, D)
+	assert.Equal(t, inp3_kind_rtt, D.Kind)
+	require.NotNil(t, D.RTT)
+	assert.Equal(t, "12345", D.RTT.TXTime)
+	assert.Equal(t, "42", D.RTT.SmoothedRTT)
+	assert.Equal(t, "41", D.RTT.LastRTT)
+	assert.Equal(t, "7", D.RTT.RTTID)
+	assert.Equal(t, "TEST", D.RTT.Alias)
+	assert.Equal(t, "LEVEL3_V2.1", D.RTT.Version)
+	assert.Equal(t, "BPQ32004", D.RTT.SWVersion)
+	assert.Equal(t, "$M90 $H4", D.RTT.Flags)
+
+	decode_inp3_print(D)
+}
+
+func Test_decode_inp3_keepalive(t *testing.T) {
+	var header = ax25EncodeAddr7(inp3_pseudo_call_keep)
+	header = append(header, ax25EncodeAddr7("Q1TEST")...)
+	header = append(header, 0x01, 0x00)
+
+	var pp = inp3PacketFrom(t, header)
+
+	var D = decode_inp3(pp)
+	require.NotNil(t, D)
+	assert.Equal(t, inp3_kind_keepalive, D.Kind)
+
+	decode_inp3_print(D)
+}
+
+// Test_decode_inp3_not_inp3 confirms plain NET/ROM traffic (any PID-0xCF
+// frame not matching one of the INP3 sentinels) is not misdetected as INP3.
+func Test_decode_inp3_not_inp3(t *testing.T) {
+	var pinfo = []byte(strings.Repeat("X", 20))
+
+	var pp = inp3PacketFrom(t, pinfo)
+
+	var D = decode_inp3(pp)
+	assert.Nil(t, D)
+}
+
+// Test_decode_inp3_wrong_pid confirms a non-NET/ROM PID is never treated as
+// INP3, even if its payload happens to match an INP3 sentinel byte pattern.
+func Test_decode_inp3_wrong_pid(t *testing.T) {
+	var header = ax25EncodeAddr7(inp3_pseudo_call_keep)
+	header = append(header, ax25EncodeAddr7("Q1TEST")...)
+	header = append(header, 0x01, 0x00)
+
+	var pp = AX25FromText("Q1TEST>Q2TEST:", true)
+	require.NotNil(t, pp)
+	ax25_set_info(pp, header)
+	ax25_set_pid(pp, AX25_PID_NO_LAYER_3)
+
+	var D = decode_inp3(pp)
+	assert.Nil(t, D)
+}

--- a/src/direwolf.go
+++ b/src/direwolf.go
@@ -1005,6 +1005,8 @@ func app_process_rec_packet(channel int, subchan int, slice int, pp *packet_t, a
 		if ftype == frame_type_U_XID {
 			var _, info2text, _ = xid_parse(pinfo)
 			dw_printf(" %s\n", info2text)
+		} else if inp3 := decode_inp3(pp); inp3 != nil {
+			decode_inp3_print(inp3)
 		} else {
 			AX25SafePrint(pinfo, asciiOnly)
 			dw_printf("\n")

--- a/src/server_inp3_test.go
+++ b/src/server_inp3_test.go
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: The Samoyed Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package direwolf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// inp3RIFPayload builds a synthetic INP3 RIF (routing) message payload as
+// carried in the info part of a NET/ROM (PID 0xCF) frame: a leading 0xFF
+// sentinel byte (in place of what would normally be a source callsign),
+// followed by a route entry whose RTT field happens to contain an embedded
+// 0x00 byte, and terminated by the 0x00 TLV-options terminator.
+//
+// This is the kind of binary data that a naive C-string-oriented pass-through
+// (strlcat/strlcpy, NUL-terminated copies) would truncate or corrupt, which
+// is exactly what issue #527's NET/ROM fixes in server.go were guarding
+// against. INP3 is layered on the same NET/ROM PID and inherits the same
+// risk, plus its own 0xFF sentinel byte.
+func inp3RIFPayload() []byte {
+	return []byte{
+		0xff,                              // RIF sentinel (replaces source call byte 0)
+		'Q', '1', 'T', 'E', 'S', 'T', ' ', // callsign (7 bytes, AX.25-style, space padded)
+		3,          // hops
+		0x00, 0x2a, // RTT/STT big-endian uint16, low byte deliberately 0x00
+		0x00, // TLV options terminator
+	}
+}
+
+// TestHandleClientCommand_V_PreservesINP3BinaryPayload is a regression test
+// proving the AGW 'V' (transmit UI frame) handler preserves an INP3-shaped
+// binary payload - including the leading 0xFF sentinel and an embedded 0x00
+// byte - byte-for-byte, along with PID 0xCF, onto the packet it enqueues for
+// transmission.
+func TestHandleClientCommand_V_PreservesINP3BinaryPayload(t *testing.T) {
+	var cfg audio_s
+	cfg.chan_medium[0] = MEDIUM_RADIO
+	save_audio_config_p = &cfg
+	t.Cleanup(func() { save_audio_config_p = nil })
+
+	// Drain anything already queued on channel 0 so the test starts clean.
+	for tq_remove(0, TQ_PRIO_1_LO) != nil {
+	}
+
+	var payload = inp3RIFPayload()
+
+	var cmd = new(AGWPEMessage)
+	cmd.Header.DataKind = 'V'
+	cmd.Header.PID = AX25_PID_NETROM
+	copy(cmd.Header.CallFrom[:], "Q1TEST")
+	copy(cmd.Header.CallTo[:], "Q2TEST")
+
+	var data = make([]byte, 1+len(payload)) // 0 digipeaters, then payload
+	data[0] = 0
+	copy(data[1:], payload)
+	cmd.Data = data
+	cmd.Header.DataLen = uint32(len(data))
+
+	handleClientCommand(0, cmd)
+
+	var pp = tq_remove(0, TQ_PRIO_1_LO)
+	t.Cleanup(func() {
+		if pp != nil {
+			AX25Delete(pp)
+		}
+	})
+
+	require.NotNil(t, pp, "expected a packet to be enqueued for transmission")
+	assert.Equal(t, byte(AX25_PID_NETROM), byte(ax25_get_pid(pp)))
+	assert.Equal(t, payload, AX25GetInfo(pp))
+}
+
+// TestHandleClientCommand_M_PreservesINP3BinaryPayload is the same
+// regression as above for the AGW 'M' (send UNPROTO information, no
+// digipeater path) handler.
+func TestHandleClientCommand_M_PreservesINP3BinaryPayload(t *testing.T) {
+	var cfg audio_s
+	cfg.chan_medium[0] = MEDIUM_RADIO
+	save_audio_config_p = &cfg
+	t.Cleanup(func() { save_audio_config_p = nil })
+
+	for tq_remove(0, TQ_PRIO_1_LO) != nil {
+	}
+
+	var payload = inp3RIFPayload()
+
+	var cmd = new(AGWPEMessage)
+	cmd.Header.DataKind = 'M'
+	cmd.Header.PID = AX25_PID_NETROM
+	copy(cmd.Header.CallFrom[:], "Q1TEST")
+	copy(cmd.Header.CallTo[:], "Q2TEST")
+	cmd.Data = payload
+	cmd.Header.DataLen = uint32(len(payload))
+
+	handleClientCommand(0, cmd)
+
+	var pp = tq_remove(0, TQ_PRIO_1_LO)
+	t.Cleanup(func() {
+		if pp != nil {
+			AX25Delete(pp)
+		}
+	})
+
+	require.NotNil(t, pp, "expected a packet to be enqueued for transmission")
+	assert.Equal(t, byte(AX25_PID_NETROM), byte(ax25_get_pid(pp)))
+	assert.Equal(t, payload, AX25GetInfo(pp))
+}
+
+// TestServerSendMonitored_PreservesINP3BinaryPayload is a regression test
+// proving that server_send_monitored (the AGWPE MONITOR-frame path fixed
+// under issue #367 for NET/ROM) also preserves an INP3-shaped binary
+// payload - including the embedded 0x00 byte - byte-for-byte in the message
+// sent to a monitoring client, rather than truncating at the first NUL as a
+// C-string-oriented implementation would.
+func TestServerSendMonitored_PreservesINP3BinaryPayload(t *testing.T) {
+	var client = 0
+	enable_send_monitor_to_client[client] = true
+	t.Cleanup(func() { enable_send_monitor_to_client[client] = false })
+
+	var conn = setupClientPipe(t)
+	var replyCh = asyncReply(conn)
+
+	var payload = inp3RIFPayload()
+	var pp = AX25FromText("Q1TEST>Q2TEST:", true)
+	require.NotNil(t, pp)
+	ax25_set_info(pp, payload)
+	ax25_set_pid(pp, AX25_PID_NETROM)
+
+	server_send_monitored(0, pp, 0)
+
+	var reply = <-replyCh
+	require.NotNil(t, reply, "expected a MONITOR message to be sent to the client")
+
+	// The info part is embedded between the "[HH:MM:SS]\r" timestamp and the
+	// trailing "\r\x00" added by server_send_monitored - confirm the exact
+	// payload bytes, including the embedded 0x00, appear intact and are not
+	// truncated.
+	assert.Contains(t, string(reply.Data), string(payload))
+}


### PR DESCRIPTION
## Summary

🤖 Adds INP3 support in two scoped commits, as agreed after investigating the reference protocol implementation (G8BPQ's LinBPQ `BPQINP3.c`, GPL):

- **Pass-through hardening**: regression tests proving the AGWPE `'V'`/`'M'` transmit handlers and the MONITOR frame path preserve INP3-shaped binary payloads (leading `0xFF` sentinel, embedded `0x00` bytes) byte-for-byte. No code changes were needed — existing NET/ROM fixes (issues #367/#527) already cover this; these tests just close the coverage gap and guard against regression.
- **Decode/display**: a new `decode_inp3.go`, analogous to `decode_aprs.go`, that recognises and prints RIF (routing), RTT (link-timing), and keepalive INP3 messages in human-readable form instead of opaque bytes.

Samoyed does **not** participate in INP3 routing (no routing table, no probing, no broadcasting, no session forwarding) — that would require a NET/ROM Level 4 (connected-mode circuit-switching) implementation that Samoyed, like Dire Wolf, doesn't have. This is scoped as a passive observer/decoder only. See `docs/source/protocol-support.rst`.

The wire format was reverse-engineered from LinBPQ's source rather than a formal spec, so the exact NET/ROM L3 header length preceding a RIF entry list is a best-effort inference (flagged in code comments); the RTT message is instead located via its literal `"L3RTT: "` ID field, which sidesteps that particular uncertainty.

## Test plan

- [x] `make fix`
- [x] `make check`
- [x] `make test` (full suite, including new `server_inp3_test.go` and `decode_inp3_test.go`)